### PR TITLE
5. feat: frontend mode awareness and settings page

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { queryClient } from '@/lib/queryClient';
+import { useModeStore } from '@/store/modeStore';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || '/api/v1';
 
@@ -27,10 +28,14 @@ apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {
-      localStorage.removeItem('auth_token');
-      // Clear all query cache to prevent stale data
-      queryClient.clear();
-      window.location.href = '/login';
+      // In local mode, don't redirect to login
+      const { mode } = useModeStore.getState();
+      if (mode !== 'local') {
+        localStorage.removeItem('auth_token');
+        // Clear all query cache to prevent stale data
+        queryClient.clear();
+        window.location.href = '/login';
+      }
     }
     return Promise.reject(error);
   }

--- a/frontend/src/api/remote.ts
+++ b/frontend/src/api/remote.ts
@@ -1,0 +1,22 @@
+import { apiClient } from '@/api/client';
+
+export interface RemoteServerStatus {
+  connected: boolean;
+  server_url: string;
+  username: string;
+}
+
+export interface ConnectServerRequest {
+  url: string;
+  username: string;
+  password: string;
+}
+
+export const remoteApi = {
+  getServer: () =>
+    apiClient.get<RemoteServerStatus>('/remote/server').then((r) => r.data),
+  connectServer: (req: ConnectServerRequest) =>
+    apiClient.post<RemoteServerStatus>('/remote/connect', req).then((r) => r.data),
+  disconnectServer: () =>
+    apiClient.delete('/remote/server').then((r) => r.data),
+};

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,12 +1,14 @@
 import { Outlet, NavLink, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/store/authStore';
+import { useModeStore } from '@/store/modeStore';
 import { useIsAdmin } from '@/hooks/useAdmin';
 import { Button } from '@/components/ui/button';
-import { LogOut, Boxes, ListTodo, Shield } from 'lucide-react';
+import { LogOut, Boxes, ListTodo, Shield, Settings } from 'lucide-react';
 import { useState } from 'react';
 
 export const Layout = () => {
   const { user, clearAuth } = useAuthStore();
+  const isLocalMode = useModeStore((s) => s.isLocalMode());
   const navigate = useNavigate();
   const { data: isAdmin } = useIsAdmin();
   const [avatarError, setAvatarError] = useState(false);
@@ -63,32 +65,47 @@ export const Layout = () => {
                     )}
                   </NavLink>
                 )}
+                {isLocalMode && (
+                  <NavLink to="/settings">
+                    {({ isActive }) => (
+                      <Button
+                        variant={isActive ? 'secondary' : 'ghost'}
+                        className="gap-2"
+                      >
+                        <Settings className="h-4 w-4" />
+                        Settings
+                      </Button>
+                    )}
+                  </NavLink>
+                )}
               </nav>
             </div>
-            <div className="flex items-center gap-4">
-              {user?.avatar_url && !avatarError ? (
-                <img
-                  src={user.avatar_url}
-                  alt={user.username}
-                  className="h-8 w-8 rounded-full"
-                  referrerPolicy="no-referrer-when-downgrade"
-                  crossOrigin="anonymous"
-                  onError={() => setAvatarError(true)}
-                />
-              ) : (
-                <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center">
-                  <span className="text-sm font-medium text-primary">
-                    {user?.username?.charAt(0).toUpperCase()}
-                  </span>
-                </div>
-              )}
-              <span className="text-sm font-medium text-foreground">
-                {user?.username}
-              </span>
-              <Button variant="ghost" size="icon" onClick={handleLogout}>
-                <LogOut className="h-4 w-4" />
-              </Button>
-            </div>
+            {!isLocalMode && (
+              <div className="flex items-center gap-4">
+                {user?.avatar_url && !avatarError ? (
+                  <img
+                    src={user.avatar_url}
+                    alt={user.username}
+                    className="h-8 w-8 rounded-full"
+                    referrerPolicy="no-referrer-when-downgrade"
+                    crossOrigin="anonymous"
+                    onError={() => setAvatarError(true)}
+                  />
+                ) : (
+                  <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center">
+                    <span className="text-sm font-medium text-primary">
+                      {user?.username?.charAt(0).toUpperCase()}
+                    </span>
+                  </div>
+                )}
+                <span className="text-sm font-medium text-foreground">
+                  {user?.username}
+                </span>
+                <Button variant="ghost" size="icon" onClick={handleLogout}>
+                  <LogOut className="h-4 w-4" />
+                </Button>
+              </div>
+            )}
           </div>
         </div>
       </header>

