### PR TITLE
Phase 2: Drift Detection Core - Local drift, remote fetching, tag mutation

### DIFF
--- a/internal/drift/drift.go
+++ b/internal/drift/drift.go
@@ -1,0 +1,134 @@
+// Package drift provides drift detection for Nebi workspaces.
+//
+// Drift detection compares local file content against the layer digests
+// stored in the .nebi metadata file. This allows offline detection of
+// whether files have been modified since they were pulled.
+package drift
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/aktech/darb/internal/nebifile"
+)
+
+// Status represents the drift status of a workspace or file.
+type Status string
+
+const (
+	// StatusClean means the local file matches the pulled layer digest.
+	StatusClean Status = "clean"
+
+	// StatusModified means the local file differs from the pulled layer digest.
+	StatusModified Status = "modified"
+
+	// StatusMissing means the local file no longer exists.
+	StatusMissing Status = "missing"
+
+	// StatusUnknown means drift cannot be determined (e.g., .nebi metadata missing).
+	StatusUnknown Status = "unknown"
+)
+
+// FileStatus represents the drift status of a single file.
+type FileStatus struct {
+	Filename      string `json:"filename"`
+	Status        Status `json:"status"`
+	OriginDigest  string `json:"origin_digest,omitempty"`
+	CurrentDigest string `json:"current_digest,omitempty"`
+}
+
+// WorkspaceStatus represents the overall drift status of a workspace.
+type WorkspaceStatus struct {
+	Overall Status       `json:"overall"`
+	Files   []FileStatus `json:"files"`
+}
+
+// Check performs drift detection on a workspace directory.
+// It reads the .nebi metadata file and compares local file hashes
+// against the stored layer digests.
+func Check(dir string) (*WorkspaceStatus, error) {
+	nf, err := nebifile.Read(dir)
+	if err != nil {
+		return &WorkspaceStatus{
+			Overall: StatusUnknown,
+		}, fmt.Errorf("failed to read .nebi metadata: %w", err)
+	}
+
+	return CheckWithNebiFile(dir, nf), nil
+}
+
+// CheckWithNebiFile performs drift detection using an already-loaded .nebi file.
+// This is useful when the caller already has the NebiFile loaded.
+func CheckWithNebiFile(dir string, nf *nebifile.NebiFile) *WorkspaceStatus {
+	ws := &WorkspaceStatus{
+		Overall: StatusClean,
+		Files:   make([]FileStatus, 0, len(nf.Layers)),
+	}
+
+	for filename, layer := range nf.Layers {
+		fs := checkFile(dir, filename, layer.Digest)
+		ws.Files = append(ws.Files, fs)
+
+		if fs.Status != StatusClean {
+			ws.Overall = StatusModified
+		}
+	}
+
+	return ws
+}
+
+// checkFile checks the drift status of a single file.
+func checkFile(dir, filename, originDigest string) FileStatus {
+	path := filepath.Join(dir, filename)
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return FileStatus{
+				Filename:     filename,
+				Status:       StatusMissing,
+				OriginDigest: originDigest,
+			}
+		}
+		// Can't read file - treat as unknown
+		return FileStatus{
+			Filename:     filename,
+			Status:       StatusUnknown,
+			OriginDigest: originDigest,
+		}
+	}
+
+	currentDigest := nebifile.ComputeDigest(content)
+
+	if currentDigest == originDigest {
+		return FileStatus{
+			Filename:      filename,
+			Status:        StatusClean,
+			OriginDigest:  originDigest,
+			CurrentDigest: currentDigest,
+		}
+	}
+
+	return FileStatus{
+		Filename:      filename,
+		Status:        StatusModified,
+		OriginDigest:  originDigest,
+		CurrentDigest: currentDigest,
+	}
+}
+
+// IsModified returns true if any file in the workspace has been modified.
+func (ws *WorkspaceStatus) IsModified() bool {
+	return ws.Overall == StatusModified
+}
+
+// GetFileStatus returns the status of a specific file, or nil if not tracked.
+func (ws *WorkspaceStatus) GetFileStatus(filename string) *FileStatus {
+	for i := range ws.Files {
+		if ws.Files[i].Filename == filename {
+			return &ws.Files[i]
+		}
+	}
+	return nil
+}

