### PR TITLE
Phase 5: feat: shell activation, workspace list --local, prune, push drift (#36, #37, #38, #39)

### DIFF
--- a/cmd/nebi/shell.go
+++ b/cmd/nebi/shell.go
@@ -6,28 +6,35 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/aktech/darb/internal/drift"
+	"github.com/aktech/darb/internal/localindex"
+	"github.com/aktech/darb/internal/nebifile"
 	"github.com/spf13/cobra"
 )
 
 var shellPixiEnv string
 
 var shellCmd = &cobra.Command{
-	Use:   "shell <workspace>[:<tag>]",
+	Use:   "shell [<workspace>[:<tag>]]",
 	Short: "Activate workspace shell",
 	Long: `Activate a workspace shell using pixi shell.
 
-The workspace is pulled from the server and cached locally.
+When run without arguments in a directory with .nebi metadata, uses the
+local workspace. When given a workspace reference, looks up the local
+index (preferring global copies) and falls back to pulling from server.
+
+Drift detection warns if local files have been modified since pull.
 
 Examples:
-  # Shell into latest version
-  nebi shell myworkspace
+  # Shell from current directory (reads .nebi metadata)
+  nebi shell
 
-  # Shell into specific tag
+  # Shell into specific workspace by name
   nebi shell myworkspace:v1.0.0
 
   # Shell into specific pixi environment
   nebi shell myworkspace:v1.0.0 -e dev`,
-	Args: cobra.ExactArgs(1),
+	Args: cobra.MaximumNArgs(1),
 	Run:  runShell,
 }
 