--- a/frontend/src/hooks/useRemote.ts
+++ b/frontend/src/hooks/useRemote.ts
@@ -1,0 +1,34 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { remoteApi } from '@/api/remote';
+import type { ConnectServerRequest } from '@/api/remote';
+import { useModeStore } from '@/store/modeStore';
+
+export const useServerStatus = () => {
+  const isLocal = useModeStore((s) => s.mode === 'local');
+  return useQuery({
+    queryKey: ['remote', 'server'],
+    queryFn: remoteApi.getServer,
+    enabled: isLocal,
+    refetchInterval: 30000, // poll every 30s
+  });
+};
+
+export const useConnectServer = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (req: ConnectServerRequest) => remoteApi.connectServer(req),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['remote'] });
+    },
+  });
+};
+
+export const useDisconnectServer = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => remoteApi.disconnectServer(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['remote'] });
+    },
+  });
+};

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuthStore } from '@/store/authStore';
+import { useModeStore } from '@/store/modeStore';
 import { authApi } from '@/api/auth';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -14,7 +15,18 @@ export const Login = () => {
   const [searchParams] = useSearchParams();
 
   const setAuth = useAuthStore((state) => state.setAuth);
+  const isLocalMode = useModeStore((s) => s.isLocalMode());
   const navigate = useNavigate();
+
+  // In local mode, redirect straight to workspaces
+  useEffect(() => {
+    if (isLocalMode) {
+      navigate('/workspaces');
+    }
+  }, [isLocalMode, navigate]);
+
+  // Don't render login form in local mode
+  if (isLocalMode) return null;
 
   // Handle OAuth callback
   useEffect(() => {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,0 +1,170 @@
+import { useState } from 'react';
+import { useServerStatus, useConnectServer, useDisconnectServer } from '@/hooks/useRemote';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Settings as SettingsIcon, Loader2, Wifi, WifiOff } from 'lucide-react';
+
+export const Settings = () => {
+  const { data: serverStatus, isLoading } = useServerStatus();
+  const connectMutation = useConnectServer();
+  const disconnectMutation = useDisconnectServer();
+
+  const [url, setUrl] = useState('');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleConnect = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    try {
+      await connectMutation.mutateAsync({ url, username, password });
+      setUrl('');
+      setUsername('');
+      setPassword('');
+    } catch (err: unknown) {
+      const apiError = err as { response?: { data?: { error?: string } } };
+      setError(apiError.response?.data?.error || 'Failed to connect to server');
+    }
+  };
+
+  const handleDisconnect = async () => {
+    setError('');
+    try {
+      await disconnectMutation.mutateAsync();
+    } catch (err: unknown) {
+      const apiError = err as { response?: { data?: { error?: string } } };
+      setError(apiError.response?.data?.error || 'Failed to disconnect from server');
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-96">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  const isConnected = serverStatus?.connected ?? false;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold flex items-center gap-3">
+          <SettingsIcon className="h-8 w-8" />
+          Settings
+        </h1>
+        <p className="text-muted-foreground">Configure your local Nebi instance</p>
+      </div>
+
+      {error && (
+        <div className="bg-red-500/10 border border-red-500/20 text-red-500 px-4 py-3 rounded">
+          {error}
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>Remote Server Connection</CardTitle>
+            <Badge
+              className={
+                isConnected
+                  ? 'bg-green-500/10 text-green-500 border-green-500/20'
+                  : 'bg-gray-500/10 text-gray-500 border-gray-500/20'
+              }
+            >
+              {isConnected ? (
+                <Wifi className="h-3 w-3 mr-1" />
+              ) : (
+                <WifiOff className="h-3 w-3 mr-1" />
+              )}
+              {isConnected ? 'Connected' : 'Disconnected'}
+            </Badge>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {isConnected ? (
+            <div className="space-y-4">
+              <div className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-muted-foreground w-24">Server URL</span>
+                  <span className="text-sm font-mono">{serverStatus?.server_url}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-muted-foreground w-24">Username</span>
+                  <span className="text-sm">{serverStatus?.username}</span>
+                </div>
+              </div>
+              <div className="pt-2">
+                <Button
+                  variant="destructive"
+                  onClick={handleDisconnect}
+                  disabled={disconnectMutation.isPending}
+                >
+                  {disconnectMutation.isPending ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Disconnecting...
+                    </>
+                  ) : (
+                    'Disconnect'
+                  )}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <form onSubmit={handleConnect} className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                Connect to a remote Nebi server to sync workspaces and access shared resources.
+              </p>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Server URL</label>
+                <Input
+                  type="url"
+                  placeholder="https://nebi.example.com"
+                  value={url}
+                  onChange={(e) => setUrl(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Username</label>
+                <Input
+                  type="text"
+                  placeholder="Username"
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Password</label>
+                <Input
+                  type="password"
+                  placeholder="Password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                />
+              </div>
+              <Button type="submit" disabled={connectMutation.isPending}>
+                {connectMutation.isPending ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Connecting...
+                  </>
+                ) : (
+                  'Connect'
+                )}
+              </Button>
+            </form>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/frontend/src/store/modeStore.ts
+++ b/frontend/src/store/modeStore.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+import { apiClient } from '@/api/client';
+
+interface ModeState {
+  mode: 'local' | 'team' | null;
+  features: Record<string, boolean>;
+  loading: boolean;
+  fetchMode: () => Promise<void>;
+  isLocalMode: () => boolean;
+}
+
+export const useModeStore = create<ModeState>()((set, get) => ({
+  mode: null,
+  features: {},
+  loading: true,
+  fetchMode: async () => {
+    try {
+      const { data } = await apiClient.get('/version');
+      set({ mode: data.mode, features: data.features || {}, loading: false });
+    } catch {
+      // Default to team mode on error
+      set({ mode: 'team', features: {}, loading: false });
+    }
+  },
+  isLocalMode: () => get().mode === 'local',
+}));


### PR DESCRIPTION
## Summary
- Frontend detects local vs team mode by fetching `/api/v1/version` on startup
- In local mode: login is bypassed, logout/avatar hidden, Settings nav added
- Settings page lets users connect/disconnect from a remote Nebi team server
- 401 interceptor skips login redirect in local mode

## New files
- `store/modeStore.ts` — Zustand store for mode/features
- `api/remote.ts` — Axios functions for remote proxy endpoints
- `hooks/useRemote.ts` — React Query hooks for server status/connect/disconnect
- `pages/Settings.tsx` — Remote server connection management UI

## Modified files
- `App.tsx` — ModeLoader wrapper, PrivateRoute bypasses auth in local mode, /settings route
- `Layout.tsx` — Hide logout in local mode, show Settings nav
- `Login.tsx` — Auto-redirect to /workspaces in local mode
- `client.ts` — Skip 401 redirect in local mode

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — production build succeeds
- [ ] Manual: start in local mode, verify login bypassed, Settings page works
- [ ] Manual: start in team mode, verify login required, Settings nav hidden