### PR TITLE
Add central storage for CLI environments

### DIFF
--- a/cmd/nebi/paths.go
+++ b/cmd/nebi/paths.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// EnvIndex maps workspace names to their UUIDs for local lookup.
+type EnvIndex struct {
+	Workspaces map[string]string `json:"workspaces"` // name -> UUID
+}
+
+// getDataDir returns the XDG data directory for nebi (~/.local/share/nebi).
+func getDataDir() (string, error) {
+	// Check XDG_DATA_HOME first, then fall back to ~/.local/share
+	dataHome := os.Getenv("XDG_DATA_HOME")
+	if dataHome == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get home directory: %w", err)
+		}
+		dataHome = filepath.Join(homeDir, ".local", "share")
+	}
+	return filepath.Join(dataHome, "nebi"), nil
+}
+
+// getEnvsDir returns the central environments directory (~/.local/share/nebi/envs).
+func getEnvsDir() (string, error) {
+	dataDir, err := getDataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dataDir, "envs"), nil
+}
+
+// getIndexPath returns the path to the index.json file.
+func getIndexPath() (string, error) {
+	envsDir, err := getEnvsDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(envsDir, "index.json"), nil
+}
+
+// loadIndex loads the index.json file, creating it if it doesn't exist.
+func loadIndex() (*EnvIndex, error) {
+	indexPath, err := getIndexPath()
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure the envs directory exists
+	envsDir := filepath.Dir(indexPath)
+	if err := os.MkdirAll(envsDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create envs directory: %w", err)
+	}
+
+	// Try to read existing index
+	data, err := os.ReadFile(indexPath)
+	if os.IsNotExist(err) {
+		// Return empty index
+		return &EnvIndex{
+			Workspaces: make(map[string]string),
+		}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read index: %w", err)
+	}
+
+	var index EnvIndex
+	if err := json.Unmarshal(data, &index); err != nil {
+		return nil, fmt.Errorf("failed to parse index: %w", err)
+	}
+
+	// Initialize map if nil
+	if index.Workspaces == nil {
+		index.Workspaces = make(map[string]string)
+	}
+
+	return &index, nil
+}
+
+// saveIndex saves the index.json file.
+func saveIndex(index *EnvIndex) error {
+	indexPath, err := getIndexPath()
+	if err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal index: %w", err)
+	}
+
+	if err := os.WriteFile(indexPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write index: %w", err)
+	}
+
+	return nil
+}
+
+// getOrCreateWorkspaceUUID gets the UUID for a workspace from the index,
+// or adds it if not present. The workspaceID should come from the server.
+func getOrCreateWorkspaceUUID(index *EnvIndex, workspaceName, workspaceID string) string {
+	// Check if we already have this workspace
+	if existingID, ok := index.Workspaces[workspaceName]; ok {
+		// If the ID matches, use it; otherwise update to new ID
+		if existingID == workspaceID {
+			return existingID
+		}
+		// Workspace was recreated with new ID, update
+	}
+
+	// Add or update the mapping
+	index.Workspaces[workspaceName] = workspaceID
+	return workspaceID
+}
+
+// lookupWorkspaceUUID looks up a workspace UUID by name from the local index.
+// Returns the UUID and true if found, or empty string and false if not found.
+func lookupWorkspaceUUID(workspaceName string) (string, bool) {
+	index, err := loadIndex()
+	if err != nil {
+		return "", false
+	}
+	uuid, ok := index.Workspaces[workspaceName]
+	return uuid, ok
+}
+
+// sanitizePathComponent sanitizes a string for safe use as a directory name.
+// Replaces special characters that are problematic on filesystems.
+func sanitizePathComponent(s string) string {
+	// Replace characters that are problematic on various filesystems
+	// : is invalid on Windows, / is a path separator, etc.
+	replacer := strings.NewReplacer(
+		":", "_",
+		"/", "_",
+		"\\", "_",
+		"<", "_",
+		">", "_",
+		"\"", "_",
+		"|", "_",
+		"?", "_",
+		"*", "_",
+		" ", "_",
+	)
+	result := replacer.Replace(s)
+
+	// Collapse multiple underscores
+	re := regexp.MustCompile(`_+`)
+	result = re.ReplaceAllString(result, "_")
+
+	// Trim leading/trailing underscores
+	result = strings.Trim(result, "_")
+
+	return result
+}
+
+// getCentralEnvPath returns the path for a centrally stored environment.
+// Structure: ~/.local/share/nebi/envs/<workspace-uuid>/<sanitized-registry>/<tag>/
+func getCentralEnvPath(workspaceUUID, registryName, tag string) (string, error) {
+	envsDir, err := getEnvsDir()
+	if err != nil {
+		return "", err
+	}
+
+	sanitizedRegistry := sanitizePathComponent(registryName)
+	sanitizedTag := sanitizePathComponent(tag)
+	if sanitizedTag == "" {
+		sanitizedTag = "latest"
+	}
+
+	return filepath.Join(envsDir, workspaceUUID, sanitizedRegistry, sanitizedTag), nil
+}
+
+// envExistsLocally checks if a pixi.toml exists in the given directory.
+func envExistsLocally(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, "pixi.toml"))
+	return err == nil
+}
+
+// findLocalPixiToml looks for pixi.toml in the current directory.
+// Returns the directory path and true if found, or empty string and false if not found.
+func findLocalPixiToml() (string, bool) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", false
+	}
+	pixiPath := filepath.Join(cwd, "pixi.toml")
+	if _, err := os.Stat(pixiPath); err == nil {
+		return cwd, true
+	}
+	return "", false
+}
+
+// expandPath expands ~ to the home directory and resolves relative paths.
+func expandPath(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+
+	// Expand ~
+	if strings.HasPrefix(path, "~") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get home directory: %w", err)
+		}
+		path = filepath.Join(homeDir, path[1:])
+	}
+
+	// Convert to absolute path
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	return absPath, nil
+}

