### PR TITLE
4. feat: remote proxy handler for desktop app

### DIFF
--- a/internal/api/handlers/remote.go
+++ b/internal/api/handlers/remote.go
@@ -1,0 +1,299 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/nebari-dev/nebi/internal/cliclient"
+	"github.com/nebari-dev/nebi/internal/store"
+	"gorm.io/gorm"
+)
+
+// RemoteHandler proxies requests to a remote Nebi server.
+// Used in local/desktop mode so the frontend can browse remote servers.
+type RemoteHandler struct {
+	db *gorm.DB
+}
+
+// NewRemoteHandler creates a new remote handler.
+func NewRemoteHandler(db *gorm.DB) *RemoteHandler {
+	return &RemoteHandler{db: db}
+}
+
+// getClient builds a cliclient.Client from the stored server URL and credentials.
+func (h *RemoteHandler) getClient() (*cliclient.Client, error) {
+	var cfg store.Config
+	if err := h.db.First(&cfg).Error; err != nil {
+		return nil, fmt.Errorf("no server configured")
+	}
+	if cfg.ServerURL == "" {
+		return nil, fmt.Errorf("no server URL configured")
+	}
+	var creds store.Credentials
+	if err := h.db.First(&creds).Error; err != nil || creds.Token == "" {
+		return nil, fmt.Errorf("not authenticated with remote server")
+	}
+	return cliclient.New(cfg.ServerURL, creds.Token), nil
+}
+
+// notConnected returns 503 when no remote server is configured.
+func (h *RemoteHandler) notConnected(c *gin.Context, err error) {
+	c.JSON(http.StatusServiceUnavailable, ErrorResponse{Error: err.Error()})
+}
+
+// ConnectServer authenticates with a remote server and stores credentials.
+func (h *RemoteHandler) ConnectServer(c *gin.Context) {
+	var req struct {
+		URL      string `json:"url" binding:"required"`
+		Username string `json:"username" binding:"required"`
+		Password string `json:"password" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+		return
+	}
+
+	// Login to remote server
+	client := cliclient.NewWithoutAuth(req.URL)
+	loginResp, err := client.Login(c.Request.Context(), req.Username, req.Password)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: fmt.Sprintf("Failed to connect: %v", err)})
+		return
+	}
+
+	// Store URL and credentials
+	if err := h.db.Model(&store.Config{}).Where("id = ?", 1).Update("server_url", req.URL).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to store server URL"})
+		return
+	}
+	if err := h.db.Model(&store.Credentials{}).Where("id = ?", 1).Updates(map[string]any{
+		"token":    loginResp.Token,
+		"username": loginResp.User.Username,
+	}).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to store credentials"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"connected":  true,
+		"server_url": req.URL,
+		"username":   loginResp.User.Username,
+	})
+}
+
+// GetServer returns the current connection status.
+func (h *RemoteHandler) GetServer(c *gin.Context) {
+	var cfg store.Config
+	h.db.First(&cfg)
+	var creds store.Credentials
+	h.db.First(&creds)
+
+	c.JSON(http.StatusOK, gin.H{
+		"connected":  cfg.ServerURL != "" && creds.Token != "",
+		"server_url": cfg.ServerURL,
+		"username":   creds.Username,
+	})
+}
+
+// DisconnectServer clears stored credentials.
+func (h *RemoteHandler) DisconnectServer(c *gin.Context) {
+	if err := h.db.Model(&store.Config{}).Where("id = ?", 1).Update("server_url", "").Error; err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to clear server config"})
+		return
+	}
+	if err := h.db.Model(&store.Credentials{}).Where("id = ?", 1).Updates(map[string]any{
+		"token":    "",
+		"username": "",
+	}).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to clear credentials"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"connected": false})
+}
+
+// ListWorkspaces proxies workspace listing to the remote server.
+func (h *RemoteHandler) ListWorkspaces(c *gin.Context) {
+	client, err := h.getClient()
+	if err != nil {
+		h.notConnected(c, err)
+		return
+	}
+	workspaces, err := client.ListWorkspaces(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusBadGateway, ErrorResponse{Error: fmt.Sprintf("Remote error: %v", err)})
+		return
+	}
+	c.JSON(http.StatusOK, workspaces)
+}
+
+// GetWorkspace proxies a single workspace fetch to the remote server.
+func (h *RemoteHandler) GetWorkspace(c *gin.Context) {
+	client, err := h.getClient()
+	if err != nil {
+		h.notConnected(c, err)
+		return
+	}
+	id := c.Param("id")
+	ws, err := client.GetWorkspace(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, ErrorResponse{Error: fmt.Sprintf("Remote error: %v", err)})
+		return
+	}
+	c.JSON(http.StatusOK, ws)
+}
+
+// CreateWorkspace proxies workspace creation to the remote server.
+func (h *RemoteHandler) CreateWorkspace(c *gin.Context) {
+	client, err := h.getClient()
+	if err != nil {
+		h.notConnected(c, err)
+		return
+	}
+	var req cliclient.CreateWorkspaceRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+		return
+	}
+	ws, err := client.CreateWorkspace(c.Request.Context(), req)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, ErrorResponse{Error: fmt.Sprintf("Remote error: %v", err)})
+		return
+	}
+	c.JSON(http.StatusCreated, ws)
+}
+
+// DeleteWorkspace proxies workspace deletion to the remote server.
+func (h *RemoteHandler) DeleteWorkspace(c *gin.Context) {
+	client, err := h.getClient()
+	if err != nil {
+		h.notConnected(c, err)
+		return
+	}
+	id := c.Param("id")
+	if err := client.DeleteWorkspace(c.Request.Context(), id); err != nil {
+		c.JSON(http.StatusBadGateway, ErrorResponse{Error: fmt.Sprintf("Remote error: %v", err)})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// ListVersions proxies version listing for a remote workspace.
+func (h *RemoteHandler) ListVersions(c *gin.Context) {
+	client, err := h.getClient()
+	if err != nil {
+		h.notConnected(c, err)
+		return
+	}
+	id := c.Param("id")
+	versions, err := client.GetWorkspaceVersions(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, ErrorResponse{Error: fmt.Sprintf("Remote error: %v", err)})
+		return
+	}
+	c.JSON(http.StatusOK, versions)
+}
+
+// ListTags proxies tag listing for a remote workspace.
+func (h *RemoteHandler) ListTags(c *gin.Context) {
+	client, err := h.getClient()
+	if err != nil {
+		h.notConnected(c, err)
+		return
+	}
+	id := c.Param("id")
+	tags, err := client.GetWorkspaceTags(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, ErrorResponse{Error: fmt.Sprintf("Remote error: %v", err)})
+		return
+	}
+	c.JSON(http.StatusOK, tags)
+}
+
+// GetPixiToml proxies pixi.toml fetch for a remote workspace.
+// Returns JSON {"content": "..."} for uniform frontend consumption.
+func (h *RemoteHandler) GetPixiToml(c *gin.Context) {
+	client, err := h.getClient()
+	if err != nil {
+		h.notConnected(c, err)
+		return
+	}
+	id := c.Param("id")
+	var result struct {
+		Content string `json:"content"`
+	}
+	if _, err := client.Get(c.Request.Context(), "/workspaces/"+id+"/pixi-toml", &result); err != nil {
+		c.JSON(http.StatusBadGateway, ErrorResponse{Error: fmt.Sprintf("Remote error: %v", err)})
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+// GetVersionPixiToml proxies version-specific pixi.toml fetch.
+// Returns JSON {"content": "..."} — the upstream returns plain text but we
+// wrap it in JSON for uniform frontend consumption.
+func (h *RemoteHandler) GetVersionPixiToml(c *gin.Context) {
+	client, err := h.getClient()
+	if err != nil {
+		h.notConnected(c, err)
+		return
+	}
+	id := c.Param("id")
+	version := c.Param("version")
+	versionNum, err := strconv.ParseInt(version, 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Invalid version number"})
+		return
+	}
+	content, err := client.GetVersionPixiToml(c.Request.Context(), id, int32(versionNum))
+	if err != nil {
+		c.JSON(http.StatusBadGateway, ErrorResponse{Error: fmt.Sprintf("Remote error: %v", err)})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"content": content})
+}
+
+// GetVersionPixiLock proxies version-specific pixi.lock fetch.
+// Returns JSON {"content": "..."} — see GetVersionPixiToml for rationale.
+func (h *RemoteHandler) GetVersionPixiLock(c *gin.Context) {
+	client, err := h.getClient()
+	if err != nil {
+		h.notConnected(c, err)
+		return
+	}
+	id := c.Param("id")
+	version := c.Param("version")
+	versionNum, err := strconv.ParseInt(version, 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Invalid version number"})
+		return
+	}
+	content, err := client.GetVersionPixiLock(c.Request.Context(), id, int32(versionNum))
+	if err != nil {
+		c.JSON(http.StatusBadGateway, ErrorResponse{Error: fmt.Sprintf("Remote error: %v", err)})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"content": content})
+}
+
+// PushVersion proxies version push to the remote server.
+func (h *RemoteHandler) PushVersion(c *gin.Context) {
+	client, err := h.getClient()
+	if err != nil {
+		h.notConnected(c, err)
+		return
+	}
+	id := c.Param("id")
+	var req cliclient.PushRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+		return
+	}
+	resp, err := client.PushVersion(c.Request.Context(), id, req)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, ErrorResponse{Error: fmt.Sprintf("Remote error: %v", err)})
+		return
+	}
+	c.JSON(http.StatusCreated, resp)
+}

--- a/internal/api/handlers/remote_test.go
+++ b/internal/api/handlers/remote_test.go
@@ -1,0 +1,241 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/nebari-dev/nebi/internal/store"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// setupTestDB creates an in-memory SQLite DB with the store tables seeded.
+func setupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	if err := db.AutoMigrate(&store.Config{}, &store.Credentials{}); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+	db.Exec("INSERT OR IGNORE INTO store_config (id) VALUES (1)")
+	db.Exec("INSERT OR IGNORE INTO store_credentials (id) VALUES (1)")
+	return db
+}
+
+// setupRouter creates a Gin engine with the remote handler routes registered.
+func setupRouter(db *gorm.DB) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h := NewRemoteHandler(db)
+	remote := r.Group("/api/v1/remote")
+	{
+		remote.POST("/connect", h.ConnectServer)
+		remote.GET("/server", h.GetServer)
+		remote.DELETE("/server", h.DisconnectServer)
+		remote.GET("/workspaces", h.ListWorkspaces)
+		remote.GET("/workspaces/:id", h.GetWorkspace)
+		remote.POST("/workspaces", h.CreateWorkspace)
+		remote.DELETE("/workspaces/:id", h.DeleteWorkspace)
+		remote.GET("/workspaces/:id/versions", h.ListVersions)
+		remote.GET("/workspaces/:id/tags", h.ListTags)
+		remote.GET("/workspaces/:id/pixi-toml", h.GetPixiToml)
+		remote.GET("/workspaces/:id/versions/:version/pixi-toml", h.GetVersionPixiToml)
+		remote.GET("/workspaces/:id/versions/:version/pixi-lock", h.GetVersionPixiLock)
+		remote.POST("/workspaces/:id/push", h.PushVersion)
+	}
+	return r
+}
+
+func TestGetServer_NoConfig(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupRouter(db)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/v1/remote/server", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp["connected"] != false {
+		t.Errorf("expected connected=false, got %v", resp["connected"])
+	}
+}
+
+func TestConnectServer_MissingFields(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupRouter(db)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/v1/remote/connect", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDisconnectServer(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupRouter(db)
+
+	// First set some data in the store
+	db.Model(&store.Config{}).Where("id = ?", 1).Update("server_url", "http://example.com")
+	db.Model(&store.Credentials{}).Where("id = ?", 1).Updates(map[string]any{
+		"token":    "some-token",
+		"username": "someuser",
+	})
+
+	// Disconnect
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/api/v1/remote/server", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp["connected"] != false {
+		t.Errorf("expected connected=false, got %v", resp["connected"])
+	}
+
+	// Verify DB was cleared
+	var cfg store.Config
+	db.First(&cfg)
+	if cfg.ServerURL != "" {
+		t.Errorf("expected empty server_url, got %q", cfg.ServerURL)
+	}
+	var creds store.Credentials
+	db.First(&creds)
+	if creds.Token != "" {
+		t.Errorf("expected empty token, got %q", creds.Token)
+	}
+}
+
+func TestGetServer_AfterStoreSetup(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupRouter(db)
+
+	// Set config and credentials in DB
+	db.Model(&store.Config{}).Where("id = ?", 1).Update("server_url", "https://nebi.example.com")
+	db.Model(&store.Credentials{}).Where("id = ?", 1).Updates(map[string]any{
+		"token":    "valid-token",
+		"username": "testuser",
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/v1/remote/server", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp["connected"] != true {
+		t.Errorf("expected connected=true, got %v", resp["connected"])
+	}
+	if resp["server_url"] != "https://nebi.example.com" {
+		t.Errorf("expected server_url=https://nebi.example.com, got %v", resp["server_url"])
+	}
+	if resp["username"] != "testuser" {
+		t.Errorf("expected username=testuser, got %v", resp["username"])
+	}
+}
+
+func TestListWorkspaces_NotConnected(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupRouter(db)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/v1/remote/workspaces", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestConnectServer_WithMockRemote(t *testing.T) {
+	// Create a mock remote Nebi server
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/api/v1/auth/login" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]any{
+				"token": "test-token-abc",
+				"user": map[string]any{
+					"username": "remoteuser",
+					"id":       "user-123",
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer mockServer.Close()
+
+	db := setupTestDB(t)
+	router := setupRouter(db)
+
+	body := `{"url":"` + mockServer.URL + `","username":"remoteuser","password":"secret"}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/v1/remote/connect", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp["connected"] != true {
+		t.Errorf("expected connected=true, got %v", resp["connected"])
+	}
+	if resp["server_url"] != mockServer.URL {
+		t.Errorf("expected server_url=%s, got %v", mockServer.URL, resp["server_url"])
+	}
+	if resp["username"] != "remoteuser" {
+		t.Errorf("expected username=remoteuser, got %v", resp["username"])
+	}
+
+	// Verify credentials were stored in DB
+	var cfg store.Config
+	db.First(&cfg)
+	if cfg.ServerURL != mockServer.URL {
+		t.Errorf("expected stored server_url=%s, got %q", mockServer.URL, cfg.ServerURL)
+	}
+	var creds store.Credentials
+	db.First(&creds)
+	if creds.Token != "test-token-abc" {
+		t.Errorf("expected stored token=test-token-abc, got %q", creds.Token)
+	}
+	if creds.Username != "remoteuser" {
+		t.Errorf("expected stored username=remoteuser, got %q", creds.Username)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -199,6 +199,27 @@ func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Exe
 			admin.PUT("/registries/:id", registryHandler.UpdateRegistry)
 			admin.DELETE("/registries/:id", registryHandler.DeleteRegistry)
 		}
+
+		// Remote proxy endpoints (local mode only)
+		if localMode {
+			remoteHandler := handlers.NewRemoteHandler(db)
+			remote := protected.Group("/remote")
+			{
+				remote.POST("/connect", remoteHandler.ConnectServer)
+				remote.GET("/server", remoteHandler.GetServer)
+				remote.DELETE("/server", remoteHandler.DisconnectServer)
+				remote.GET("/workspaces", remoteHandler.ListWorkspaces)
+				remote.GET("/workspaces/:id", remoteHandler.GetWorkspace)
+				remote.POST("/workspaces", remoteHandler.CreateWorkspace)
+				remote.DELETE("/workspaces/:id", remoteHandler.DeleteWorkspace)
+				remote.GET("/workspaces/:id/versions", remoteHandler.ListVersions)
+				remote.GET("/workspaces/:id/tags", remoteHandler.ListTags)
+				remote.GET("/workspaces/:id/pixi-toml", remoteHandler.GetPixiToml)
+				remote.GET("/workspaces/:id/versions/:version/pixi-toml", remoteHandler.GetVersionPixiToml)
+				remote.GET("/workspaces/:id/versions/:version/pixi-lock", remoteHandler.GetVersionPixiLock)
+				remote.POST("/workspaces/:id/push", remoteHandler.PushVersion)
+			}
+		}
 	}
 
 	// Swagger documentation