@@ -36,13 +43,106 @@ func init() {
 }
 
 func runShell(cmd *cobra.Command, args []string) {
-	// Parse workspace:tag format
-	workspaceName, tag, err := parseWorkspaceRef(args[0])
+	var shellDir string
+
+	if len(args) == 0 {
+		// No argument - use current directory
+		shellDir = resolveShellFromCwd()
+	} else {
+		// Parse workspace:tag format
+		workspaceName, tag, err := parseWorkspaceRef(args[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		shellDir = resolveShellFromRef(workspaceName, tag)
+	}
+
+	// Check for drift and warn
+	checkShellDrift(shellDir)
+
+	// Run pixi shell
+	runPixiShell(shellDir)
+}
+
+// resolveShellFromCwd resolves a shell directory from the current working directory.
+func resolveShellFromCwd() string {
+	absDir, err := filepath.Abs(".")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 
+	// Check for .nebi metadata
+	if nebifile.Exists(absDir) {
+		return absDir
+	}
+
+	// Check for pixi.toml (can still shell without .nebi)
+	if _, err := os.Stat(filepath.Join(absDir, "pixi.toml")); err == nil {
+		return absDir
+	}
+
+	fmt.Fprintf(os.Stderr, "Error: No workspace found in current directory\n")
+	fmt.Fprintln(os.Stderr, "Run 'nebi pull <workspace>:<tag>' to pull a workspace, or specify one: 'nebi shell <workspace>:<tag>'")
+	os.Exit(1)
+	return ""
+}
+
+// resolveShellFromRef resolves a shell directory from a workspace reference.
+// Priority: global copy > most recent local copy > pull from server.
+func resolveShellFromRef(workspaceName, tag string) string {
+	store := localindex.NewStore()
+
+	// First, check for a global copy
+	if tag != "" {
+		global, err := store.FindGlobal(workspaceName, tag)
+		if err == nil && global != nil {
+			if _, err := os.Stat(global.Path); err == nil {
+				refStr := workspaceName + ":" + tag
+				fmt.Printf("Using global copy of %s\n", refStr)
+				return global.Path
+			}
+		}
+	}
+
+	// Check local index for any matching entries
+	if tag != "" {
+		matches, err := store.FindByWorkspaceTag(workspaceName, tag)
+		if err == nil && len(matches) > 0 {
+			// Filter to entries that still exist
+			var valid []localindex.WorkspaceEntry
+			for _, m := range matches {
+				if _, err := os.Stat(m.Path); err == nil {
+					valid = append(valid, m)
+				}
+			}
+
+			if len(valid) == 1 {
+				fmt.Printf("Using local copy at %s\n", valid[0].Path)
+				return valid[0].Path
+			}
+			if len(valid) > 1 {
+				// Use most recent
+				best := valid[0]
+				for _, v := range valid[1:] {
+					if v.PulledAt.After(best.PulledAt) {
+						best = v
+					}
+				}
+				fmt.Printf("Using most recent local copy at %s (pulled %s)\n",
+					best.Path, formatTimeAgo(best.PulledAt))
+				return best.Path
+			}
+		}
+	}
+
+	// Not in local index - pull from server
+	return pullForShell(workspaceName, tag)
+}
+
+// pullForShell pulls a workspace from the server for shell activation.
+func pullForShell(workspaceName, tag string) string {
 	client := mustGetClient()
 	ctx := mustGetAuthContext()
 
@@ -53,18 +153,7 @@ func runShell(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	// Create cache directory for this workspace (include tag in path if specified)
-	cacheName := workspaceName
-	if tag != "" {
-		cacheName = workspaceName + "-" + tag
-	}
-	cacheDir, err := getWorkspaceCacheDir(cacheName)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: Failed to create cache directory: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Get versions to find the latest
+	// Get versions to find the right one
 	versions, err := client.GetEnvironmentVersions(ctx, env.ID)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: Failed to get versions: %v\n", err)
@@ -83,62 +172,98 @@ func runShell(cmd *cobra.Command, args []string) {
 			latestVersion = v
 		}
 	}
-	versionNumber := latestVersion.VersionNumber
 
-	// Check if we need to update the cached files
-	pixiTomlPath := filepath.Join(cacheDir, "pixi.toml")
-	pixiLockPath := filepath.Join(cacheDir, "pixi.lock")
-
-	needsUpdate := true
-	if _, err := os.Stat(pixiTomlPath); err == nil {
-		// Files exist, could add version checking here
-		needsUpdate = false
+	// Resolve tag for display
+	if tag == "" {
+		tag = "latest"
 	}
 
-	refStr := workspaceName
-	if tag != "" {
-		refStr = workspaceName + ":" + tag
+	refStr := workspaceName + ":" + tag
+	fmt.Printf("Pulling %s (version %d)...\n", refStr, latestVersion.VersionNumber)
+
+	// Get content
+	pixiToml, err := client.GetVersionPixiToml(ctx, env.ID, latestVersion.VersionNumber)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Failed to get pixi.toml: %v\n", err)
+		os.Exit(1)
+	}
+	pixiLock, err := client.GetVersionPixiLock(ctx, env.ID, latestVersion.VersionNumber)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Failed to get pixi.lock: %v\n", err)
+		os.Exit(1)
 	}
 
-	if needsUpdate {
-		fmt.Printf("Pulling %s (version %d)...\n", refStr, versionNumber)
-
-		// Get pixi.toml
-		pixiToml, err := client.GetVersionPixiToml(ctx, env.ID, versionNumber)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: Failed to get pixi.toml: %v\n", err)
-			os.Exit(1)
-		}
-
-		// Get pixi.lock
-		pixiLock, err := client.GetVersionPixiLock(ctx, env.ID, versionNumber)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: Failed to get pixi.lock: %v\n", err)
-			os.Exit(1)
-		}
-
-		// Write files
-		if err := os.WriteFile(pixiTomlPath, []byte(pixiToml), 0644); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: Failed to write pixi.toml: %v\n", err)
-			os.Exit(1)
-		}
-
-		if err := os.WriteFile(pixiLockPath, []byte(pixiLock), 0644); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: Failed to write pixi.lock: %v\n", err)
-			os.Exit(1)
-		}
+	// Use global storage for shell-pulled workspaces
+	store := localindex.NewStore()
+	cacheDir := store.GlobalWorkspacePath(env.ID, tag)
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Failed to create cache directory: %v\n", err)
+		os.Exit(1)
 	}
 
