### PR TITLE
Phase 1: Pull Workflows - Directory pull, global pull, and aliases

### DIFF
--- a/cmd/nebi/pull_test.go
+++ b/cmd/nebi/pull_test.go
@@ -1,0 +1,370 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aktech/darb/internal/localindex"
+	"github.com/aktech/darb/internal/nebifile"
+)
+
+func TestHandleGlobalPull_NewWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	store := localindex.NewStoreWithDir(dir)
+
+	outputDir, err := handleGlobalPull(store, "uuid-123", "data-science", "v1.0")
+	if err != nil {
+		t.Fatalf("handleGlobalPull() error = %v", err)
+	}
+
+	expected := store.GlobalWorkspacePath("uuid-123", "v1.0")
+	if outputDir != expected {
+		t.Errorf("outputDir = %q, want %q", outputDir, expected)
+	}
+}
+
+func TestHandleGlobalPull_ExistingBlocked(t *testing.T) {
+	dir := t.TempDir()
+	store := localindex.NewStoreWithDir(dir)
+
+	// Add existing global entry
+	store.AddEntry(localindex.WorkspaceEntry{
+		Workspace: "data-science",
+		Tag:       "v1.0",
+		Path:      store.GlobalWorkspacePath("uuid-123", "v1.0"),
+		IsGlobal:  true,
+		PulledAt:  time.Now(),
+	})
+
+	// Should be blocked without --force
+	pullForce = false
+	_, err := handleGlobalPull(store, "uuid-123", "data-science", "v1.0")
+	if err == nil {
+		t.Fatal("handleGlobalPull() should return error for existing workspace without --force")
+	}
+}
+
+func TestHandleGlobalPull_ExistingForced(t *testing.T) {
+	dir := t.TempDir()
+	store := localindex.NewStoreWithDir(dir)
+
+	// Add existing global entry
+	store.AddEntry(localindex.WorkspaceEntry{
+		Workspace: "data-science",
+		Tag:       "v1.0",
+		Path:      store.GlobalWorkspacePath("uuid-123", "v1.0"),
+		IsGlobal:  true,
+		PulledAt:  time.Now(),
+	})
+
+	// Should succeed with --force
+	pullForce = true
+	defer func() { pullForce = false }()
+
+	outputDir, err := handleGlobalPull(store, "uuid-123", "data-science", "v1.0")
+	if err != nil {
+		t.Fatalf("handleGlobalPull() with --force error = %v", err)
+	}
+
+	expected := store.GlobalWorkspacePath("uuid-123", "v1.0")
+	if outputDir != expected {
+		t.Errorf("outputDir = %q, want %q", outputDir, expected)
+	}
+}
+
+func TestHandleGlobalPull_DifferentTag(t *testing.T) {
+	dir := t.TempDir()
+	store := localindex.NewStoreWithDir(dir)
+
+	// Add existing global entry for v1.0
+	store.AddEntry(localindex.WorkspaceEntry{
+		Workspace: "data-science",
+		Tag:       "v1.0",
+		Path:      store.GlobalWorkspacePath("uuid-123", "v1.0"),
+		IsGlobal:  true,
+		PulledAt:  time.Now(),
+	})
+
+	// Pull v2.0 should succeed (different tag = separate directory)
+	pullForce = false
+	outputDir, err := handleGlobalPull(store, "uuid-123", "data-science", "v2.0")
+	if err != nil {
+		t.Fatalf("handleGlobalPull() for different tag error = %v", err)
+	}
+
+	expected := store.GlobalWorkspacePath("uuid-123", "v2.0")
+	if outputDir != expected {
+		t.Errorf("outputDir = %q, want %q", outputDir, expected)
+	}
+}
+
+func TestHandleDirectoryPull_NewDirectory(t *testing.T) {
+	dir := t.TempDir()
+	store := localindex.NewStoreWithDir(dir)
+
+	pullOutput = filepath.Join(dir, "output")
+	pullForce = false
+	pullYes = false
+
+	outputDir, err := handleDirectoryPull(store, "data-science", "v1.0")
+	if err != nil {
+		t.Fatalf("handleDirectoryPull() error = %v", err)
+	}
+
+	if outputDir != pullOutput {
+		t.Errorf("outputDir = %q, want %q", outputDir, pullOutput)
+	}
+}
+
+func TestHandleDirectoryPull_SameWorkspaceTag(t *testing.T) {
+	dir := t.TempDir()
+	store := localindex.NewStoreWithDir(dir)
+
+	outputPath := filepath.Join(dir, "output")
+	os.MkdirAll(outputPath, 0755)
+
+	// Add existing entry for same workspace:tag
+	absPath, _ := filepath.Abs(outputPath)
+	store.AddEntry(localindex.WorkspaceEntry{
+		Workspace: "data-science",
+		Tag:       "v1.0",
+		Path:      absPath,
+		PulledAt:  time.Now(),
+	})
+
+	pullOutput = outputPath
+	pullForce = false
+	pullYes = false
+
+	// Same workspace:tag to same dir should succeed (re-pull, no prompt)
+	outputDir, err := handleDirectoryPull(store, "data-science", "v1.0")
+	if err != nil {
+		t.Fatalf("handleDirectoryPull() error = %v", err)
+	}
+
+	if outputDir != pullOutput {
+		t.Errorf("outputDir = %q, want %q", outputDir, pullOutput)
+	}
+}
+
+func TestHandleDirectoryPull_DifferentTagWithForce(t *testing.T) {
+	dir := t.TempDir()
+	store := localindex.NewStoreWithDir(dir)
+
+	outputPath := filepath.Join(dir, "output")
+	os.MkdirAll(outputPath, 0755)
+
+	// Add existing entry for different tag
+	absPath, _ := filepath.Abs(outputPath)
+	store.AddEntry(localindex.WorkspaceEntry{
+		Workspace: "data-science",
+		Tag:       "v1.0",
+		Path:      absPath,
+		PulledAt:  time.Now(),
+	})
+
+	pullOutput = outputPath
+	pullForce = true
+	defer func() { pullForce = false }()
+
+	// Different tag with --force should succeed
+	outputDir, err := handleDirectoryPull(store, "data-science", "v2.0")
+	if err != nil {
+		t.Fatalf("handleDirectoryPull() with --force error = %v", err)
+	}
+
+	if outputDir != pullOutput {
+		t.Errorf("outputDir = %q, want %q", outputDir, pullOutput)
+	}
+}
+
+func TestPullIntegration_WritesNebiFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Simulate what runPull does after fetching content
+	pixiTomlContent := []byte("[workspace]\nname = \"test\"\n")
+	pixiLockContent := []byte("version: 1\npackages: []\n")
+
+	// Write files
+	os.WriteFile(filepath.Join(dir, "pixi.toml"), pixiTomlContent, 0644)
+	os.WriteFile(filepath.Join(dir, "pixi.lock"), pixiLockContent, 0644)
+
+	// Compute digests
+	tomlDigest := nebifile.ComputeDigest(pixiTomlContent)
+	lockDigest := nebifile.ComputeDigest(pixiLockContent)
+
+	// Write .nebi file
+	nf := nebifile.NewFromPull(
+		"test-workspace", "v1.0", "test-registry", "https://nebi.example.com",
+		1, "sha256:manifest123",
+		tomlDigest, int64(len(pixiTomlContent)),
+		lockDigest, int64(len(pixiLockContent)),
+	)
+	if err := nebifile.Write(dir, nf); err != nil {
+		t.Fatalf("nebifile.Write() error = %v", err)
+	}
+
+	// Verify .nebi file was created
+	if !nebifile.Exists(dir) {
+		t.Fatal(".nebi file should exist")
+	}
+
+	// Read it back
+	loaded, err := nebifile.Read(dir)
+	if err != nil {
+		t.Fatalf("nebifile.Read() error = %v", err)
+	}
+
+	if loaded.Origin.Workspace != "test-workspace" {
+		t.Errorf("Workspace = %q, want %q", loaded.Origin.Workspace, "test-workspace")
+	}
+	if loaded.Origin.Tag != "v1.0" {
+		t.Errorf("Tag = %q, want %q", loaded.Origin.Tag, "v1.0")
+	}
+	if loaded.Origin.ServerURL != "https://nebi.example.com" {
+		t.Errorf("ServerURL = %q, want %q", loaded.Origin.ServerURL, "https://nebi.example.com")
+	}
+	if loaded.GetLayerDigest("pixi.toml") != tomlDigest {
+		t.Errorf("pixi.toml digest mismatch")
+	}
+	if loaded.GetLayerDigest("pixi.lock") != lockDigest {
+		t.Errorf("pixi.lock digest mismatch")
+	}
+}
+
+func TestPullIntegration_UpdatesIndex(t *testing.T) {
+	dir := t.TempDir()
+	store := localindex.NewStoreWithDir(dir)
+
+	// Simulate adding an entry (as runPull does)
+	entry := localindex.WorkspaceEntry{
+		Workspace:       "test-workspace",
+		Tag:             "v1.0",
+		ServerURL:       "https://nebi.example.com",
+		ServerVersionID: 1,
+		Path:            filepath.Join(dir, "workspace"),
+		IsGlobal:        false,
+		PulledAt:        time.Now(),
+		ManifestDigest:  "sha256:manifest123",
+		Layers: map[string]string{
+			"pixi.toml": "sha256:toml456",
+			"pixi.lock": "sha256:lock789",
+		},
+	}
+
+	if err := store.AddEntry(entry); err != nil {
+		t.Fatalf("AddEntry() error = %v", err)
+	}
+
+	// Verify entry is in index
+	found, err := store.FindByPath(entry.Path)
+	if err != nil {
+		t.Fatalf("FindByPath() error = %v", err)
+	}
+	if found == nil {
+		t.Fatal("Entry should be found in index")
+	}
+	if found.Workspace != "test-workspace" {
+		t.Errorf("Workspace = %q, want %q", found.Workspace, "test-workspace")
+	}
+	if found.ManifestDigest != "sha256:manifest123" {
+		t.Errorf("ManifestDigest = %q, want %q", found.ManifestDigest, "sha256:manifest123")
+	}
+}
+
+func TestPullIntegration_GlobalWithAlias(t *testing.T) {
+	dir := t.TempDir()
+	store := localindex.NewStoreWithDir(dir)
+
+	// Simulate global pull with alias
+	uuid := "550e8400-e29b-41d4-a716-446655440000"
+	tag := "v1.0"
+
+	entry := localindex.WorkspaceEntry{
+		Workspace:       "data-science",
+		Tag:             tag,
+		ServerURL:       "https://nebi.example.com",
+		ServerVersionID: 42,
+		Path:            store.GlobalWorkspacePath(uuid, tag),
+		IsGlobal:        true,
+		PulledAt:        time.Now(),
+		ManifestDigest:  "sha256:abc123",
+		Layers: map[string]string{
+			"pixi.toml": "sha256:111",
+			"pixi.lock": "sha256:222",
+		},
+	}
+
+	if err := store.AddEntry(entry); err != nil {
+		t.Fatalf("AddEntry() error = %v", err)
+	}
+
+	// Set alias
+	alias := localindex.Alias{UUID: uuid, Tag: tag}
+	if err := store.SetAlias("ds-stable", alias); err != nil {
+		t.Fatalf("SetAlias() error = %v", err)
+	}
+
+	// Verify alias resolves
+	got, err := store.GetAlias("ds-stable")
+	if err != nil {
+		t.Fatalf("GetAlias() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("Alias should exist")
+	}
+	if got.UUID != uuid {
+		t.Errorf("Alias UUID = %q, want %q", got.UUID, uuid)
+	}
+	if got.Tag != tag {
+		t.Errorf("Alias Tag = %q, want %q", got.Tag, tag)
+	}
+
+	// Verify global entry is findable
+	global, err := store.FindGlobal("data-science", "v1.0")
+	if err != nil {
+		t.Fatalf("FindGlobal() error = %v", err)
+	}
+	if global == nil {
+		t.Fatal("Global entry should be found")
+	}
+	if !global.IsGlobal {
+		t.Error("Entry should be global")
+	}
+}
+
+func TestPullIntegration_DirectoryPullDuplicateAllowed(t *testing.T) {
+	dir := t.TempDir()
+	store := localindex.NewStoreWithDir(dir)
+
+	now := time.Now()
+
+	// Pull to path A
+	entryA := localindex.WorkspaceEntry{
+		Workspace: "data-science",
+		Tag:       "v1.0",
+		Path:      filepath.Join(dir, "project-a"),
+		PulledAt:  now,
+	}
+	store.AddEntry(entryA)
+
+	// Pull same workspace:tag to path B (allowed for directory pulls)
+	entryB := localindex.WorkspaceEntry{
+		Workspace: "data-science",
+		Tag:       "v1.0",
+		Path:      filepath.Join(dir, "project-b"),
+		PulledAt:  now.Add(time.Hour),
+	}
+	store.AddEntry(entryB)
+
+	// Both should exist
+	matches, err := store.FindByWorkspaceTag("data-science", "v1.0")
+	if err != nil {
+		t.Fatalf("FindByWorkspaceTag() error = %v", err)
+	}
+	if len(matches) != 2 {
+		t.Errorf("Expected 2 entries for same workspace:tag, got %d", len(matches))
+	}
+}

--- a/internal/nebifile/digest.go
+++ b/internal/nebifile/digest.go
@@ -1,0 +1,14 @@
+package nebifile
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+// ComputeDigest computes the sha256 digest of content, returning it in the
+// format "sha256:<hex>". This matches the OCI layer digest format used by
+// Nebi's publisher.
+func ComputeDigest(content []byte) string {
+	h := sha256.Sum256(content)
+	return fmt.Sprintf("sha256:%x", h)
+}

--- a/internal/nebifile/digest_test.go
+++ b/internal/nebifile/digest_test.go
@@ -1,0 +1,62 @@
+package nebifile
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+)
+
+func TestComputeDigest(t *testing.T) {
+	// Known sha256 of "hello world\n"
+	content := []byte("hello world\n")
+	h := sha256.Sum256(content)
+	expected := fmt.Sprintf("sha256:%x", h)
+
+	got := ComputeDigest(content)
+	if got != expected {
+		t.Errorf("ComputeDigest() = %q, want %q", got, expected)
+	}
+}
+
+func TestComputeDigestEmpty(t *testing.T) {
+	// sha256 of empty content
+	content := []byte{}
+	got := ComputeDigest(content)
+	// Known sha256 of empty: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+	expected := "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	if got != expected {
+		t.Errorf("ComputeDigest(empty) = %q, want %q", got, expected)
+	}
+}
+
+func TestComputeDigestDeterministic(t *testing.T) {
+	content := []byte("test content for digest")
+	d1 := ComputeDigest(content)
+	d2 := ComputeDigest(content)
+	if d1 != d2 {
+		t.Errorf("ComputeDigest is not deterministic: %q != %q", d1, d2)
+	}
+}
+
+func TestComputeDigestDifferentContent(t *testing.T) {
+	d1 := ComputeDigest([]byte("content a"))
+	d2 := ComputeDigest([]byte("content b"))
+	if d1 == d2 {
+		t.Error("Different content should produce different digests")
+	}
+}
+
+func TestComputeDigestFormat(t *testing.T) {
+	content := []byte("test")
+	got := ComputeDigest(content)
+
+	// Should start with "sha256:"
+	if len(got) < 7 || got[:7] != "sha256:" {
+		t.Errorf("ComputeDigest() = %q, should start with 'sha256:'", got)
+	}
+
+	// Should be sha256: + 64 hex chars = 71 chars total
+	if len(got) != 71 {
+		t.Errorf("ComputeDigest() length = %d, want 71", len(got))
+	}
+}


### PR DESCRIPTION
## Summary

- Enhanced `nebi pull` to create `.nebi` metadata files and update the local index on every pull
- Added `--global` flag for UUID-based global storage with duplicate prevention
- Added `--name` flag for assigning human-readable aliases to global workspaces
- Added `--force` and `--yes` flags for controlling overwrite behavior
- Added `ComputeDigest` utility for sha256 content hashing

## Issues

Closes #30 (Directory pull with .nebi + index tracking)
Closes #31 (Global pull with duplicate prevention)
Closes #32 (Global workspace aliases)

Part of #50 (Phase 1: Pull Workflows)

## Test plan

- [x] Unit tests for global pull scenarios (new, existing blocked, existing forced, different tag)
- [x] Unit tests for directory pull scenarios (new dir, same tag re-pull, different tag with force)
- [x] Integration tests for .nebi file creation and index updates
- [x] Integration test for global pull with alias creation
- [x] Digest computation tests (empty, deterministic, format verification)
- [x] `go test ./cmd/nebi/ ./internal/nebifile/ -v` passes (16 new tests)