--- a/internal/drift/drift_test.go
+++ b/internal/drift/drift_test.go
@@ -1,0 +1,279 @@
+package drift
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aktech/darb/internal/nebifile"
+)
+
+func setupTestWorkspace(t *testing.T, pixiToml, pixiLock string) (string, *nebifile.NebiFile) {
+	t.Helper()
+	dir := t.TempDir()
+
+	// Write files
+	tomlBytes := []byte(pixiToml)
+	lockBytes := []byte(pixiLock)
+	os.WriteFile(filepath.Join(dir, "pixi.toml"), tomlBytes, 0644)
+	os.WriteFile(filepath.Join(dir, "pixi.lock"), lockBytes, 0644)
+
+	// Compute digests
+	tomlDigest := nebifile.ComputeDigest(tomlBytes)
+	lockDigest := nebifile.ComputeDigest(lockBytes)
+
+	// Create .nebi file
+	nf := nebifile.NewFromPull(
+		"test-workspace", "v1.0", "test-registry", "https://nebi.example.com",
+		1, "sha256:manifest123",
+		tomlDigest, int64(len(tomlBytes)),
+		lockDigest, int64(len(lockBytes)),
+	)
+	nebifile.Write(dir, nf)
+
+	return dir, nf
+}
+
+func TestCheck_Clean(t *testing.T) {
+	dir, _ := setupTestWorkspace(t,
+		"[workspace]\nname = \"test\"\n",
+		"version: 1\npackages: []\n",
+	)
+
+	ws, err := Check(dir)
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+
+	if ws.Overall != StatusClean {
+		t.Errorf("Overall = %q, want %q", ws.Overall, StatusClean)
+	}
+	if ws.IsModified() {
+		t.Error("IsModified() should be false for clean workspace")
+	}
+}
+
+func TestCheck_ModifiedPixiToml(t *testing.T) {
+	dir, _ := setupTestWorkspace(t,
+		"[workspace]\nname = \"test\"\n",
+		"version: 1\npackages: []\n",
+	)
+
+	// Modify pixi.toml
+	os.WriteFile(filepath.Join(dir, "pixi.toml"), []byte("[workspace]\nname = \"modified\"\n"), 0644)
+
+	ws, err := Check(dir)
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+
+	if ws.Overall != StatusModified {
+		t.Errorf("Overall = %q, want %q", ws.Overall, StatusModified)
+	}
+	if !ws.IsModified() {
+		t.Error("IsModified() should be true for modified workspace")
+	}
+
+	// Check file-level status
+	tomlStatus := ws.GetFileStatus("pixi.toml")
+	if tomlStatus == nil {
+		t.Fatal("GetFileStatus(pixi.toml) returned nil")
+	}
+	if tomlStatus.Status != StatusModified {
+		t.Errorf("pixi.toml status = %q, want %q", tomlStatus.Status, StatusModified)
+	}
+
+	lockStatus := ws.GetFileStatus("pixi.lock")
+	if lockStatus == nil {
+		t.Fatal("GetFileStatus(pixi.lock) returned nil")
+	}
+	if lockStatus.Status != StatusClean {
+		t.Errorf("pixi.lock status = %q, want %q", lockStatus.Status, StatusClean)
+	}
+}
+
+func TestCheck_ModifiedPixiLock(t *testing.T) {
+	dir, _ := setupTestWorkspace(t,
+		"[workspace]\nname = \"test\"\n",
+		"version: 1\npackages: []\n",
+	)
+
+	// Modify pixi.lock
+	os.WriteFile(filepath.Join(dir, "pixi.lock"), []byte("version: 2\npackages:\n  - numpy\n"), 0644)
+
+	ws, err := Check(dir)
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+
+	if ws.Overall != StatusModified {
+		t.Errorf("Overall = %q, want %q", ws.Overall, StatusModified)
+	}
+
+	lockStatus := ws.GetFileStatus("pixi.lock")
+	if lockStatus.Status != StatusModified {
+		t.Errorf("pixi.lock status = %q, want %q", lockStatus.Status, StatusModified)
+	}
+}
+
+func TestCheck_BothModified(t *testing.T) {
+	dir, _ := setupTestWorkspace(t,
+		"[workspace]\nname = \"test\"\n",
+		"version: 1\npackages: []\n",
+	)
+
+	// Modify both files
+	os.WriteFile(filepath.Join(dir, "pixi.toml"), []byte("modified toml"), 0644)
+	os.WriteFile(filepath.Join(dir, "pixi.lock"), []byte("modified lock"), 0644)
+
+	ws, err := Check(dir)
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+
+	if ws.Overall != StatusModified {
+		t.Errorf("Overall = %q, want %q", ws.Overall, StatusModified)
+	}
+
+	tomlStatus := ws.GetFileStatus("pixi.toml")
+	if tomlStatus.Status != StatusModified {
+		t.Errorf("pixi.toml status = %q, want %q", tomlStatus.Status, StatusModified)
+	}
+
+	lockStatus := ws.GetFileStatus("pixi.lock")
+	if lockStatus.Status != StatusModified {
+		t.Errorf("pixi.lock status = %q, want %q", lockStatus.Status, StatusModified)
+	}
+}
+
+func TestCheck_MissingFile(t *testing.T) {
+	dir, _ := setupTestWorkspace(t,
+		"[workspace]\nname = \"test\"\n",
+		"version: 1\npackages: []\n",
+	)
+
+	// Delete pixi.lock
+	os.Remove(filepath.Join(dir, "pixi.lock"))
+
+	ws, err := Check(dir)
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+
+	if ws.Overall != StatusModified {
+		t.Errorf("Overall = %q, want %q", ws.Overall, StatusModified)
+	}
+
+	lockStatus := ws.GetFileStatus("pixi.lock")
+	if lockStatus.Status != StatusMissing {
+		t.Errorf("pixi.lock status = %q, want %q", lockStatus.Status, StatusMissing)
+	}
+}
+
+func TestCheck_NoNebiFile(t *testing.T) {
+	dir := t.TempDir()
+
+	ws, err := Check(dir)
+	if err == nil {
+		t.Fatal("Check() should return error when .nebi file is missing")
+	}
+	if ws.Overall != StatusUnknown {
+		t.Errorf("Overall = %q, want %q", ws.Overall, StatusUnknown)
+	}
+}
+
+func TestCheckWithNebiFile(t *testing.T) {
+	dir := t.TempDir()
+
+	content := []byte("test content")
+	os.WriteFile(filepath.Join(dir, "pixi.toml"), content, 0644)
+
+	digest := nebifile.ComputeDigest(content)
+	nf := &nebifile.NebiFile{
+		Layers: map[string]nebifile.Layer{
+			"pixi.toml": {Digest: digest, Size: int64(len(content))},
+		},
+	}
+
+	ws := CheckWithNebiFile(dir, nf)
+	if ws.Overall != StatusClean {
+		t.Errorf("Overall = %q, want %q", ws.Overall, StatusClean)
+	}
+}
+
+func TestGetFileStatus_NotFound(t *testing.T) {
+	ws := &WorkspaceStatus{
+		Files: []FileStatus{
+			{Filename: "pixi.toml", Status: StatusClean},
+		},
+	}
+
+	result := ws.GetFileStatus("nonexistent.txt")
+	if result != nil {
+		t.Errorf("GetFileStatus(nonexistent) = %v, want nil", result)
+	}
+}
+
+func TestFileStatusDigests(t *testing.T) {
+	dir, nf := setupTestWorkspace(t,
+		"original content",
+		"original lock",
+	)
+
+	// Modify pixi.toml
+	newContent := []byte("modified content")
+	os.WriteFile(filepath.Join(dir, "pixi.toml"), newContent, 0644)
+
+	ws := CheckWithNebiFile(dir, nf)
+
+	tomlStatus := ws.GetFileStatus("pixi.toml")
+	if tomlStatus == nil {
+		t.Fatal("pixi.toml status not found")
+	}
+
+	// Origin digest should match what .nebi has
+	if tomlStatus.OriginDigest != nf.GetLayerDigest("pixi.toml") {
+		t.Errorf("OriginDigest = %q, want %q", tomlStatus.OriginDigest, nf.GetLayerDigest("pixi.toml"))
+	}
+
+	// Current digest should match the new content
+	expectedCurrent := nebifile.ComputeDigest(newContent)
+	if tomlStatus.CurrentDigest != expectedCurrent {
+		t.Errorf("CurrentDigest = %q, want %q", tomlStatus.CurrentDigest, expectedCurrent)
+	}
+}
+
+func TestStatusConstants(t *testing.T) {
+	if StatusClean != "clean" {
+		t.Errorf("StatusClean = %q, want %q", StatusClean, "clean")
+	}
+	if StatusModified != "modified" {
+		t.Errorf("StatusModified = %q, want %q", StatusModified, "modified")
+	}
+	if StatusMissing != "missing" {
+		t.Errorf("StatusMissing = %q, want %q", StatusMissing, "missing")
+	}
+	if StatusUnknown != "unknown" {
+		t.Errorf("StatusUnknown = %q, want %q", StatusUnknown, "unknown")
+	}
+}
+
+func TestCheck_WhitespaceOnlyChange(t *testing.T) {
+	// Byte-level comparison means even whitespace changes are detected
+	dir, _ := setupTestWorkspace(t,
+		"[workspace]\nname = \"test\"\n",
+		"version: 1\n",
+	)
+
+	// Add a trailing space (byte-level change)
+	os.WriteFile(filepath.Join(dir, "pixi.toml"), []byte("[workspace]\nname = \"test\" \n"), 0644)
+
+	ws, err := Check(dir)
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+
+	if ws.Overall != StatusModified {
+		t.Errorf("Overall = %q, want %q (whitespace change should be detected)", ws.Overall, StatusModified)
+	}
+}