-	// Run pixi shell
-	fmt.Printf("Starting shell for %s...\n", refStr)
+	// Write files
+	pixiTomlBytes := []byte(pixiToml)
+	pixiLockBytes := []byte(pixiLock)
+	if err := os.WriteFile(filepath.Join(cacheDir, "pixi.toml"), pixiTomlBytes, 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Failed to write pixi.toml: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "pixi.lock"), pixiLockBytes, 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Failed to write pixi.lock: %v\n", err)
+		os.Exit(1)
+	}
 
+	// Write .nebi metadata
+	tomlDigest := nebifile.ComputeDigest(pixiTomlBytes)
+	lockDigest := nebifile.ComputeDigest(pixiLockBytes)
+	nf := nebifile.NewFromPull(
+		workspaceName, tag, "", "",
+		latestVersion.VersionNumber, "",
+		tomlDigest, int64(len(pixiTomlBytes)),
+		lockDigest, int64(len(pixiLockBytes)),
+	)
+	nebifile.Write(cacheDir, nf)
+
+	// Add to local index
+	store.AddEntry(localindex.WorkspaceEntry{
+		Workspace:       workspaceName,
+		Tag:             tag,
+		Path:            cacheDir,
+		IsGlobal:        true,
+		ServerVersionID: latestVersion.VersionNumber,
+	})
+
+	fmt.Printf("Cached at %s\n", cacheDir)
+	return cacheDir
+}
+
+// checkShellDrift checks for local modifications and warns the user.
+func checkShellDrift(dir string) {
+	ws, err := drift.Check(dir)
+	if err != nil {
+		return // No .nebi file or other issue - silently proceed
+	}
+
+	if ws.Overall == drift.StatusModified {
+		fmt.Fprintln(os.Stderr, "Warning: Local workspace has been modified since pull")
+		for _, f := range ws.Files {
+			if f.Status == drift.StatusModified {
+				fmt.Fprintf(os.Stderr, "  modified: %s\n", f.Filename)
+			}
+		}
+		fmt.Fprintln(os.Stderr, "")
+	}
+}
+
+// runPixiShell runs pixi shell in the given directory.
+func runPixiShell(dir string) {
 	pixiArgs := []string{"shell"}
 	if shellPixiEnv != "" {
 		pixiArgs = append(pixiArgs, "-e", shellPixiEnv)
 	}
 
 	pixiCmd := exec.Command("pixi", pixiArgs...)
-	pixiCmd.Dir = cacheDir
+	pixiCmd.Dir = dir
 	pixiCmd.Stdin = os.Stdin
 	pixiCmd.Stdout = os.Stdout
 	pixiCmd.Stderr = os.Stderr

--- a/cmd/nebi/shell_test.go
+++ b/cmd/nebi/shell_test.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aktech/darb/internal/localindex"
+	"github.com/aktech/darb/internal/nebifile"
+)
+
+func TestResolveShellFromCwd_WithNebiFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create .nebi file
+	pixiToml := []byte("[workspace]\nname = \"test\"\n")
+	pixiLock := []byte("version: 1\n")
+	os.WriteFile(filepath.Join(dir, "pixi.toml"), pixiToml, 0644)
+	os.WriteFile(filepath.Join(dir, "pixi.lock"), pixiLock, 0644)
+
+	tomlDigest := nebifile.ComputeDigest(pixiToml)
+	lockDigest := nebifile.ComputeDigest(pixiLock)
+	nf := nebifile.NewFromPull(
+		"test-ws", "v1.0", "", "https://example.com",
+		1, "sha256:abc",
+		tomlDigest, int64(len(pixiToml)),
+		lockDigest, int64(len(pixiLock)),
+	)
+	nebifile.Write(dir, nf)
+
+	// Change to that directory
+	oldDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldDir)
+
+	result := resolveShellFromCwd()
+	absDir, _ := filepath.Abs(".")
+	if result != absDir {
+		t.Errorf("resolveShellFromCwd() = %q, want %q", result, absDir)
+	}
+}
+
+func TestResolveShellFromCwd_WithPixiToml(t *testing.T) {
+	dir := t.TempDir()
+
+	// Only pixi.toml, no .nebi
+	os.WriteFile(filepath.Join(dir, "pixi.toml"), []byte("[workspace]\nname=\"test\"\n"), 0644)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(oldDir)
+
+	result := resolveShellFromCwd()
+	absDir, _ := filepath.Abs(".")
+	if result != absDir {
+		t.Errorf("resolveShellFromCwd() = %q, want %q", result, absDir)
+	}
+}
+
+func TestResolveShellFromRef_GlobalPreferred(t *testing.T) {
+	dir := t.TempDir()
+	store := localindex.NewStoreWithDir(dir)
+
+	// Create a global workspace directory
+	globalPath := store.GlobalWorkspacePath("uuid-123", "v1.0")
+	os.MkdirAll(globalPath, 0755)
+	os.WriteFile(filepath.Join(globalPath, "pixi.toml"), []byte("test"), 0644)
+
+	// Add global entry
+	store.AddEntry(localindex.WorkspaceEntry{
+		Workspace: "data-science",
+		Tag:       "v1.0",
+		Path:      globalPath,
+		IsGlobal:  true,
+		PulledAt:  time.Now(),
+	})
+
+	// Also add a local entry
+	localPath := filepath.Join(dir, "local-ws")
+	os.MkdirAll(localPath, 0755)
+	store.AddEntry(localindex.WorkspaceEntry{
+		Workspace: "data-science",
+		Tag:       "v1.0",
+		Path:      localPath,
+		IsGlobal:  false,
+		PulledAt:  time.Now(),
+	})
+
+	// Global should be preferred
+	global, _ := store.FindGlobal("data-science", "v1.0")
+	if global == nil {
+		t.Fatal("Global entry should exist")
+	}
+	if global.Path != globalPath {
+		t.Errorf("Global path = %q, want %q", global.Path, globalPath)
+	}
+}
+
+func TestResolveShellFromRef_LocalFallback(t *testing.T) {
+	dir := t.TempDir()
+	store := localindex.NewStoreWithDir(dir)
+
+	// Only add local entries
+	localPath1 := filepath.Join(dir, "ws1")
+	localPath2 := filepath.Join(dir, "ws2")
+	os.MkdirAll(localPath1, 0755)
+	os.MkdirAll(localPath2, 0755)
+
+	now := time.Now()
+	store.AddEntry(localindex.WorkspaceEntry{
+		Workspace: "data-science",
+		Tag:       "v1.0",
+		Path:      localPath1,
+		IsGlobal:  false,
+		PulledAt:  now.Add(-time.Hour),
+	})
+	store.AddEntry(localindex.WorkspaceEntry{
+		Workspace: "data-science",
+		Tag:       "v1.0",
+		Path:      localPath2,
+		IsGlobal:  false,
+		PulledAt:  now,
+	})
+
+	// FindByWorkspaceTag should return both
+	matches, err := store.FindByWorkspaceTag("data-science", "v1.0")
+	if err != nil {
+		t.Fatalf("FindByWorkspaceTag() error = %v", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("Expected 2 matches, got %d", len(matches))
+	}
+
+	// Most recent should be ws2
+	best := matches[0]
+	for _, m := range matches[1:] {
+		if m.PulledAt.After(best.PulledAt) {
+			best = m
+		}
+	}
+	if best.Path != localPath2 {
+		t.Errorf("Most recent path = %q, want %q", best.Path, localPath2)
+	}
+}
+
+func TestCheckShellDrift_Clean(t *testing.T) {
+	dir := t.TempDir()
+
+	pixiToml := []byte("[workspace]\nname = \"test\"\n")
+	pixiLock := []byte("version: 1\n")
+	os.WriteFile(filepath.Join(dir, "pixi.toml"), pixiToml, 0644)
+	os.WriteFile(filepath.Join(dir, "pixi.lock"), pixiLock, 0644)
+
+	tomlDigest := nebifile.ComputeDigest(pixiToml)
+	lockDigest := nebifile.ComputeDigest(pixiLock)
+	nf := nebifile.NewFromPull(
+		"test-ws", "v1.0", "", "https://example.com",
+		1, "sha256:abc",
+		tomlDigest, int64(len(pixiToml)),
+		lockDigest, int64(len(pixiLock)),
+	)
+	nebifile.Write(dir, nf)
+
+	// Should not panic
+	checkShellDrift(dir)
+}
+
+func TestCheckShellDrift_NoNebiFile(t *testing.T) {
+	dir := t.TempDir()
+	// Should not panic when no .nebi file exists
+	checkShellDrift(dir)
+}
+
+func TestCheckShellDrift_Modified(t *testing.T) {
+	dir := t.TempDir()
+
+	originalToml := []byte("[workspace]\nname = \"test\"\n")
+	modifiedToml := []byte("[workspace]\nname = \"modified\"\n")
+	pixiLock := []byte("version: 1\n")
+
+	os.WriteFile(filepath.Join(dir, "pixi.toml"), modifiedToml, 0644)
+	os.WriteFile(filepath.Join(dir, "pixi.lock"), pixiLock, 0644)
+
+	tomlDigest := nebifile.ComputeDigest(originalToml)
+	lockDigest := nebifile.ComputeDigest(pixiLock)
+	nf := nebifile.NewFromPull(
+		"test-ws", "v1.0", "", "https://example.com",
+		1, "sha256:abc",
+		tomlDigest, int64(len(originalToml)),
+		lockDigest, int64(len(pixiLock)),
+	)
+	nebifile.Write(dir, nf)
+
+	// Should not panic, just prints warning to stderr
+	checkShellDrift(dir)
+}
+
+func TestShellCmd_HasEnvFlag(t *testing.T) {
+	flag := shellCmd.Flags().Lookup("env")
+	if flag == nil {
+		t.Fatal("--env flag should be registered")
+	}
+	if flag.Shorthand != "e" {
+		t.Errorf("--env shorthand = %q, want %q", flag.Shorthand, "e")
+	}
+}
+
+func TestShellCmd_AcceptsZeroOrOneArgs(t *testing.T) {
+	// The command accepts 0 or 1 args (MaximumNArgs(1))
+	if shellCmd.Args == nil {
+		t.Fatal("Args should not be nil")
+	}
+}

--- a/cmd/nebi/workspace_test.go
+++ b/cmd/nebi/workspace_test.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aktech/darb/internal/drift"
+	"github.com/aktech/darb/internal/localindex"
+	"github.com/aktech/darb/internal/nebifile"
+)
+
+func TestGetLocalEntryStatus_PathMissing(t *testing.T) {
+	entry := localindex.WorkspaceEntry{
+		Path: "/nonexistent/path/12345",
+	}
+	status := getLocalEntryStatus(entry)
+	if status != "missing" {
+		t.Errorf("status = %q, want %q", status, "missing")
+	}
+}
+
+func TestGetLocalEntryStatus_Clean(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write pixi.toml and pixi.lock
+	pixiToml := []byte("[workspace]\nname = \"test\"\n")
+	pixiLock := []byte("version: 1\n")
+	os.WriteFile(filepath.Join(dir, "pixi.toml"), pixiToml, 0644)
+	os.WriteFile(filepath.Join(dir, "pixi.lock"), pixiLock, 0644)
+
+	// Write matching .nebi metadata
+	tomlDigest := nebifile.ComputeDigest(pixiToml)
+	lockDigest := nebifile.ComputeDigest(pixiLock)
+	nf := nebifile.NewFromPull(
+		"test", "v1.0", "", "https://example.com",
+		1, "sha256:abc",
+		tomlDigest, int64(len(pixiToml)),
+		lockDigest, int64(len(pixiLock)),
+	)
+	nebifile.Write(dir, nf)
+
+	entry := localindex.WorkspaceEntry{Path: dir}
+	status := getLocalEntryStatus(entry)
+	if status != string(drift.StatusClean) {
+		t.Errorf("status = %q, want %q", status, drift.StatusClean)
+	}
+}
+
+func TestGetLocalEntryStatus_Modified(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write pixi.toml with different content than metadata
+	originalToml := []byte("[workspace]\nname = \"test\"\n")
+	modifiedToml := []byte("[workspace]\nname = \"test\"\n[dependencies]\nnumpy = \">=1.0\"\n")
+	pixiLock := []byte("version: 1\n")
+	os.WriteFile(filepath.Join(dir, "pixi.toml"), modifiedToml, 0644)
+	os.WriteFile(filepath.Join(dir, "pixi.lock"), pixiLock, 0644)
+
+	// Write .nebi with original digest
+	tomlDigest := nebifile.ComputeDigest(originalToml)
+	lockDigest := nebifile.ComputeDigest(pixiLock)
+	nf := nebifile.NewFromPull(
+		"test", "v1.0", "", "https://example.com",
+		1, "sha256:abc",
+		tomlDigest, int64(len(originalToml)),
+		lockDigest, int64(len(pixiLock)),
+	)
+	nebifile.Write(dir, nf)
+
+	entry := localindex.WorkspaceEntry{Path: dir}
+	status := getLocalEntryStatus(entry)
+	if status != string(drift.StatusModified) {
+		t.Errorf("status = %q, want %q", status, drift.StatusModified)
+	}
+}
+
+func TestGetLocalEntryStatus_NoNebiFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Just has pixi.toml, no .nebi
+	os.WriteFile(filepath.Join(dir, "pixi.toml"), []byte("test"), 0644)
+
+	entry := localindex.WorkspaceEntry{Path: dir}
+	status := getLocalEntryStatus(entry)
+	// Should be "unknown" since drift.Check will fail without .nebi
+	if status != "unknown" {
+		t.Errorf("status = %q, want %q", status, "unknown")
+	}
+}
+
+func TestFormatLocation_Local(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	path := filepath.Join(home, "projects", "my-workspace")
+
+	result := formatLocation(path, false)
+	if result != "~/projects/my-workspace (local)" {
+		t.Errorf("formatLocation() = %q, want %q", result, "~/projects/my-workspace (local)")
+	}
+}
+
+func TestFormatLocation_Global(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	path := filepath.Join(home, ".local", "share", "nebi", "workspaces", "uuid", "v1.0")
+
+	result := formatLocation(path, true)
+	if result != "~/.local/share/nebi/... (global)" {
+		t.Errorf("formatLocation() = %q, want %q", result, "~/.local/share/nebi/... (global)")
+	}
+}
+
+func TestFormatLocation_AbsolutePath(t *testing.T) {
+	result := formatLocation("/opt/workspaces/test", false)
+	if result != "/opt/workspaces/test (local)" {
+		t.Errorf("formatLocation() = %q, want %q", result, "/opt/workspaces/test (local)")
+	}
+}
+
+func TestWorkspacePrune_Integration(t *testing.T) {
+	dir := t.TempDir()
+	store := localindex.NewStoreWithDir(dir)
+
+	// Add entries - one with valid path, one with missing path
+	validPath := filepath.Join(dir, "valid")
+	os.MkdirAll(validPath, 0755)
+
+	store.AddEntry(localindex.WorkspaceEntry{
+		Workspace: "valid-ws",
+		Tag:       "v1.0",
+		Path:      validPath,
+		PulledAt:  time.Now(),
+	})
+	store.AddEntry(localindex.WorkspaceEntry{
+		Workspace: "missing-ws",
+		Tag:       "v1.0",
+		Path:      filepath.Join(dir, "does-not-exist"),
+		PulledAt:  time.Now(),
+	})
+
+	// Prune
+	removed, err := store.Prune()
+	if err != nil {
+		t.Fatalf("Prune() error = %v", err)
+	}
+
+	if len(removed) != 1 {
+		t.Fatalf("Prune() removed %d entries, want 1", len(removed))
+	}
+	if removed[0].Workspace != "missing-ws" {
+		t.Errorf("removed workspace = %q, want %q", removed[0].Workspace, "missing-ws")
+	}
+
+	// Verify valid entry still exists
+	found, _ := store.FindByPath(validPath)
+	if found == nil {
+		t.Error("Valid entry should still exist after prune")
+	}
+}
+
+func TestWorkspaceListLocal_EmptyIndex(t *testing.T) {
+	dir := t.TempDir()
+	store := localindex.NewStoreWithDir(dir)
+
+	index, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(index.Workspaces) != 0 {
+		t.Errorf("Empty index should have 0 workspaces, got %d", len(index.Workspaces))
+	}
+}
+
+func TestWorkspaceListLocal_WithEntries(t *testing.T) {
+	dir := t.TempDir()
+	store := localindex.NewStoreWithDir(dir)
+
+	// Add some entries
+	path1 := filepath.Join(dir, "ws1")
+	path2 := filepath.Join(dir, "ws2")
+	os.MkdirAll(path1, 0755)
+	os.MkdirAll(path2, 0755)
+
+	store.AddEntry(localindex.WorkspaceEntry{
+		Workspace: "data-science",
+		Tag:       "v1.0",
+		Path:      path1,
+		IsGlobal:  false,
+		PulledAt:  time.Now(),
+	})
+	store.AddEntry(localindex.WorkspaceEntry{
+		Workspace: "data-science",
+		Tag:       "v2.0",
+		Path:      path2,
+		IsGlobal:  true,
+		PulledAt:  time.Now(),
+	})
+
+	index, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(index.Workspaces) != 2 {
+		t.Errorf("Expected 2 workspaces, got %d", len(index.Workspaces))
+	}
+}
+
+func TestWorkspacePruneCmd_HasNoArgs(t *testing.T) {
+	if workspacePruneCmd.Args == nil {
+		t.Fatal("Args should not be nil")
+	}
+}
+
+func TestWorkspaceListCmd_HasLocalFlag(t *testing.T) {
+	flag := workspaceListCmd.Flags().Lookup("local")
+	if flag == nil {
+		t.Fatal("--local flag should be registered")
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("--local default = %q, want %q", flag.DefValue, "false")
+	}
+}