--- a/cmd/nebi/pull.go
+++ b/cmd/nebi/pull.go
@@ -6,15 +6,22 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/aktech/darb/internal/cliclient"
 	"github.com/spf13/cobra"
 )
 
-var pullOutput string
+var pullPath string
+var pullRegistry string
 
 var pullCmd = &cobra.Command{
 	Use:   "pull <workspace>[:<tag>]",
-	Short: "Pull workspace from server",
-	Long: `Pull a workspace's pixi.toml and pixi.lock from the server.
+	Short: "Pull workspace from registry",
+	Long: `Pull a workspace's pixi.toml and pixi.lock from the registry.
+
+By default, environments are stored in the central location:
+  ~/.local/share/nebi/envs/<workspace-uuid>/<registry>/<tag>/
+
+Use --path to pull to a specific directory instead.
 
 Supports Docker-style references:
   - workspace:tag    - Pull specific tag
@@ -22,23 +29,24 @@ Supports Docker-style references:
   - workspace@digest - Pull by digest (immutable)
 
 Examples:
+  # Pull to central storage (default)
+  nebi pull data-science:v1.0.0 -r ds-team
+
   # Pull latest version
-  nebi pull myworkspace
-
-  # Pull specific tag
-  nebi pull myworkspace:v1.0.0
-
-  # Pull by digest
-  nebi pull myworkspace@sha256:abc123def
+  nebi pull data-science -r ds-team
 
   # Pull to specific directory
-  nebi pull myworkspace:v1.0.0 -o ./my-project`,
+  nebi pull data-science:v1.0.0 --path ./my-project
+
+  # Pull by digest
+  nebi pull data-science@sha256:abc123def -r ds-team`,
 	Args: cobra.ExactArgs(1),
 	Run:  runPull,
 }
 
 func init() {
-	pullCmd.Flags().StringVarP(&pullOutput, "output", "o", ".", "Output directory")
+	pullCmd.Flags().StringVarP(&pullPath, "path", "p", "", "Output path (default: central storage)")
+	pullCmd.Flags().StringVarP(&pullRegistry, "registry", "r", "", "Named registry")
 }
 
 func runPull(cmd *cobra.Command, args []string) {
@@ -61,6 +69,24 @@ func runPull(cmd *cobra.Command, args []string) {
 
 	client := mustGetClient()
 	ctx := mustGetAuthContext()
+
+	// Determine registry
+	var registry *cliclient.Registry
+	if pullRegistry != "" {
+		registry, err = findRegistryByName(client, ctx, pullRegistry)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		// Find default registry
+		registry, err = findDefaultRegistry(client, ctx)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			fmt.Fprintln(os.Stderr, "Hint: Set a default registry with 'nebi registry set-default <name>' or specify one with -r")
+			os.Exit(1)
+		}
+	}
 
 	// Find workspace by name
 	env, err := findWorkspaceByName(client, ctx, workspaceName)
@@ -117,6 +143,47 @@ func runPull(cmd *cobra.Command, args []string) {
 	}
 	versionNumber := latestVersion.VersionNumber
 
+	// Determine output directory
+	var outputDir string
+	useCentralStorage := pullPath == ""
+
+	if useCentralStorage {
+		// Use central storage location
+		effectiveTag := tag
+		if effectiveTag == "" {
+			effectiveTag = "latest"
+		}
+
+		// Load and update the index
+		index, err := loadIndex()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: Failed to load index: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Map workspace name to UUID
+		workspaceUUID := getOrCreateWorkspaceUUID(index, workspaceName, env.ID)
+
+		// Save the updated index
+		if err := saveIndex(index); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: Failed to save index: %v\n", err)
+			os.Exit(1)
+		}
+
+		outputDir, err = getCentralEnvPath(workspaceUUID, registry.Name, effectiveTag)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: Failed to determine storage path: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		// Use specified path
+		outputDir, err = expandPath(pullPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: Failed to resolve path: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
 	// Get pixi.toml
 	pixiToml, err := client.GetVersionPixiToml(ctx, env.ID, versionNumber)
 	if err != nil {
@@ -132,13 +199,13 @@ func runPull(cmd *cobra.Command, args []string) {
 	}
 
 	// Create output directory if needed
-	if err := os.MkdirAll(pullOutput, 0755); err != nil {
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: Failed to create output directory: %v\n", err)
 		os.Exit(1)
 	}
 
 	// Write pixi.toml
-	pixiTomlPath := filepath.Join(pullOutput, "pixi.toml")
+	pixiTomlPath := filepath.Join(outputDir, "pixi.toml")
 	if err := os.WriteFile(pixiTomlPath, []byte(pixiToml), 0644); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: Failed to write pixi.toml: %v\n", err)
 		os.Exit(1)
@@ -146,20 +213,29 @@ func runPull(cmd *cobra.Command, args []string) {
 	fmt.Printf("Wrote %s\n", pixiTomlPath)
 
 	// Write pixi.lock
-	pixiLockPath := filepath.Join(pullOutput, "pixi.lock")
+	pixiLockPath := filepath.Join(outputDir, "pixi.lock")
 	if err := os.WriteFile(pixiLockPath, []byte(pixiLock), 0644); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: Failed to write pixi.lock: %v\n", err)
 		os.Exit(1)
 	}
 	fmt.Printf("Wrote %s\n", pixiLockPath)
 
+	// Build reference string for display
 	refStr := workspaceName
 	if tag != "" {
 		refStr = workspaceName + ":" + tag
 	} else if digest != "" {
 		refStr = workspaceName + "@" + digest
 	}
+
 	fmt.Printf("\nPulled %s (version %d)\n", refStr, versionNumber)
-	fmt.Println("\nTo install the environment, run:")
-	fmt.Printf("  cd %s && pixi install\n", pullOutput)
+
+	if useCentralStorage {
+		fmt.Printf("\nEnvironment stored at: %s\n", outputDir)
+		fmt.Println("\nTo activate, run:")
+		fmt.Printf("  nebi shell %s\n", refStr)
+	} else {
+		fmt.Println("\nTo install the environment, run:")
+		fmt.Printf("  cd %s && pixi install\n", outputDir)
+	}
 }

--- a/cmd/nebi/shell.go
+++ b/cmd/nebi/shell.go
@@ -1,144 +1,177 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 
+	"github.com/aktech/darb/internal/cliclient"
 	"github.com/spf13/cobra"
 )
 
 var shellPixiEnv string
+var shellPath string
+var shellRegistry string
 
 var shellCmd = &cobra.Command{
-	Use:   "shell <workspace>[:<tag>]",
+	Use:   "shell [<workspace>[:<tag>]]",
 	Short: "Activate workspace shell",
 	Long: `Activate a workspace shell using pixi shell.
 
-The workspace is pulled from the server and cached locally.
+With no arguments: looks for local pixi.toml in current directory.
+With workspace:tag: uses centrally stored environment (auto-pulls if needed).
+With --path: uses environment at specified path.
 
 Examples:
-  # Shell into latest version
-  nebi shell myworkspace
+  # Use local pixi.toml in current directory
+  nebi shell
 
-  # Shell into specific tag
-  nebi shell myworkspace:v1.0.0
+  # Activate a centrally stored environment
+  nebi shell data-science:v1.0.0 -r ds-team
 
-  # Shell into specific pixi environment
-  nebi shell myworkspace:v1.0.0 -e dev`,
-	Args: cobra.ExactArgs(1),
+  # Activate with specific pixi environment
+  nebi shell data-science:v1.0.0 -e dev
+
+  # Use environment at specific path
+  nebi shell --path ~/projects/data-science`,
+	Args: cobra.MaximumNArgs(1),
 	Run:  runShell,
 }
 
 func init() {
 	shellCmd.Flags().StringVarP(&shellPixiEnv, "env", "e", "", "Pixi environment name")
+	shellCmd.Flags().StringVar(&shellPath, "path", "", "Path to environment directory")
+	shellCmd.Flags().StringVarP(&shellRegistry, "registry", "r", "", "Named registry")
 }
 
 func runShell(cmd *cobra.Command, args []string) {
-	// Parse workspace:tag format
-	workspaceName, tag, err := parseWorkspaceRef(args[0])
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
+	var envDir string
+	var err error
 
-	client := mustGetClient()
-	ctx := mustGetAuthContext()
-
-	// Find workspace by name
-	env, err := findWorkspaceByName(client, ctx, workspaceName)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Create cache directory for this workspace (include tag in path if specified)
-	cacheName := workspaceName
-	if tag != "" {
-		cacheName = workspaceName + "-" + tag
-	}
-	cacheDir, err := getWorkspaceCacheDir(cacheName)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: Failed to create cache directory: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Get versions to find the latest
-	versions, err := client.GetEnvironmentVersions(ctx, env.ID)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: Failed to get versions: %v\n", err)
-		os.Exit(1)
-	}
-
-	if len(versions) == 0 {
-		fmt.Fprintf(os.Stderr, "Error: Workspace %q has no versions\n", workspaceName)
-		os.Exit(1)
-	}
-
-	// Use the latest version
-	latestVersion := versions[0]
-	for _, v := range versions {
-		if v.VersionNumber > latestVersion.VersionNumber {
-			latestVersion = v
-		}
-	}
-	versionNumber := latestVersion.VersionNumber
-
-	// Check if we need to update the cached files
-	pixiTomlPath := filepath.Join(cacheDir, "pixi.toml")
-	pixiLockPath := filepath.Join(cacheDir, "pixi.lock")
-
-	needsUpdate := true
-	if _, err := os.Stat(pixiTomlPath); err == nil {
-		// Files exist, could add version checking here
-		needsUpdate = false
-	}
-
-	refStr := workspaceName
-	if tag != "" {
-		refStr = workspaceName + ":" + tag
-	}
-
-	if needsUpdate {
-		fmt.Printf("Pulling %s (version %d)...\n", refStr, versionNumber)
-
-		// Get pixi.toml
-		pixiToml, err := client.GetVersionPixiToml(ctx, env.ID, versionNumber)
+	// Determine which mode we're in
+	if shellPath != "" {
+		// Mode 1: Explicit path provided
+		envDir, err = expandPath(shellPath)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: Failed to get pixi.toml: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error: Failed to resolve path: %v\n", err)
 			os.Exit(1)
 		}
 
-		// Get pixi.lock
-		pixiLock, err := client.GetVersionPixiLock(ctx, env.ID, versionNumber)
+		if !envExistsLocally(envDir) {
+			fmt.Fprintf(os.Stderr, "Error: No pixi.toml found at %s\n", envDir)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Starting shell in %s...\n", envDir)
+
+	} else if len(args) == 0 {
+		// Mode 2: No args - look for local pixi.toml
+		var found bool
+		envDir, found = findLocalPixiToml()
+		if !found {
+			fmt.Fprintln(os.Stderr, "Error: No pixi.toml found in current directory")
+			fmt.Fprintln(os.Stderr, "")
+			fmt.Fprintln(os.Stderr, "Hint: Run 'pixi init' to create a local environment, or")
+			fmt.Fprintln(os.Stderr, "      specify a workspace with 'nebi shell workspace:tag'")
+			os.Exit(1)
+		}
+
+		fmt.Println("Starting shell for local environment...")
+
+	} else {
+		// Mode 3: workspace:tag provided - use central storage
+		workspaceName, tag, err := parseWorkspaceRef(args[0])
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: Failed to get pixi.lock: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
 
-		// Write files
-		if err := os.WriteFile(pixiTomlPath, []byte(pixiToml), 0644); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: Failed to write pixi.toml: %v\n", err)
+		client := mustGetClient()
+		ctx := mustGetAuthContext()
+
+		// Determine registry
+		var registry *cliclient.Registry
+		if shellRegistry != "" {
+			registry, err = findRegistryByName(client, ctx, shellRegistry)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+		} else {
+			// Find default registry
+			registry, err = findDefaultRegistry(client, ctx)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				fmt.Fprintln(os.Stderr, "Hint: Set a default registry with 'nebi registry set-default <name>' or specify one with -r")
+				os.Exit(1)
+			}
+		}
+
+		effectiveTag := tag
+		if effectiveTag == "" {
+			effectiveTag = "latest"
+		}
+
+		// Find workspace by name to get UUID
+		env, err := findWorkspaceByName(client, ctx, workspaceName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
 
-		if err := os.WriteFile(pixiLockPath, []byte(pixiLock), 0644); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: Failed to write pixi.lock: %v\n", err)
+		// Load index and get/create workspace UUID mapping
+		index, err := loadIndex()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: Failed to load index: %v\n", err)
 			os.Exit(1)
 		}
+
+		workspaceUUID := getOrCreateWorkspaceUUID(index, workspaceName, env.ID)
+
+		// Get central env path
+		envDir, err = getCentralEnvPath(workspaceUUID, registry.Name, effectiveTag)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: Failed to determine storage path: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Check if env exists locally, if not, pull it
+		if !envExistsLocally(envDir) {
+			refStr := workspaceName
+			if tag != "" {
+				refStr = workspaceName + ":" + tag
+			}
+			fmt.Printf("Environment not found locally, pulling %s...\n", refStr)
+
+			// Pull the environment
+			if err := pullEnvironmentToPath(client, ctx, env, envDir); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: Failed to pull environment: %v\n", err)
+				os.Exit(1)
+			}
+
+			// Save the index (we already have the mapping)
+			if err := saveIndex(index); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: Failed to save index: %v\n", err)
+			}
+		}
+
+		refStr := workspaceName
+		if tag != "" {
+			refStr = workspaceName + ":" + tag
+		}
+		fmt.Printf("Starting shell for %s...\n", refStr)
 	}
 
 	// Run pixi shell
-	fmt.Printf("Starting shell for %s...\n", refStr)
-
 	pixiArgs := []string{"shell"}
 	if shellPixiEnv != "" {
 		pixiArgs = append(pixiArgs, "-e", shellPixiEnv)
 	}
 
 	pixiCmd := exec.Command("pixi", pixiArgs...)
-	pixiCmd.Dir = cacheDir
+	pixiCmd.Dir = envDir
 	pixiCmd.Stdin = os.Stdin
 	pixiCmd.Stdout = os.Stdout
 	pixiCmd.Stderr = os.Stderr
@@ -152,17 +185,50 @@ func runShell(cmd *cobra.Command, args []string) {
 	}
 }
 
-// getWorkspaceCacheDir returns the cache directory for a workspace.
-func getWorkspaceCacheDir(workspaceName string) (string, error) {
-	cacheDir, err := os.UserCacheDir()
+// pullEnvironmentToPath pulls an environment's pixi.toml and pixi.lock to a specific path.
+func pullEnvironmentToPath(client *cliclient.Client, ctx context.Context, env *cliclient.Environment, outputDir string) error {
+	// Get versions to find the latest
+	versions, err := client.GetEnvironmentVersions(ctx, env.ID)
 	if err != nil {
-		return "", err
+		return fmt.Errorf("failed to get versions: %v", err)
 	}
 
-	workspaceDir := filepath.Join(cacheDir, "nebi", "workspaces", workspaceName)
-	if err := os.MkdirAll(workspaceDir, 0755); err != nil {
-		return "", err
+	if len(versions) == 0 {
+		return fmt.Errorf("workspace has no versions")
 	}
 
-	return workspaceDir, nil
+	// Use the latest version (highest version number)
+	latestVersion := versions[0]
+	for _, v := range versions {
+		if v.VersionNumber > latestVersion.VersionNumber {
+			latestVersion = v
+		}
+	}
+	versionNumber := latestVersion.VersionNumber
+
+	// Create output directory
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %v", err)
+	}
+
+	// Get and write pixi.toml
+	pixiToml, err := client.GetVersionPixiToml(ctx, env.ID, versionNumber)
+	if err != nil {
+		return fmt.Errorf("failed to get pixi.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, "pixi.toml"), []byte(pixiToml), 0644); err != nil {
+		return fmt.Errorf("failed to write pixi.toml: %v", err)
+	}
+
+	// Get and write pixi.lock
+	pixiLock, err := client.GetVersionPixiLock(ctx, env.ID, versionNumber)
+	if err != nil {
+		return fmt.Errorf("failed to get pixi.lock: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, "pixi.lock"), []byte(pixiLock), 0644); err != nil {
+		return fmt.Errorf("failed to write pixi.lock: %v", err)
+	}
+
+	fmt.Printf("Pulled to %s\n", outputDir)
+	return nil
 }

--- a/cmd/nebi/workspace.go
+++ b/cmd/nebi/workspace.go
@@ -17,15 +17,23 @@ var workspaceCmd = &cobra.Command{
 	Long:    `List, delete, and inspect workspaces.`,
 }
 
+var workspaceListLocal bool
+
 var workspaceListCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"ls"},
 	Short:   "List workspaces",
-	Long: `List workspaces from the server.
+	Long: `List workspaces from the server or local storage.
+
+By default, lists workspaces from the remote server.
+Use --local to list workspaces stored in the central location.
 
 Examples:
-  # List all workspaces
-  nebi workspace list`,
+  # List all workspaces from server (default)
+  nebi workspace list
+
+  # List locally stored workspaces
+  nebi workspace list --local`,
 	Args: cobra.NoArgs,
 	Run:  runWorkspaceList,
 }
@@ -71,9 +79,18 @@ func init() {
 
 	// workspace tags is a subcommand of list
 	workspaceListCmd.AddCommand(workspaceListTagsCmd)
+
+	// Add flags
+	workspaceListCmd.Flags().BoolVar(&workspaceListLocal, "local", false, "List locally stored workspaces")
 }
 
 func runWorkspaceList(cmd *cobra.Command, args []string) {
+	if workspaceListLocal {
+		runWorkspaceListLocal()
+		return
+	}
+
+	// Default: list from server
 	client := mustGetClient()
 	ctx := mustGetAuthContext()
 
@@ -100,6 +117,111 @@ func runWorkspaceList(cmd *cobra.Command, args []string) {
 			env.Status,
 			env.PackageManager,
 			owner,
+		)
+	}
+	w.Flush()
+}
+
+func runWorkspaceListLocal() {
+	envsDir, err := getEnvsDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Load the index to map UUIDs back to workspace names
+	index, err := loadIndex()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Failed to load index: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Build reverse map: UUID -> workspace name
+	uuidToName := make(map[string]string)
+	for name, uuid := range index.Workspaces {
+		uuidToName[uuid] = name
+	}
+
+	// Check if envs directory exists
+	entries, err := os.ReadDir(envsDir)
+	if os.IsNotExist(err) {
+		fmt.Println("No local workspaces found")
+		return
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Failed to read envs directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Collect all local environments
+	type localEnv struct {
+		Workspace string
+		Registry  string
+		Tag       string
+		Path      string
+	}
+	var localEnvs []localEnv
+
+	for _, uuidEntry := range entries {
+		if !uuidEntry.IsDir() || uuidEntry.Name() == "index.json" {
+			continue
+		}
+
+		workspaceUUID := uuidEntry.Name()
+		workspaceName := uuidToName[workspaceUUID]
+		if workspaceName == "" {
+			workspaceName = workspaceUUID[:8] + "..." // Show truncated UUID if name unknown
+		}
+
+		uuidPath := envsDir + "/" + uuidEntry.Name()
+		registries, err := os.ReadDir(uuidPath)
+		if err != nil {
+			continue
+		}
+
+		for _, regEntry := range registries {
+			if !regEntry.IsDir() {
+				continue
+			}
+
+			regPath := uuidPath + "/" + regEntry.Name()
+			tags, err := os.ReadDir(regPath)
+			if err != nil {
+				continue
+			}
+
+			for _, tagEntry := range tags {
+				if !tagEntry.IsDir() {
+					continue
+				}
+
+				tagPath := regPath + "/" + tagEntry.Name()
+				// Only include if pixi.toml exists
+				if envExistsLocally(tagPath) {
+					localEnvs = append(localEnvs, localEnv{
+						Workspace: workspaceName,
+						Registry:  regEntry.Name(),
+						Tag:       tagEntry.Name(),
+						Path:      tagPath,
+					})
+				}
+			}
+		}
+	}
+
+	if len(localEnvs) == 0 {
+		fmt.Println("No local workspaces found")
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "WORKSPACE\tREGISTRY\tTAG\tPATH")
+	for _, env := range localEnvs {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			env.Workspace,
+			env.Registry,
+			env.Tag,
+			env.Path,
 		)
 	}
 	w.Flush()

--- a/internal/cliclient/environments.go
+++ b/internal/cliclient/environments.go
@@ -73,7 +73,7 @@ func (c *Client) GetEnvironmentVersions(ctx context.Context, envID string) ([]En
 
 // GetVersionPixiToml returns the pixi.toml for a specific version.
 func (c *Client) GetVersionPixiToml(ctx context.Context, envID string, version int32) (string, error) {
-	content, _, err := c.GetText(ctx, fmt.Sprintf("/environments/%s/versions/%d/pixi.toml", envID, version))
+	content, _, err := c.GetText(ctx, fmt.Sprintf("/environments/%s/versions/%d/pixi-toml", envID, version))
 	if err != nil {
 		return "", err
 	}
@@ -82,7 +82,7 @@ func (c *Client) GetVersionPixiToml(ctx context.Context, envID string, version i
 
 // GetVersionPixiLock returns the pixi.lock for a specific version.
 func (c *Client) GetVersionPixiLock(ctx context.Context, envID string, version int32) (string, error) {
-	content, _, err := c.GetText(ctx, fmt.Sprintf("/environments/%s/versions/%d/pixi.lock", envID, version))
+	content, _, err := c.GetText(ctx, fmt.Sprintf("/environments/%s/versions/%d/pixi-lock", envID, version))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary
- Implement central storage for CLI environments at `~/.local/share/nebi/envs/`
- Add `index.json` to track workspace name → UUID mappings for human-readable references
- Update `pull`, `push`, and `shell` commands with new `-p/--path` and `-r/--registry` flags
- Add `workspace list --local` to view locally cached environments
- Fix API client endpoints to match server routes (`pixi-toml`, `pixi-lock`)

## Test plan
- [ ] Run `nebi pull my-ds-env:v1` and verify it stores in `~/.local/share/nebi/envs/<uuid>/<registry>/v1/`
- [ ] Run `nebi pull my-ds-env:v1 -p ./local-dir` and verify it pulls to the specified path
- [ ] Run `nebi shell my-ds-env:v1` and verify it activates the centrally stored environment
- [ ] Run `nebi shell` in a directory with `pixi.toml` and verify it uses the local env
- [ ] Run `nebi workspace list --local` and verify it shows cached environments
- [ ] Run `nebi push myenv:v1 -p ~/some/path` and verify it reads from the specified path

***

## DO NOT MERGE
I don't think this should be merged due to https://github.com/openteams-ai/nebi/issues/16.  This PR is to help with discussion though.