### PR TITLE
Phase 0: Foundation - Local index and .nebi metadata file

### DIFF
--- a/internal/localindex/localindex.go
+++ b/internal/localindex/localindex.go
@@ -1,0 +1,349 @@
+// Package localindex provides CRUD operations for the local workspace index.
+//
+// The local index is stored at ~/.local/share/nebi/index.json and tracks all
+// workspaces that have been pulled to the local machine, including their
+// origin information, layer digests for drift detection, and optional aliases.
+package localindex
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	// CurrentVersion is the current schema version of the index file.
+	CurrentVersion = 1
+
+	// DefaultIndexDir is the default directory for the index file.
+	DefaultIndexDir = ".local/share/nebi"
+
+	// IndexFileName is the name of the index file.
+	IndexFileName = "index.json"
+)
+
+// Index represents the local workspace index.
+type Index struct {
+	Version    int              `json:"version"`
+	Workspaces []WorkspaceEntry `json:"workspaces"`
+	Aliases    map[string]Alias `json:"aliases,omitempty"`
+}
+
+// WorkspaceEntry represents a single workspace entry in the index.
+type WorkspaceEntry struct {
+	Workspace       string            `json:"workspace"`
+	Tag             string            `json:"tag"`
+	Registry        string            `json:"registry,omitempty"`
+	ServerURL       string            `json:"server_url"`
+	ServerVersionID int32             `json:"server_version_id"`
+	Path            string            `json:"path"`
+	IsGlobal        bool              `json:"is_global"`
+	PulledAt        time.Time         `json:"pulled_at"`
+	ManifestDigest  string            `json:"manifest_digest,omitempty"`
+	Layers          map[string]string `json:"layers,omitempty"`
+}
+
+// Alias maps a user-friendly name to a UUID + tag in global storage.
+type Alias struct {
+	UUID string `json:"uuid"`
+	Tag  string `json:"tag"`
+}
+
+// Store provides CRUD operations for the local index.
+type Store struct {
+	mu       sync.Mutex
+	indexDir string
+}
+
+// NewStore creates a new Store with the default index directory.
+func NewStore() *Store {
+	homeDir, _ := os.UserHomeDir()
+	return &Store{
+		indexDir: filepath.Join(homeDir, DefaultIndexDir),
+	}
+}
+
+// NewStoreWithDir creates a new Store with a custom index directory.
+// This is primarily useful for testing.
+func NewStoreWithDir(dir string) *Store {
+	return &Store{
+		indexDir: dir,
+	}
+}
+
+// IndexPath returns the full path to the index file.
+func (s *Store) IndexPath() string {
+	return filepath.Join(s.indexDir, IndexFileName)
+}
+
+// Load reads the index from disk. Returns an empty index if the file doesn't exist.
+func (s *Store) Load() (*Index, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.loadUnsafe()
+}
+
+// loadUnsafe reads the index without holding the lock (caller must hold lock).
+func (s *Store) loadUnsafe() (*Index, error) {
+	path := s.IndexPath()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Index{
+				Version:    CurrentVersion,
+				Workspaces: []WorkspaceEntry{},
+				Aliases:    make(map[string]Alias),
+			}, nil
+		}
+		return nil, fmt.Errorf("failed to read index file: %w", err)
+	}
+
+	var idx Index
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return nil, fmt.Errorf("failed to parse index file: %w", err)
+	}
+
+	if idx.Aliases == nil {
+		idx.Aliases = make(map[string]Alias)
+	}
+
+	return &idx, nil
+}
+
+// Save writes the index to disk, creating the directory if needed.
+func (s *Store) Save(idx *Index) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.saveUnsafe(idx)
+}
+
+// saveUnsafe writes the index without holding the lock (caller must hold lock).
+func (s *Store) saveUnsafe(idx *Index) error {
+	if err := os.MkdirAll(s.indexDir, 0755); err != nil {
+		return fmt.Errorf("failed to create index directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(idx, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal index: %w", err)
+	}
+
+	path := s.IndexPath()
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write index file: %w", err)
+	}
+
+	return nil
+}
+
+// AddEntry adds or updates a workspace entry in the index.
+// If an entry with the same path already exists, it is replaced.
+func (s *Store) AddEntry(entry WorkspaceEntry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	idx, err := s.loadUnsafe()
+	if err != nil {
+		return err
+	}
+
+	// Replace existing entry with same path
+	found := false
+	for i, existing := range idx.Workspaces {
+		if existing.Path == entry.Path {
+			idx.Workspaces[i] = entry
+			found = true
+			break
+		}
+	}
+	if !found {
+		idx.Workspaces = append(idx.Workspaces, entry)
+	}
+
+	return s.saveUnsafe(idx)
+}
+
+// RemoveByPath removes the entry at the given path.
+// Returns true if an entry was removed, false if not found.
+func (s *Store) RemoveByPath(path string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	idx, err := s.loadUnsafe()
+	if err != nil {
+		return false, err
+	}
+
+	found := false
+	filtered := make([]WorkspaceEntry, 0, len(idx.Workspaces))
+	for _, entry := range idx.Workspaces {
+		if entry.Path == path {
+			found = true
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+
+	if !found {
+		return false, nil
+	}
+
+	idx.Workspaces = filtered
+	return true, s.saveUnsafe(idx)
+}
+
+// FindByPath returns the entry at the given path, or nil if not found.
+func (s *Store) FindByPath(path string) (*WorkspaceEntry, error) {
+	idx, err := s.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range idx.Workspaces {
+		if idx.Workspaces[i].Path == path {
+			return &idx.Workspaces[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// FindByWorkspaceTag returns all entries matching a workspace name and tag.
+func (s *Store) FindByWorkspaceTag(workspace, tag string) ([]WorkspaceEntry, error) {
+	idx, err := s.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	var matches []WorkspaceEntry
+	for _, entry := range idx.Workspaces {
+		if entry.Workspace == workspace && entry.Tag == tag {
+			matches = append(matches, entry)
+		}
+	}
+	return matches, nil
+}
+
+// FindGlobal returns all entries matching a workspace name and tag that are global.
+func (s *Store) FindGlobal(workspace, tag string) (*WorkspaceEntry, error) {
+	idx, err := s.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range idx.Workspaces {
+		if idx.Workspaces[i].Workspace == workspace &&
+			idx.Workspaces[i].Tag == tag &&
+			idx.Workspaces[i].IsGlobal {
+			return &idx.Workspaces[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// ListAll returns all workspace entries.
+func (s *Store) ListAll() ([]WorkspaceEntry, error) {
+	idx, err := s.Load()
+	if err != nil {
+		return nil, err
+	}
+	return idx.Workspaces, nil
+}
+
+// SetAlias sets a user-friendly alias for a global workspace.
+func (s *Store) SetAlias(name string, alias Alias) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	idx, err := s.loadUnsafe()
+	if err != nil {
+		return err
+	}
+
+	idx.Aliases[name] = alias
+	return s.saveUnsafe(idx)
+}
+
+// RemoveAlias removes an alias by name.
+// Returns true if the alias was removed, false if not found.
+func (s *Store) RemoveAlias(name string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	idx, err := s.loadUnsafe()
+	if err != nil {
+		return false, err
+	}
+
+	if _, exists := idx.Aliases[name]; !exists {
+		return false, nil
+	}
+
+	delete(idx.Aliases, name)
+	return true, s.saveUnsafe(idx)
+}
+
+// GetAlias returns the alias for the given name, or nil if not found.
+func (s *Store) GetAlias(name string) (*Alias, error) {
+	idx, err := s.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	alias, exists := idx.Aliases[name]
+	if !exists {
+		return nil, nil
+	}
+	return &alias, nil
+}
+
+// ListAliases returns all aliases.
+func (s *Store) ListAliases() (map[string]Alias, error) {
+	idx, err := s.Load()
+	if err != nil {
+		return nil, err
+	}
+	return idx.Aliases, nil
+}
+
+// Prune removes entries whose paths no longer exist on disk.
+// Returns the list of removed entries.
+func (s *Store) Prune() ([]WorkspaceEntry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	idx, err := s.loadUnsafe()
+	if err != nil {
+		return nil, err
+	}
+
+	var pruned []WorkspaceEntry
+	filtered := make([]WorkspaceEntry, 0, len(idx.Workspaces))
+	for _, entry := range idx.Workspaces {
+		if _, err := os.Stat(entry.Path); os.IsNotExist(err) {
+			pruned = append(pruned, entry)
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+
+	if len(pruned) == 0 {
+		return nil, nil
+	}
+
+	idx.Workspaces = filtered
+	if err := s.saveUnsafe(idx); err != nil {
+		return nil, err
+	}
+	return pruned, nil
+}
+
+// GlobalWorkspacePath returns the path where a global workspace would be stored.
+func (s *Store) GlobalWorkspacePath(uuid, tag string) string {
+	return filepath.Join(s.indexDir, "workspaces", uuid, tag)
+}

--- a/internal/localindex/localindex_test.go
+++ b/internal/localindex/localindex_test.go
@@ -1,0 +1,599 @@
+package localindex
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func setupTestStore(t *testing.T) (*Store, string) {
+	t.Helper()
+	dir := t.TempDir()
+	store := NewStoreWithDir(dir)
+	return store, dir
+}
+
+func TestNewStore(t *testing.T) {
+	store := NewStore()
+	homeDir, _ := os.UserHomeDir()
+	expected := filepath.Join(homeDir, DefaultIndexDir, IndexFileName)
+	if store.IndexPath() != expected {
+		t.Errorf("IndexPath() = %q, want %q", store.IndexPath(), expected)
+	}
+}
+
+func TestNewStoreWithDir(t *testing.T) {
+	store := NewStoreWithDir("/tmp/test-nebi")
+	expected := "/tmp/test-nebi/index.json"
+	if store.IndexPath() != expected {
+		t.Errorf("IndexPath() = %q, want %q", store.IndexPath(), expected)
+	}
+}
+
+func TestLoadEmptyIndex(t *testing.T) {
+	store, _ := setupTestStore(t)
+
+	idx, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if idx.Version != CurrentVersion {
+		t.Errorf("Version = %d, want %d", idx.Version, CurrentVersion)
+	}
+	if len(idx.Workspaces) != 0 {
+		t.Errorf("Workspaces length = %d, want 0", len(idx.Workspaces))
+	}
+	if idx.Aliases == nil {
+		t.Error("Aliases should not be nil")
+	}
+}
+
+func TestSaveAndLoad(t *testing.T) {
+	store, _ := setupTestStore(t)
+
+	now := time.Now().Truncate(time.Second)
+	idx := &Index{
+		Version: CurrentVersion,
+		Workspaces: []WorkspaceEntry{
+			{
+				Workspace:       "data-science",
+				Tag:             "v1.0",
+				Registry:        "ds-team",
+				ServerURL:       "https://nebi.example.com",
+				ServerVersionID: 42,
+				Path:            "/home/user/project-a",
+				IsGlobal:        false,
+				PulledAt:        now,
+				ManifestDigest:  "sha256:abc123",
+				Layers: map[string]string{
+					"pixi.toml": "sha256:111",
+					"pixi.lock": "sha256:222",
+				},
+			},
+		},
+		Aliases: map[string]Alias{
+			"ds-stable": {UUID: "550e8400-e29b-41d4-a716-446655440000", Tag: "v1.0"},
+		},
+	}
+
+	if err := store.Save(idx); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if loaded.Version != CurrentVersion {
+		t.Errorf("Version = %d, want %d", loaded.Version, CurrentVersion)
+	}
+	if len(loaded.Workspaces) != 1 {
+		t.Fatalf("Workspaces length = %d, want 1", len(loaded.Workspaces))
+	}
+
+	ws := loaded.Workspaces[0]
+	if ws.Workspace != "data-science" {
+		t.Errorf("Workspace = %q, want %q", ws.Workspace, "data-science")
+	}
+	if ws.Tag != "v1.0" {
+		t.Errorf("Tag = %q, want %q", ws.Tag, "v1.0")
+	}
+	if ws.Registry != "ds-team" {
+		t.Errorf("Registry = %q, want %q", ws.Registry, "ds-team")
+	}
+	if ws.ServerURL != "https://nebi.example.com" {
+		t.Errorf("ServerURL = %q, want %q", ws.ServerURL, "https://nebi.example.com")
+	}
+	if ws.ServerVersionID != 42 {
+		t.Errorf("ServerVersionID = %d, want 42", ws.ServerVersionID)
+	}
+	if ws.Path != "/home/user/project-a" {
+		t.Errorf("Path = %q, want %q", ws.Path, "/home/user/project-a")
+	}
+	if ws.IsGlobal {
+		t.Error("IsGlobal should be false")
+	}
+	if ws.ManifestDigest != "sha256:abc123" {
+		t.Errorf("ManifestDigest = %q, want %q", ws.ManifestDigest, "sha256:abc123")
+	}
+	if ws.Layers["pixi.toml"] != "sha256:111" {
+		t.Errorf("Layers[pixi.toml] = %q, want %q", ws.Layers["pixi.toml"], "sha256:111")
+	}
+	if ws.Layers["pixi.lock"] != "sha256:222" {
+		t.Errorf("Layers[pixi.lock] = %q, want %q", ws.Layers["pixi.lock"], "sha256:222")
+	}
+
+	// Check alias
+	alias, exists := loaded.Aliases["ds-stable"]
+	if !exists {
+		t.Fatal("Alias 'ds-stable' not found")
+	}
+	if alias.UUID != "550e8400-e29b-41d4-a716-446655440000" {
+		t.Errorf("Alias UUID = %q, want %q", alias.UUID, "550e8400-e29b-41d4-a716-446655440000")
+	}
+	if alias.Tag != "v1.0" {
+		t.Errorf("Alias Tag = %q, want %q", alias.Tag, "v1.0")
+	}
+}
+
+func TestAddEntry(t *testing.T) {
+	store, _ := setupTestStore(t)
+	now := time.Now().Truncate(time.Second)
+
+	entry := WorkspaceEntry{
+		Workspace:       "data-science",
+		Tag:             "v1.0",
+		ServerURL:       "https://nebi.example.com",
+		ServerVersionID: 42,
+		Path:            "/home/user/project-a",
+		PulledAt:        now,
+	}
+
+	if err := store.AddEntry(entry); err != nil {
+		t.Fatalf("AddEntry() error = %v", err)
+	}
+
+	entries, err := store.ListAll()
+	if err != nil {
+		t.Fatalf("ListAll() error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("ListAll() length = %d, want 1", len(entries))
+	}
+	if entries[0].Workspace != "data-science" {
+		t.Errorf("Workspace = %q, want %q", entries[0].Workspace, "data-science")
+	}
+}
+
+func TestAddEntryReplacesSamePath(t *testing.T) {
+	store, _ := setupTestStore(t)
+	now := time.Now().Truncate(time.Second)
+
+	entry1 := WorkspaceEntry{
+		Workspace: "data-science",
+		Tag:       "v1.0",
+		Path:      "/home/user/project-a",
+		PulledAt:  now,
+	}
+	entry2 := WorkspaceEntry{
+		Workspace: "data-science",
+		Tag:       "v2.0",
+		Path:      "/home/user/project-a",
+		PulledAt:  now.Add(time.Hour),
+	}
+
+	if err := store.AddEntry(entry1); err != nil {
+		t.Fatalf("AddEntry(entry1) error = %v", err)
+	}
+	if err := store.AddEntry(entry2); err != nil {
+		t.Fatalf("AddEntry(entry2) error = %v", err)
+	}
+
+	entries, err := store.ListAll()
+	if err != nil {
+		t.Fatalf("ListAll() error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("ListAll() length = %d, want 1", len(entries))
+	}
+	if entries[0].Tag != "v2.0" {
+		t.Errorf("Tag = %q, want %q (should be replaced)", entries[0].Tag, "v2.0")
+	}
+}
+
+func TestAddMultipleEntries(t *testing.T) {
+	store, _ := setupTestStore(t)
+	now := time.Now().Truncate(time.Second)
+
+	entries := []WorkspaceEntry{
+		{Workspace: "ws1", Tag: "v1.0", Path: "/path/a", PulledAt: now},
+		{Workspace: "ws2", Tag: "v1.0", Path: "/path/b", PulledAt: now},
+		{Workspace: "ws1", Tag: "v1.0", Path: "/path/c", PulledAt: now},
+	}
+
+	for _, e := range entries {
+		if err := store.AddEntry(e); err != nil {
+			t.Fatalf("AddEntry() error = %v", err)
+		}
+	}
+
+	all, err := store.ListAll()
+	if err != nil {
+		t.Fatalf("ListAll() error = %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("ListAll() length = %d, want 3", len(all))
+	}
+}
+
+func TestRemoveByPath(t *testing.T) {
+	store, _ := setupTestStore(t)
+	now := time.Now().Truncate(time.Second)
+
+	store.AddEntry(WorkspaceEntry{Workspace: "ws1", Tag: "v1.0", Path: "/path/a", PulledAt: now})
+	store.AddEntry(WorkspaceEntry{Workspace: "ws2", Tag: "v1.0", Path: "/path/b", PulledAt: now})
+
+	removed, err := store.RemoveByPath("/path/a")
+	if err != nil {
+		t.Fatalf("RemoveByPath() error = %v", err)
+	}
+	if !removed {
+		t.Error("RemoveByPath() should return true")
+	}
+
+	entries, _ := store.ListAll()
+	if len(entries) != 1 {
+		t.Fatalf("ListAll() length = %d, want 1", len(entries))
+	}
+	if entries[0].Path != "/path/b" {
+		t.Errorf("Path = %q, want %q", entries[0].Path, "/path/b")
+	}
+}
+
+func TestRemoveByPathNotFound(t *testing.T) {
+	store, _ := setupTestStore(t)
+
+	removed, err := store.RemoveByPath("/nonexistent")
+	if err != nil {
+		t.Fatalf("RemoveByPath() error = %v", err)
+	}
+	if removed {
+		t.Error("RemoveByPath() should return false for nonexistent path")
+	}
+}
+
+func TestFindByPath(t *testing.T) {
+	store, _ := setupTestStore(t)
+	now := time.Now().Truncate(time.Second)
+
+	store.AddEntry(WorkspaceEntry{Workspace: "ws1", Tag: "v1.0", Path: "/path/a", PulledAt: now})
+	store.AddEntry(WorkspaceEntry{Workspace: "ws2", Tag: "v2.0", Path: "/path/b", PulledAt: now})
+
+	entry, err := store.FindByPath("/path/a")
+	if err != nil {
+		t.Fatalf("FindByPath() error = %v", err)
+	}
+	if entry == nil {
+		t.Fatal("FindByPath() returned nil")
+	}
+	if entry.Workspace != "ws1" {
+		t.Errorf("Workspace = %q, want %q", entry.Workspace, "ws1")
+	}
+}
+
+func TestFindByPathNotFound(t *testing.T) {
+	store, _ := setupTestStore(t)
+
+	entry, err := store.FindByPath("/nonexistent")
+	if err != nil {
+		t.Fatalf("FindByPath() error = %v", err)
+	}
+	if entry != nil {
+		t.Errorf("FindByPath() = %v, want nil", entry)
+	}
+}
+
+func TestFindByWorkspaceTag(t *testing.T) {
+	store, _ := setupTestStore(t)
+	now := time.Now().Truncate(time.Second)
+
+	store.AddEntry(WorkspaceEntry{Workspace: "ws1", Tag: "v1.0", Path: "/path/a", PulledAt: now})
+	store.AddEntry(WorkspaceEntry{Workspace: "ws1", Tag: "v1.0", Path: "/path/b", PulledAt: now})
+	store.AddEntry(WorkspaceEntry{Workspace: "ws1", Tag: "v2.0", Path: "/path/c", PulledAt: now})
+	store.AddEntry(WorkspaceEntry{Workspace: "ws2", Tag: "v1.0", Path: "/path/d", PulledAt: now})
+
+	matches, err := store.FindByWorkspaceTag("ws1", "v1.0")
+	if err != nil {
+		t.Fatalf("FindByWorkspaceTag() error = %v", err)
+	}
+	if len(matches) != 2 {
+		t.Errorf("FindByWorkspaceTag() length = %d, want 2", len(matches))
+	}
+}
+
+func TestFindGlobal(t *testing.T) {
+	store, _ := setupTestStore(t)
+	now := time.Now().Truncate(time.Second)
+
+	store.AddEntry(WorkspaceEntry{Workspace: "ws1", Tag: "v1.0", Path: "/path/a", IsGlobal: false, PulledAt: now})
+	store.AddEntry(WorkspaceEntry{Workspace: "ws1", Tag: "v1.0", Path: "/global/ws1/v1.0", IsGlobal: true, PulledAt: now})
+
+	entry, err := store.FindGlobal("ws1", "v1.0")
+	if err != nil {
+		t.Fatalf("FindGlobal() error = %v", err)
+	}
+	if entry == nil {
+		t.Fatal("FindGlobal() returned nil")
+	}
+	if !entry.IsGlobal {
+		t.Error("Expected IsGlobal = true")
+	}
+	if entry.Path != "/global/ws1/v1.0" {
+		t.Errorf("Path = %q, want %q", entry.Path, "/global/ws1/v1.0")
+	}
+}
+
+func TestFindGlobalNotFound(t *testing.T) {
+	store, _ := setupTestStore(t)
+	now := time.Now().Truncate(time.Second)
+
+	store.AddEntry(WorkspaceEntry{Workspace: "ws1", Tag: "v1.0", Path: "/path/a", IsGlobal: false, PulledAt: now})
+
+	entry, err := store.FindGlobal("ws1", "v1.0")
+	if err != nil {
+		t.Fatalf("FindGlobal() error = %v", err)
+	}
+	if entry != nil {
+		t.Errorf("FindGlobal() = %v, want nil", entry)
+	}
+}
+
+func TestSetAlias(t *testing.T) {
+	store, _ := setupTestStore(t)
+
+	alias := Alias{UUID: "test-uuid", Tag: "v1.0"}
+	if err := store.SetAlias("my-alias", alias); err != nil {
+		t.Fatalf("SetAlias() error = %v", err)
+	}
+
+	got, err := store.GetAlias("my-alias")
+	if err != nil {
+		t.Fatalf("GetAlias() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetAlias() returned nil")
+	}
+	if got.UUID != "test-uuid" {
+		t.Errorf("UUID = %q, want %q", got.UUID, "test-uuid")
+	}
+	if got.Tag != "v1.0" {
+		t.Errorf("Tag = %q, want %q", got.Tag, "v1.0")
+	}
+}
+
+func TestSetAliasOverwrite(t *testing.T) {
+	store, _ := setupTestStore(t)
+
+	store.SetAlias("my-alias", Alias{UUID: "uuid-1", Tag: "v1.0"})
+	store.SetAlias("my-alias", Alias{UUID: "uuid-2", Tag: "v2.0"})
+
+	got, err := store.GetAlias("my-alias")
+	if err != nil {
+		t.Fatalf("GetAlias() error = %v", err)
+	}
+	if got.UUID != "uuid-2" {
+		t.Errorf("UUID = %q, want %q (should be overwritten)", got.UUID, "uuid-2")
+	}
+}
+
+func TestRemoveAlias(t *testing.T) {
+	store, _ := setupTestStore(t)
+
+	store.SetAlias("my-alias", Alias{UUID: "test-uuid", Tag: "v1.0"})
+
+	removed, err := store.RemoveAlias("my-alias")
+	if err != nil {
+		t.Fatalf("RemoveAlias() error = %v", err)
+	}
+	if !removed {
+		t.Error("RemoveAlias() should return true")
+	}
+
+	got, _ := store.GetAlias("my-alias")
+	if got != nil {
+		t.Errorf("GetAlias() after remove = %v, want nil", got)
+	}
+}
+
+func TestRemoveAliasNotFound(t *testing.T) {
+	store, _ := setupTestStore(t)
+
+	removed, err := store.RemoveAlias("nonexistent")
+	if err != nil {
+		t.Fatalf("RemoveAlias() error = %v", err)
+	}
+	if removed {
+		t.Error("RemoveAlias() should return false for nonexistent alias")
+	}
+}
+
+func TestListAliases(t *testing.T) {
+	store, _ := setupTestStore(t)
+
+	store.SetAlias("alias1", Alias{UUID: "uuid-1", Tag: "v1.0"})
+	store.SetAlias("alias2", Alias{UUID: "uuid-2", Tag: "v2.0"})
+
+	aliases, err := store.ListAliases()
+	if err != nil {
+		t.Fatalf("ListAliases() error = %v", err)
+	}
+	if len(aliases) != 2 {
+		t.Errorf("ListAliases() length = %d, want 2", len(aliases))
+	}
+}
+
+func TestPrune(t *testing.T) {
+	store, dir := setupTestStore(t)
+	now := time.Now().Truncate(time.Second)
+
+	// Create a real directory for one entry
+	realDir := filepath.Join(dir, "real-workspace")
+	os.MkdirAll(realDir, 0755)
+
+	store.AddEntry(WorkspaceEntry{Workspace: "ws1", Tag: "v1.0", Path: realDir, PulledAt: now})
+	store.AddEntry(WorkspaceEntry{Workspace: "ws2", Tag: "v1.0", Path: "/nonexistent/path", PulledAt: now})
+
+	pruned, err := store.Prune()
+	if err != nil {
+		t.Fatalf("Prune() error = %v", err)
+	}
+	if len(pruned) != 1 {
+		t.Fatalf("Prune() length = %d, want 1", len(pruned))
+	}
+	if pruned[0].Path != "/nonexistent/path" {
+		t.Errorf("Pruned path = %q, want %q", pruned[0].Path, "/nonexistent/path")
+	}
+
+	entries, _ := store.ListAll()
+	if len(entries) != 1 {
+		t.Fatalf("ListAll() after prune = %d, want 1", len(entries))
+	}
+	if entries[0].Path != realDir {
+		t.Errorf("Remaining path = %q, want %q", entries[0].Path, realDir)
+	}
+}
+
+func TestPruneNothingToPrune(t *testing.T) {
+	store, dir := setupTestStore(t)
+	now := time.Now().Truncate(time.Second)
+
+	realDir := filepath.Join(dir, "real-workspace")
+	os.MkdirAll(realDir, 0755)
+
+	store.AddEntry(WorkspaceEntry{Workspace: "ws1", Tag: "v1.0", Path: realDir, PulledAt: now})
+
+	pruned, err := store.Prune()
+	if err != nil {
+		t.Fatalf("Prune() error = %v", err)
+	}
+	if pruned != nil {
+		t.Errorf("Prune() = %v, want nil (nothing to prune)", pruned)
+	}
+}
+
+func TestGlobalWorkspacePath(t *testing.T) {
+	store := NewStoreWithDir("/home/user/.local/share/nebi")
+	path := store.GlobalWorkspacePath("550e8400-e29b-41d4-a716-446655440000", "v1.0")
+	expected := "/home/user/.local/share/nebi/workspaces/550e8400-e29b-41d4-a716-446655440000/v1.0"
+	if path != expected {
+		t.Errorf("GlobalWorkspacePath() = %q, want %q", path, expected)
+	}
+}
+
+func TestLoadCorruptedFile(t *testing.T) {
+	store, dir := setupTestStore(t)
+
+	// Write corrupted JSON
+	os.MkdirAll(dir, 0755)
+	os.WriteFile(filepath.Join(dir, IndexFileName), []byte("not json{{{"), 0644)
+
+	_, err := store.Load()
+	if err == nil {
+		t.Fatal("Load() should return error for corrupted file")
+	}
+}
+
+func TestSaveCreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "deep", "dir")
+	store := NewStoreWithDir(dir)
+
+	idx := &Index{Version: CurrentVersion, Workspaces: []WorkspaceEntry{}}
+	if err := store.Save(idx); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Verify file exists
+	if _, err := os.Stat(store.IndexPath()); err != nil {
+		t.Fatalf("Index file not created: %v", err)
+	}
+}
+
+func TestIndexJSONFormat(t *testing.T) {
+	store, _ := setupTestStore(t)
+	now := time.Date(2024, 1, 20, 10, 30, 0, 0, time.UTC)
+
+	idx := &Index{
+		Version: CurrentVersion,
+		Workspaces: []WorkspaceEntry{
+			{
+				Workspace:       "data-science",
+				Tag:             "v1.0",
+				Registry:        "ds-team",
+				ServerURL:       "https://nebi.example.com",
+				ServerVersionID: 42,
+				Path:            "/home/user/project-a",
+				IsGlobal:        false,
+				PulledAt:        now,
+				ManifestDigest:  "sha256:abc123def456",
+				Layers: map[string]string{
+					"pixi.toml": "sha256:111aaa",
+					"pixi.lock": "sha256:222bbb",
+				},
+			},
+		},
+		Aliases: map[string]Alias{
+			"ds-stable": {UUID: "550e8400-e29b-41d4-a716-446655440000", Tag: "v1.0"},
+		},
+	}
+
+	store.Save(idx)
+
+	// Read raw JSON and verify structure
+	data, err := os.ReadFile(store.IndexPath())
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	// Check version field is number
+	version, ok := raw["version"].(float64)
+	if !ok || version != 1 {
+		t.Errorf("version = %v, want 1", raw["version"])
+	}
+
+	// Check workspaces is array
+	workspaces, ok := raw["workspaces"].([]interface{})
+	if !ok || len(workspaces) != 1 {
+		t.Fatalf("workspaces = %v", raw["workspaces"])
+	}
+
+	// Check aliases is object
+	aliases, ok := raw["aliases"].(map[string]interface{})
+	if !ok || len(aliases) != 1 {
+		t.Fatalf("aliases = %v", raw["aliases"])
+	}
+}
+
+func TestLoadNilAliases(t *testing.T) {
+	store, dir := setupTestStore(t)
+
+	// Write JSON without aliases field
+	os.MkdirAll(dir, 0755)
+	data := `{"version": 1, "workspaces": []}`
+	os.WriteFile(filepath.Join(dir, IndexFileName), []byte(data), 0644)
+
+	idx, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if idx.Aliases == nil {
+		t.Error("Aliases should be initialized to empty map, not nil")
+	}
+}

--- a/internal/nebifile/nebifile.go
+++ b/internal/nebifile/nebifile.go
@@ -1,0 +1,182 @@
+// Package nebifile provides read/write operations for .nebi metadata files.
+//
+// A .nebi file is written to a workspace directory after a pull operation.
+// It contains origin information (where the workspace was pulled from) and
+// per-file layer digests for drift detection.
+//
+// Format (YAML):
+//
+//	origin:
+//	  workspace: data-science
+//	  tag: v1.0
+//	  registry: ds-team
+//	  server_url: https://nebi.example.com
+//	  server_version_id: 42
+//	  manifest_digest: sha256:abc123...
+//	  pulled_at: 2024-01-20T10:30:00Z
+//	layers:
+//	  pixi.toml:
+//	    digest: sha256:111...
+//	    size: 2345
+//	    media_type: application/vnd.pixi.toml.v1+toml
+//	  pixi.lock:
+//	    digest: sha256:222...
+//	    size: 45678
+//	    media_type: application/vnd.pixi.lock.v1+yaml
+package nebifile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// FileName is the name of the nebi metadata file.
+	FileName = ".nebi"
+
+	// MediaTypePixiToml is the OCI media type for pixi.toml files.
+	MediaTypePixiToml = "application/vnd.pixi.toml.v1+toml"
+
+	// MediaTypePixiLock is the OCI media type for pixi.lock files.
+	MediaTypePixiLock = "application/vnd.pixi.lock.v1+yaml"
+)
+
+// NebiFile represents the contents of a .nebi metadata file.
+type NebiFile struct {
+	Origin Origin           `yaml:"origin"`
+	Layers map[string]Layer `yaml:"layers"`
+}
+
+// Origin contains information about where the workspace was pulled from.
+type Origin struct {
+	Workspace       string    `yaml:"workspace"`
+	Tag             string    `yaml:"tag"`
+	Registry        string    `yaml:"registry,omitempty"`
+	ServerURL       string    `yaml:"server_url"`
+	ServerVersionID int32     `yaml:"server_version_id"`
+	ManifestDigest  string    `yaml:"manifest_digest,omitempty"`
+	PulledAt        time.Time `yaml:"pulled_at"`
+}
+
+// Layer contains information about a single file layer.
+type Layer struct {
+	Digest    string `yaml:"digest"`
+	Size      int64  `yaml:"size"`
+	MediaType string `yaml:"media_type"`
+}
+
+// Read reads a .nebi file from the given directory.
+func Read(dir string) (*NebiFile, error) {
+	path := filepath.Join(dir, FileName)
+	return ReadFile(path)
+}
+
+// ReadFile reads a .nebi file from the given path.
+func ReadFile(path string) (*NebiFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("not a nebi workspace: %s not found", path)
+		}
+		return nil, fmt.Errorf("failed to read %s: %w", FileName, err)
+	}
+
+	var nf NebiFile
+	if err := yaml.Unmarshal(data, &nf); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", FileName, err)
+	}
+
+	if nf.Layers == nil {
+		nf.Layers = make(map[string]Layer)
+	}
+
+	return &nf, nil
+}
+
+// Write writes the .nebi file to the given directory.
+func Write(dir string, nf *NebiFile) error {
+	path := filepath.Join(dir, FileName)
+	return WriteFile(path, nf)
+}
+
+// WriteFile writes the .nebi file to the given path.
+func WriteFile(path string, nf *NebiFile) error {
+	data, err := yaml.Marshal(nf)
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s: %w", FileName, err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", FileName, err)
+	}
+
+	return nil
+}
+
+// Exists checks if a .nebi file exists in the given directory.
+func Exists(dir string) bool {
+	path := filepath.Join(dir, FileName)
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// New creates a new NebiFile with the given origin and layer information.
+func New(origin Origin, layers map[string]Layer) *NebiFile {
+	if layers == nil {
+		layers = make(map[string]Layer)
+	}
+	return &NebiFile{
+		Origin: origin,
+		Layers: layers,
+	}
+}
+
+// NewFromPull creates a NebiFile from pull operation results.
+// This is a convenience constructor that takes the common parameters from a pull.
+func NewFromPull(workspace, tag, registry, serverURL string, serverVersionID int32,
+	manifestDigest string, pixiTomlDigest string, pixiTomlSize int64,
+	pixiLockDigest string, pixiLockSize int64) *NebiFile {
+
+	return &NebiFile{
+		Origin: Origin{
+			Workspace:       workspace,
+			Tag:             tag,
+			Registry:        registry,
+			ServerURL:       serverURL,
+			ServerVersionID: serverVersionID,
+			ManifestDigest:  manifestDigest,
+			PulledAt:        time.Now(),
+		},
+		Layers: map[string]Layer{
+			"pixi.toml": {
+				Digest:    pixiTomlDigest,
+				Size:      pixiTomlSize,
+				MediaType: MediaTypePixiToml,
+			},
+			"pixi.lock": {
+				Digest:    pixiLockDigest,
+				Size:      pixiLockSize,
+				MediaType: MediaTypePixiLock,
+			},
+		},
+	}
+}
+
+// GetLayerDigest returns the digest for a specific file layer.
+// Returns empty string if the layer is not found.
+func (nf *NebiFile) GetLayerDigest(filename string) string {
+	if layer, ok := nf.Layers[filename]; ok {
+		return layer.Digest
+	}
+	return ""
+}
+
+// HasLayer checks if the file has a layer entry for the given filename.
+func (nf *NebiFile) HasLayer(filename string) bool {
+	_, ok := nf.Layers[filename]
+	return ok
+}

--- a/internal/nebifile/nebifile_test.go
+++ b/internal/nebifile/nebifile_test.go
@@ -1,0 +1,508 @@
+package nebifile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestReadNonExistentFile(t *testing.T) {
+	_, err := Read("/nonexistent/dir")
+	if err == nil {
+		t.Fatal("Read() should return error for nonexistent directory")
+	}
+}
+
+func TestReadInvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, FileName)
+	os.WriteFile(path, []byte("not: valid: yaml: {{{"), 0644)
+
+	_, err := Read(dir)
+	if err == nil {
+		t.Fatal("Read() should return error for invalid YAML")
+	}
+}
+
+func TestWriteAndRead(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2024, 1, 20, 10, 30, 0, 0, time.UTC)
+
+	nf := &NebiFile{
+		Origin: Origin{
+			Workspace:       "data-science",
+			Tag:             "v1.0",
+			Registry:        "ds-team",
+			ServerURL:       "https://nebi.example.com",
+			ServerVersionID: 42,
+			ManifestDigest:  "sha256:abc123def456",
+			PulledAt:        now,
+		},
+		Layers: map[string]Layer{
+			"pixi.toml": {
+				Digest:    "sha256:111aaa",
+				Size:      2345,
+				MediaType: MediaTypePixiToml,
+			},
+			"pixi.lock": {
+				Digest:    "sha256:222bbb",
+				Size:      45678,
+				MediaType: MediaTypePixiLock,
+			},
+		},
+	}
+
+	if err := Write(dir, nf); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	loaded, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	// Verify origin
+	if loaded.Origin.Workspace != "data-science" {
+		t.Errorf("Workspace = %q, want %q", loaded.Origin.Workspace, "data-science")
+	}
+	if loaded.Origin.Tag != "v1.0" {
+		t.Errorf("Tag = %q, want %q", loaded.Origin.Tag, "v1.0")
+	}
+	if loaded.Origin.Registry != "ds-team" {
+		t.Errorf("Registry = %q, want %q", loaded.Origin.Registry, "ds-team")
+	}
+	if loaded.Origin.ServerURL != "https://nebi.example.com" {
+		t.Errorf("ServerURL = %q, want %q", loaded.Origin.ServerURL, "https://nebi.example.com")
+	}
+	if loaded.Origin.ServerVersionID != 42 {
+		t.Errorf("ServerVersionID = %d, want 42", loaded.Origin.ServerVersionID)
+	}
+	if loaded.Origin.ManifestDigest != "sha256:abc123def456" {
+		t.Errorf("ManifestDigest = %q, want %q", loaded.Origin.ManifestDigest, "sha256:abc123def456")
+	}
+	if !loaded.Origin.PulledAt.Equal(now) {
+		t.Errorf("PulledAt = %v, want %v", loaded.Origin.PulledAt, now)
+	}
+
+	// Verify layers
+	if len(loaded.Layers) != 2 {
+		t.Fatalf("Layers length = %d, want 2", len(loaded.Layers))
+	}
+
+	tomlLayer := loaded.Layers["pixi.toml"]
+	if tomlLayer.Digest != "sha256:111aaa" {
+		t.Errorf("pixi.toml Digest = %q, want %q", tomlLayer.Digest, "sha256:111aaa")
+	}
+	if tomlLayer.Size != 2345 {
+		t.Errorf("pixi.toml Size = %d, want 2345", tomlLayer.Size)
+	}
+	if tomlLayer.MediaType != MediaTypePixiToml {
+		t.Errorf("pixi.toml MediaType = %q, want %q", tomlLayer.MediaType, MediaTypePixiToml)
+	}
+
+	lockLayer := loaded.Layers["pixi.lock"]
+	if lockLayer.Digest != "sha256:222bbb" {
+		t.Errorf("pixi.lock Digest = %q, want %q", lockLayer.Digest, "sha256:222bbb")
+	}
+	if lockLayer.Size != 45678 {
+		t.Errorf("pixi.lock Size = %d, want 45678", lockLayer.Size)
+	}
+	if lockLayer.MediaType != MediaTypePixiLock {
+		t.Errorf("pixi.lock MediaType = %q, want %q", lockLayer.MediaType, MediaTypePixiLock)
+	}
+}
+
+func TestExists(t *testing.T) {
+	dir := t.TempDir()
+
+	if Exists(dir) {
+		t.Error("Exists() should return false for empty directory")
+	}
+
+	// Create .nebi file
+	nf := &NebiFile{
+		Origin: Origin{Workspace: "test"},
+		Layers: make(map[string]Layer),
+	}
+	Write(dir, nf)
+
+	if !Exists(dir) {
+		t.Error("Exists() should return true after writing .nebi file")
+	}
+}
+
+func TestNew(t *testing.T) {
+	origin := Origin{
+		Workspace:       "test-ws",
+		Tag:             "v1.0",
+		ServerURL:       "https://example.com",
+		ServerVersionID: 1,
+	}
+	layers := map[string]Layer{
+		"pixi.toml": {Digest: "sha256:aaa", Size: 100, MediaType: MediaTypePixiToml},
+	}
+
+	nf := New(origin, layers)
+	if nf.Origin.Workspace != "test-ws" {
+		t.Errorf("Workspace = %q, want %q", nf.Origin.Workspace, "test-ws")
+	}
+	if len(nf.Layers) != 1 {
+		t.Errorf("Layers length = %d, want 1", len(nf.Layers))
+	}
+}
+
+func TestNewNilLayers(t *testing.T) {
+	origin := Origin{Workspace: "test-ws"}
+	nf := New(origin, nil)
+	if nf.Layers == nil {
+		t.Error("Layers should not be nil when created with nil argument")
+	}
+}
+
+func TestNewFromPull(t *testing.T) {
+	nf := NewFromPull(
+		"data-science", "v1.0", "ds-team", "https://nebi.example.com",
+		42, "sha256:manifest123",
+		"sha256:toml456", 2345,
+		"sha256:lock789", 45678,
+	)
+
+	if nf.Origin.Workspace != "data-science" {
+		t.Errorf("Workspace = %q, want %q", nf.Origin.Workspace, "data-science")
+	}
+	if nf.Origin.Tag != "v1.0" {
+		t.Errorf("Tag = %q, want %q", nf.Origin.Tag, "v1.0")
+	}
+	if nf.Origin.Registry != "ds-team" {
+		t.Errorf("Registry = %q, want %q", nf.Origin.Registry, "ds-team")
+	}
+	if nf.Origin.ServerURL != "https://nebi.example.com" {
+		t.Errorf("ServerURL = %q, want %q", nf.Origin.ServerURL, "https://nebi.example.com")
+	}
+	if nf.Origin.ServerVersionID != 42 {
+		t.Errorf("ServerVersionID = %d, want 42", nf.Origin.ServerVersionID)
+	}
+	if nf.Origin.ManifestDigest != "sha256:manifest123" {
+		t.Errorf("ManifestDigest = %q, want %q", nf.Origin.ManifestDigest, "sha256:manifest123")
+	}
+	if nf.Origin.PulledAt.IsZero() {
+		t.Error("PulledAt should not be zero")
+	}
+
+	toml := nf.Layers["pixi.toml"]
+	if toml.Digest != "sha256:toml456" {
+		t.Errorf("pixi.toml Digest = %q, want %q", toml.Digest, "sha256:toml456")
+	}
+	if toml.Size != 2345 {
+		t.Errorf("pixi.toml Size = %d, want 2345", toml.Size)
+	}
+	if toml.MediaType != MediaTypePixiToml {
+		t.Errorf("pixi.toml MediaType = %q, want %q", toml.MediaType, MediaTypePixiToml)
+	}
+
+	lock := nf.Layers["pixi.lock"]
+	if lock.Digest != "sha256:lock789" {
+		t.Errorf("pixi.lock Digest = %q, want %q", lock.Digest, "sha256:lock789")
+	}
+	if lock.Size != 45678 {
+		t.Errorf("pixi.lock Size = %d, want 45678", lock.Size)
+	}
+	if lock.MediaType != MediaTypePixiLock {
+		t.Errorf("pixi.lock MediaType = %q, want %q", lock.MediaType, MediaTypePixiLock)
+	}
+}
+
+func TestGetLayerDigest(t *testing.T) {
+	nf := &NebiFile{
+		Layers: map[string]Layer{
+			"pixi.toml": {Digest: "sha256:aaa"},
+			"pixi.lock": {Digest: "sha256:bbb"},
+		},
+	}
+
+	if got := nf.GetLayerDigest("pixi.toml"); got != "sha256:aaa" {
+		t.Errorf("GetLayerDigest(pixi.toml) = %q, want %q", got, "sha256:aaa")
+	}
+	if got := nf.GetLayerDigest("pixi.lock"); got != "sha256:bbb" {
+		t.Errorf("GetLayerDigest(pixi.lock) = %q, want %q", got, "sha256:bbb")
+	}
+	if got := nf.GetLayerDigest("nonexistent"); got != "" {
+		t.Errorf("GetLayerDigest(nonexistent) = %q, want empty string", got)
+	}
+}
+
+func TestHasLayer(t *testing.T) {
+	nf := &NebiFile{
+		Layers: map[string]Layer{
+			"pixi.toml": {Digest: "sha256:aaa"},
+		},
+	}
+
+	if !nf.HasLayer("pixi.toml") {
+		t.Error("HasLayer(pixi.toml) should return true")
+	}
+	if nf.HasLayer("pixi.lock") {
+		t.Error("HasLayer(pixi.lock) should return false")
+	}
+}
+
+func TestYAMLFormat(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2024, 1, 20, 10, 30, 0, 0, time.UTC)
+
+	nf := &NebiFile{
+		Origin: Origin{
+			Workspace:       "data-science",
+			Tag:             "v1.0",
+			Registry:        "ds-team",
+			ServerURL:       "https://nebi.example.com",
+			ServerVersionID: 42,
+			ManifestDigest:  "sha256:abc123",
+			PulledAt:        now,
+		},
+		Layers: map[string]Layer{
+			"pixi.toml": {
+				Digest:    "sha256:111",
+				Size:      2345,
+				MediaType: MediaTypePixiToml,
+			},
+		},
+	}
+
+	Write(dir, nf)
+
+	// Read raw YAML and verify structure
+	data, err := os.ReadFile(filepath.Join(dir, FileName))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	// Check top-level keys
+	if _, ok := raw["origin"]; !ok {
+		t.Error("YAML should have 'origin' key")
+	}
+	if _, ok := raw["layers"]; !ok {
+		t.Error("YAML should have 'layers' key")
+	}
+
+	// Check origin structure
+	origin, ok := raw["origin"].(map[string]interface{})
+	if !ok {
+		t.Fatal("origin should be a map")
+	}
+	if origin["workspace"] != "data-science" {
+		t.Errorf("origin.workspace = %v, want %q", origin["workspace"], "data-science")
+	}
+	if origin["server_url"] != "https://nebi.example.com" {
+		t.Errorf("origin.server_url = %v, want %q", origin["server_url"], "https://nebi.example.com")
+	}
+}
+
+func TestReadNilLayers(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write YAML without layers field
+	data := `origin:
+  workspace: test
+  tag: v1.0
+  server_url: https://example.com
+  server_version_id: 1
+  pulled_at: 2024-01-20T10:30:00Z
+`
+	os.WriteFile(filepath.Join(dir, FileName), []byte(data), 0644)
+
+	nf, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if nf.Layers == nil {
+		t.Error("Layers should be initialized to empty map, not nil")
+	}
+}
+
+func TestWriteFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "custom.nebi")
+
+	nf := &NebiFile{
+		Origin: Origin{Workspace: "test"},
+		Layers: make(map[string]Layer),
+	}
+
+	if err := WriteFile(path, nf); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	loaded, err := ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if loaded.Origin.Workspace != "test" {
+		t.Errorf("Workspace = %q, want %q", loaded.Origin.Workspace, "test")
+	}
+}
+
+func TestReadFileNonExistent(t *testing.T) {
+	_, err := ReadFile("/nonexistent/path/.nebi")
+	if err == nil {
+		t.Fatal("ReadFile() should return error for nonexistent file")
+	}
+}
+
+func TestWriteOverwrite(t *testing.T) {
+	dir := t.TempDir()
+
+	nf1 := &NebiFile{
+		Origin: Origin{Workspace: "ws1", Tag: "v1.0"},
+		Layers: make(map[string]Layer),
+	}
+	nf2 := &NebiFile{
+		Origin: Origin{Workspace: "ws2", Tag: "v2.0"},
+		Layers: make(map[string]Layer),
+	}
+
+	Write(dir, nf1)
+	Write(dir, nf2)
+
+	loaded, _ := Read(dir)
+	if loaded.Origin.Workspace != "ws2" {
+		t.Errorf("Workspace = %q, want %q (should be overwritten)", loaded.Origin.Workspace, "ws2")
+	}
+	if loaded.Origin.Tag != "v2.0" {
+		t.Errorf("Tag = %q, want %q (should be overwritten)", loaded.Origin.Tag, "v2.0")
+	}
+}
+
+func TestMediaTypeConstants(t *testing.T) {
+	if MediaTypePixiToml != "application/vnd.pixi.toml.v1+toml" {
+		t.Errorf("MediaTypePixiToml = %q, unexpected value", MediaTypePixiToml)
+	}
+	if MediaTypePixiLock != "application/vnd.pixi.lock.v1+yaml" {
+		t.Errorf("MediaTypePixiLock = %q, unexpected value", MediaTypePixiLock)
+	}
+}
+
+func TestFileNameConstant(t *testing.T) {
+	if FileName != ".nebi" {
+		t.Errorf("FileName = %q, want %q", FileName, ".nebi")
+	}
+}
+
+func TestEmptyOriginFields(t *testing.T) {
+	dir := t.TempDir()
+
+	// Only required fields
+	nf := &NebiFile{
+		Origin: Origin{
+			Workspace:       "test",
+			Tag:             "v1.0",
+			ServerURL:       "https://example.com",
+			ServerVersionID: 1,
+			PulledAt:        time.Now(),
+		},
+		Layers: make(map[string]Layer),
+	}
+
+	if err := Write(dir, nf); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	loaded, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	// Optional fields should be empty
+	if loaded.Origin.Registry != "" {
+		t.Errorf("Registry = %q, want empty", loaded.Origin.Registry)
+	}
+	if loaded.Origin.ManifestDigest != "" {
+		t.Errorf("ManifestDigest = %q, want empty", loaded.Origin.ManifestDigest)
+	}
+}
+
+func TestRoundTripPreservesData(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2024, 6, 15, 14, 30, 0, 0, time.UTC)
+
+	original := &NebiFile{
+		Origin: Origin{
+			Workspace:       "ml-pipeline",
+			Tag:             "v2.3.1-beta",
+			Registry:        "ml-team",
+			ServerURL:       "https://nebi.internal.company.com:8460",
+			ServerVersionID: 127,
+			ManifestDigest:  "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			PulledAt:        now,
+		},
+		Layers: map[string]Layer{
+			"pixi.toml": {
+				Digest:    "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+				Size:      4096,
+				MediaType: MediaTypePixiToml,
+			},
+			"pixi.lock": {
+				Digest:    "sha256:f6e5d4c3b2a1f6e5d4c3b2a1f6e5d4c3b2a1f6e5d4c3b2a1f6e5d4c3b2a1f6e5",
+				Size:      102400,
+				MediaType: MediaTypePixiLock,
+			},
+		},
+	}
+
+	if err := Write(dir, original); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	loaded, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	// Compare all fields
+	if loaded.Origin.Workspace != original.Origin.Workspace {
+		t.Errorf("Workspace mismatch: got %q, want %q", loaded.Origin.Workspace, original.Origin.Workspace)
+	}
+	if loaded.Origin.Tag != original.Origin.Tag {
+		t.Errorf("Tag mismatch: got %q, want %q", loaded.Origin.Tag, original.Origin.Tag)
+	}
+	if loaded.Origin.Registry != original.Origin.Registry {
+		t.Errorf("Registry mismatch: got %q, want %q", loaded.Origin.Registry, original.Origin.Registry)
+	}
+	if loaded.Origin.ServerURL != original.Origin.ServerURL {
+		t.Errorf("ServerURL mismatch: got %q, want %q", loaded.Origin.ServerURL, original.Origin.ServerURL)
+	}
+	if loaded.Origin.ServerVersionID != original.Origin.ServerVersionID {
+		t.Errorf("ServerVersionID mismatch: got %d, want %d", loaded.Origin.ServerVersionID, original.Origin.ServerVersionID)
+	}
+	if loaded.Origin.ManifestDigest != original.Origin.ManifestDigest {
+		t.Errorf("ManifestDigest mismatch: got %q, want %q", loaded.Origin.ManifestDigest, original.Origin.ManifestDigest)
+	}
+	if !loaded.Origin.PulledAt.Equal(original.Origin.PulledAt) {
+		t.Errorf("PulledAt mismatch: got %v, want %v", loaded.Origin.PulledAt, original.Origin.PulledAt)
+	}
+
+	for name, origLayer := range original.Layers {
+		loadedLayer, ok := loaded.Layers[name]
+		if !ok {
+			t.Errorf("Layer %q not found in loaded file", name)
+			continue
+		}
+		if loadedLayer.Digest != origLayer.Digest {
+			t.Errorf("Layer %q Digest mismatch: got %q, want %q", name, loadedLayer.Digest, origLayer.Digest)
+		}
+		if loadedLayer.Size != origLayer.Size {
+			t.Errorf("Layer %q Size mismatch: got %d, want %d", name, loadedLayer.Size, origLayer.Size)
+		}
+		if loadedLayer.MediaType != origLayer.MediaType {
+			t.Errorf("Layer %q MediaType mismatch: got %q, want %q", name, loadedLayer.MediaType, origLayer.MediaType)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/localindex` package: CRUD operations for `~/.local/share/nebi/index.json` which tracks all pulled workspaces, their origin info, layer digests for drift detection, and user-friendly aliases
- Adds `internal/nebifile` package: Read/write operations for `.nebi` YAML metadata files written to workspace directories after pull, storing origin information and per-file layer digests for offline drift detection

## Issues

Closes #28 (Local index core data model)
Closes #29 (.nebi metadata file)

Part of #50 (Phase 0: Foundation)

## Test plan

- [x] Unit tests for all CRUD operations on local index (26 tests)
- [x] Unit tests for .nebi file read/write/round-trip (18 tests)
- [x] Edge cases: corrupted files, missing directories, nil maps, overwrite behavior
- [x] `go test ./internal/localindex/ ./internal/nebifile/ -v` passes