### PR DESCRIPTION
## Summary
- **Shell activation (#38)**: Rewrites `nebi shell` to use local index (global > local > pull from server), supports running without arguments in directories with `.nebi` metadata, adds drift detection warnings
- **Workspace list --local (#36)**: Adds `--local` flag showing locally pulled workspaces with drift status indicators (clean/modified/missing), path abbreviation, and global/local markers
- **Workspace prune (#37)**: New `nebi workspace prune` command that removes stale entries from the local index where paths no longer exist on disk (does NOT delete files)
- **Push drift awareness (#39)**: Shows informational note when pushing modified workspaces, warns specifically about overwriting same-tag content, suggests new tag names

## Issues
- Closes #36
- Closes #37
- Closes #38
- Closes #39

## Test plan
- [x] All existing tests pass (cmd/nebi, internal/diff, internal/drift, internal/nebifile, internal/localindex)
- [x] Shell tests: resolveShellFromCwd (with/without .nebi), resolveShellFromRef (global preferred, local fallback), checkShellDrift (clean/modified/no-nebi), flag registration
- [x] Workspace tests: getLocalEntryStatus (missing/clean/modified/unknown), formatLocation (local/global/absolute), prune integration, list --local with entries, flag registration
- [x] Push drift tests: showPushDriftWarning (no-nebi/clean/modified-different-tag/modified-same-tag)