### PR DESCRIPTION
## Summary
- Add `RemoteHandler` that proxies frontend requests to a remote Nebi team server in local/desktop mode
- Uses existing `cliclient` package (typed methods) for all upstream communication
- Stores server URL and credentials in the local SQLite DB via `store.Config`/`store.Credentials`
- Routes registered only when `localMode == true` under `/api/v1/remote/*`

## Endpoints (13 total)
- `POST /connect` — authenticate with remote server, store token
- `GET /server` — connection status
- `DELETE /server` — disconnect, clear credentials
- `GET/POST/DELETE /workspaces[/:id]` — proxy CRUD
- `GET /workspaces/:id/versions` — proxy version listing
- `GET /workspaces/:id/tags` — proxy tag listing
- `GET /workspaces/:id/pixi-toml` — proxy pixi.toml (JSON wrapped)
- `GET /workspaces/:id/versions/:version/pixi-toml` — proxy (JSON wrapped)
- `GET /workspaces/:id/versions/:version/pixi-lock` — proxy (JSON wrapped)
- `POST /workspaces/:id/push` — proxy version push

## Design decisions
- **503 (not 400)** for "not connected" errors — distinguishes client errors from config state issues
- **JSON wrapping** for pixi.toml/lock endpoints — upstream returns plain text, proxy wraps in `{"content": "..."}` for uniform frontend consumption
- **GORM error checks** on all DB writes in connect/disconnect
- **Typed cliclient methods** used where available (ListWorkspaces, GetWorkspace, etc.)

## Test plan
- [x] `go vet ./...`
- [x] 6 unit tests: server status, connect/disconnect, mock remote, not-connected proxy
- [x] `go test ./internal/api/handlers/... ./internal/service/... ./internal/store/...`
- [x] Frontend builds cleanly