--- a/internal/drift/remote.go
+++ b/internal/drift/remote.go
@@ -1,0 +1,208 @@
+package drift
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aktech/darb/internal/cliclient"
+	"github.com/aktech/darb/internal/nebifile"
+)
+
+// RemoteStatus represents the result of a remote comparison.
+type RemoteStatus struct {
+	// TagHasMoved is true if the tag now points to a different digest
+	// than what was originally pulled.
+	TagHasMoved bool `json:"tag_has_moved"`
+
+	// OriginDigest is the manifest digest from when the workspace was pulled.
+	OriginDigest string `json:"origin_digest"`
+
+	// CurrentTagDigest is what the tag currently resolves to on the server.
+	CurrentTagDigest string `json:"current_tag_digest,omitempty"`
+
+	// CurrentVersionID is the version ID the tag currently points to.
+	CurrentVersionID int32 `json:"current_version_id,omitempty"`
+
+	// Error is set if the remote check failed.
+	Error string `json:"error,omitempty"`
+}
+
+// VersionContent holds the content fetched from the server for a specific version.
+type VersionContent struct {
+	PixiToml  string `json:"pixi_toml"`
+	PixiLock  string `json:"pixi_lock"`
+	VersionID int32  `json:"version_id"`
+}
+
+// ThreeWayStatus represents the full three-state comparison:
+// LOCAL ↔ ORIGIN ↔ CURRENT TAG
+type ThreeWayStatus struct {
+	// Local is the drift status of local files vs origin
+	Local *WorkspaceStatus `json:"local"`
+
+	// Remote is the status of the tag in the registry
+	Remote *RemoteStatus `json:"remote"`
+
+	// Summary combines local and remote status into a human-readable summary
+	Summary string `json:"summary"`
+}
+
+// CheckRemote checks if the remote tag has moved since the workspace was pulled.
+// It compares the stored manifest digest against the current tag resolution.
+func CheckRemote(ctx context.Context, client *cliclient.Client, nf *nebifile.NebiFile) *RemoteStatus {
+	rs := &RemoteStatus{
+		OriginDigest: nf.Origin.ManifestDigest,
+	}
+
+	// Find workspace by listing environments
+	envs, err := client.ListEnvironments(ctx)
+	if err != nil {
+		rs.Error = fmt.Sprintf("failed to list environments: %v", err)
+		return rs
+	}
+
+	var envID string
+	for _, env := range envs {
+		if env.Name == nf.Origin.Workspace {
+			envID = env.ID
+			break
+		}
+	}
+	if envID == "" {
+		rs.Error = fmt.Sprintf("workspace %q not found on server", nf.Origin.Workspace)
+		return rs
+	}
+
+	// Get publications to find current digest for the tag
+	pubs, err := client.GetEnvironmentPublications(ctx, envID)
+	if err != nil {
+		rs.Error = fmt.Sprintf("failed to get publications: %v", err)
+		return rs
+	}
+
+	found := false
+	for _, pub := range pubs {
+		if pub.Tag == nf.Origin.Tag {
+			rs.CurrentTagDigest = pub.Digest
+			rs.CurrentVersionID = int32(pub.VersionNumber)
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		rs.Error = fmt.Sprintf("tag %q not found in registry", nf.Origin.Tag)
+		return rs
+	}
+
+	// Compare digests
+	if rs.OriginDigest != "" && rs.CurrentTagDigest != "" {
+		rs.TagHasMoved = rs.OriginDigest != rs.CurrentTagDigest
+	}
+
+	return rs
+}
+
+// FetchVersionContent fetches the pixi.toml and pixi.lock content for a specific
+// version from the server. Used by nebi diff to get the original content.
+func FetchVersionContent(ctx context.Context, client *cliclient.Client, envID string, versionID int32) (*VersionContent, error) {
+	pixiToml, err := client.GetVersionPixiToml(ctx, envID, versionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pixi.toml for version %d: %w", versionID, err)
+	}
+
+	pixiLock, err := client.GetVersionPixiLock(ctx, envID, versionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pixi.lock for version %d: %w", versionID, err)
+	}
+
+	return &VersionContent{
+		PixiToml:  pixiToml,
+		PixiLock:  pixiLock,
+		VersionID: versionID,
+	}, nil
+}
+
+// FetchByTag resolves a tag to a version and fetches its content.
+// This is used by nebi diff --remote.
+func FetchByTag(ctx context.Context, client *cliclient.Client, workspace, tag string) (*VersionContent, error) {
+	// Find workspace
+	envs, err := client.ListEnvironments(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list environments: %w", err)
+	}
+
+	var envID string
+	for _, env := range envs {
+		if env.Name == workspace {
+			envID = env.ID
+			break
+		}
+	}
+	if envID == "" {
+		return nil, fmt.Errorf("workspace %q not found", workspace)
+	}
+
+	// Find publication for tag
+	pubs, err := client.GetEnvironmentPublications(ctx, envID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get publications: %w", err)
+	}
+
+	var versionNumber int32
+	found := false
+	for _, pub := range pubs {
+		if pub.Tag == tag {
+			versionNumber = int32(pub.VersionNumber)
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return nil, fmt.Errorf("tag %q not found for workspace %q", tag, workspace)
+	}
+
+	return FetchVersionContent(ctx, client, envID, versionNumber)
+}
+
+// CheckThreeWay performs the full three-way comparison:
+// 1. LOCAL vs ORIGIN (offline drift detection)
+// 2. ORIGIN vs CURRENT TAG (remote tag mutation detection)
+func CheckThreeWay(ctx context.Context, client *cliclient.Client, dir string, nf *nebifile.NebiFile) *ThreeWayStatus {
+	ts := &ThreeWayStatus{}
+
+	// Local drift check (offline)
+	ts.Local = CheckWithNebiFile(dir, nf)
+
+	// Remote check (network)
+	ts.Remote = CheckRemote(ctx, client, nf)
+
+	// Generate summary
+	ts.Summary = generateSummary(ts)
+
+	return ts
+}
+
+// generateSummary creates a human-readable summary of the three-way status.
+func generateSummary(ts *ThreeWayStatus) string {
+	localModified := ts.Local.Overall == StatusModified
+	remoteError := ts.Remote.Error != ""
+	tagMoved := ts.Remote.TagHasMoved
+
+	switch {
+	case remoteError:
+		if localModified {
+			return "modified locally (remote check failed)"
+		}
+		return "clean locally (remote check failed)"
+	case localModified && tagMoved:
+		return "modified locally AND remote tag has moved"
+	case localModified && !tagMoved:
+		return "modified locally, remote unchanged"
+	case !localModified && tagMoved:
+		return "clean locally, but remote tag has moved"
+	default:
+		return "clean (local matches origin, tag unchanged)"
+	}
+}

--- a/internal/drift/remote_test.go
+++ b/internal/drift/remote_test.go
@@ -1,0 +1,176 @@
+package drift
+
+import (
+	"testing"
+
+	"github.com/aktech/darb/internal/nebifile"
+)
+
+func TestRemoteStatus_TagHasMoved(t *testing.T) {
+	rs := &RemoteStatus{
+		OriginDigest:     "sha256:aaa",
+		CurrentTagDigest: "sha256:bbb",
+		TagHasMoved:      true,
+	}
+
+	if !rs.TagHasMoved {
+		t.Error("TagHasMoved should be true")
+	}
+}
+
+func TestRemoteStatus_TagUnchanged(t *testing.T) {
+	rs := &RemoteStatus{
+		OriginDigest:     "sha256:aaa",
+		CurrentTagDigest: "sha256:aaa",
+		TagHasMoved:      false,
+	}
+
+	if rs.TagHasMoved {
+		t.Error("TagHasMoved should be false when digests match")
+	}
+}
+
+func TestGenerateSummary_CleanLocalCleanRemote(t *testing.T) {
+	ts := &ThreeWayStatus{
+		Local: &WorkspaceStatus{Overall: StatusClean},
+		Remote: &RemoteStatus{
+			TagHasMoved: false,
+		},
+	}
+
+	summary := generateSummary(ts)
+	if summary != "clean (local matches origin, tag unchanged)" {
+		t.Errorf("summary = %q, unexpected", summary)
+	}
+}
+
+func TestGenerateSummary_ModifiedLocalCleanRemote(t *testing.T) {
+	ts := &ThreeWayStatus{
+		Local: &WorkspaceStatus{Overall: StatusModified},
+		Remote: &RemoteStatus{
+			TagHasMoved: false,
+		},
+	}
+
+	summary := generateSummary(ts)
+	if summary != "modified locally, remote unchanged" {
+		t.Errorf("summary = %q, unexpected", summary)
+	}
+}
+
+func TestGenerateSummary_CleanLocalMovedRemote(t *testing.T) {
+	ts := &ThreeWayStatus{
+		Local: &WorkspaceStatus{Overall: StatusClean},
+		Remote: &RemoteStatus{
+			TagHasMoved: true,
+		},
+	}
+
+	summary := generateSummary(ts)
+	if summary != "clean locally, but remote tag has moved" {
+		t.Errorf("summary = %q, unexpected", summary)
+	}
+}
+
+func TestGenerateSummary_ModifiedLocalMovedRemote(t *testing.T) {
+	ts := &ThreeWayStatus{
+		Local: &WorkspaceStatus{Overall: StatusModified},
+		Remote: &RemoteStatus{
+			TagHasMoved: true,
+		},
+	}
+
+	summary := generateSummary(ts)
+	if summary != "modified locally AND remote tag has moved" {
+		t.Errorf("summary = %q, unexpected", summary)
+	}
+}
+
+func TestGenerateSummary_RemoteError(t *testing.T) {
+	ts := &ThreeWayStatus{
+		Local: &WorkspaceStatus{Overall: StatusClean},
+		Remote: &RemoteStatus{
+			Error: "network error",
+		},
+	}
+
+	summary := generateSummary(ts)
+	if summary != "clean locally (remote check failed)" {
+		t.Errorf("summary = %q, unexpected", summary)
+	}
+}
+
+func TestGenerateSummary_RemoteErrorWithLocalModified(t *testing.T) {
+	ts := &ThreeWayStatus{
+		Local: &WorkspaceStatus{Overall: StatusModified},
+		Remote: &RemoteStatus{
+			Error: "network error",
+		},
+	}
+
+	summary := generateSummary(ts)
+	if summary != "modified locally (remote check failed)" {
+		t.Errorf("summary = %q, unexpected", summary)
+	}
+}
+
+func TestThreeWayStatus_Structure(t *testing.T) {
+	ts := &ThreeWayStatus{
+		Local: &WorkspaceStatus{
+			Overall: StatusModified,
+			Files: []FileStatus{
+				{Filename: "pixi.toml", Status: StatusModified},
+				{Filename: "pixi.lock", Status: StatusClean},
+			},
+		},
+		Remote: &RemoteStatus{
+			OriginDigest:     "sha256:aaa",
+			CurrentTagDigest: "sha256:bbb",
+			TagHasMoved:      true,
+			CurrentVersionID: 5,
+		},
+		Summary: "modified locally AND remote tag has moved",
+	}
+
+	if ts.Local.Overall != StatusModified {
+		t.Errorf("Local.Overall = %q, want %q", ts.Local.Overall, StatusModified)
+	}
+	if !ts.Remote.TagHasMoved {
+		t.Error("Remote.TagHasMoved should be true")
+	}
+	if ts.Remote.CurrentVersionID != 5 {
+		t.Errorf("Remote.CurrentVersionID = %d, want 5", ts.Remote.CurrentVersionID)
+	}
+}
+
+func TestVersionContent_Structure(t *testing.T) {
+	vc := &VersionContent{
+		PixiToml:  "[workspace]\nname = \"test\"\n",
+		PixiLock:  "version: 1\n",
+		VersionID: 42,
+	}
+
+	if vc.PixiToml == "" {
+		t.Error("PixiToml should not be empty")
+	}
+	if vc.PixiLock == "" {
+		t.Error("PixiLock should not be empty")
+	}
+	if vc.VersionID != 42 {
+		t.Errorf("VersionID = %d, want 42", vc.VersionID)
+	}
+}
+
+func TestCheckWithNebiFile_EmptyLayers(t *testing.T) {
+	nf := &nebifile.NebiFile{
+		Layers: map[string]nebifile.Layer{},
+	}
+
+	ws := CheckWithNebiFile("/tmp", nf)
+	if ws.Overall != StatusClean {
+		t.Errorf("Overall = %q, want %q (empty layers should be clean)", ws.Overall, StatusClean)
+	}
+	if len(ws.Files) != 0 {
+		t.Errorf("Files length = %d, want 0", len(ws.Files))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/drift` package for workspace drift detection
- Implements offline local drift detection via sha256 hash comparison against `.nebi` layer digests
- Adds remote content fetching (by version ID for immutable access, by tag for current state)
- Implements three-way comparison: LOCAL vs ORIGIN vs CURRENT TAG for detecting mutable tag changes
- Generates human-readable summaries for all combination states

## Issues

Closes #33 (Drift detection via hash comparison)
Closes #42 (Remote fetching by version ID and tag)
Closes #43 (Mutable tag detection with three-state comparison)

Part of #50 (Phase 2: Drift Detection Core)

## Test plan

- [x] Unit tests for clean workspace detection
- [x] Unit tests for modified pixi.toml, pixi.lock, both files
- [x] Unit tests for missing files
- [x] Unit tests for workspace without .nebi file
- [x] Unit tests for whitespace-only changes (byte-level detection)
- [x] Unit tests for three-way status generation (all 6 combinations)
- [x] Unit tests for remote status structures
- [x] `go test ./internal/drift/ -v` passes (22 tests)