### PR TITLE
Add shared PixiTomlEditor with UI/TOML mode toggle for workspace editing

### DIFF
--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -24,11 +24,13 @@ export const Layout = () => {
         <div className="container mx-auto px-4 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-8">
-              <img
-                src="/nebi-logo.png"
-                alt="Nebi"
-                className="h-10 w-auto"
-              />
+              <NavLink to="/workspaces">
+                <img
+                  src="/nebi-logo.png"
+                  alt="Nebi"
+                  className="h-10 w-auto"
+                />
+              </NavLink>
               <nav className="flex gap-1">
                 <NavLink to="/workspaces">
                   {({ isActive }) => (

--- a/frontend/src/components/workspace/PixiTomlEditor.tsx
+++ b/frontend/src/components/workspace/PixiTomlEditor.tsx
@@ -1,0 +1,232 @@
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Plus, Trash2, FileCode } from 'lucide-react';
+
+interface Package {
+  name: string;
+  version: string;
+}
+
+interface PixiTomlEditorProps {
+  tomlValue: string;
+  onTomlChange: (toml: string) => void;
+  workspaceName: string;
+}
+
+const buildPixiToml = (packages: Package[], wsName: string): string => {
+  const dependenciesLines = packages
+    .filter(pkg => pkg.name.trim())
+    .map(pkg => {
+      if (pkg.version.trim()) {
+        return `${pkg.name} = "${pkg.version}"`;
+      }
+      return `${pkg.name} = "*"`;
+    })
+    .join('\n');
+
+  return `[workspace]
+name = "${wsName}"
+channels = ["conda-forge"]
+platforms = ["osx-arm64", "linux-64", "win-64"]
+
+[dependencies]
+${dependenciesLines || 'python = ">=3.11"'}
+`;
+};
+
+const parsePixiTomlDependencies = (toml: string): Package[] => {
+  const lines = toml.split('\n');
+  const packages: Package[] = [];
+  let inDependencies = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (trimmed === '[dependencies]') {
+      inDependencies = true;
+      continue;
+    }
+
+    if (inDependencies && trimmed.startsWith('[')) {
+      break;
+    }
+
+    if (inDependencies && trimmed && !trimmed.startsWith('#')) {
+      const match = trimmed.match(/^([^\s=]+)\s*=\s*"([^"]*)"$/);
+      if (match) {
+        packages.push({ name: match[1], version: match[2] === '*' ? '' : match[2] });
+      }
+    }
+  }
+
+  return packages;
+};
+
+export const PixiTomlEditor = ({ tomlValue, onTomlChange, workspaceName }: PixiTomlEditorProps) => {
+  const [mode, setMode] = useState<'ui' | 'toml'>('ui');
+  const [packages, setPackages] = useState<Package[]>([{ name: 'python', version: '>=3.11' }]);
+  const [newPackageName, setNewPackageName] = useState('');
+  const [newPackageVersion, setNewPackageVersion] = useState('');
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    if (!initialized && tomlValue) {
+      const parsed = parsePixiTomlDependencies(tomlValue);
+      if (parsed.length > 0) {
+        setPackages(parsed);
+      }
+      setInitialized(true);
+    }
+  }, [tomlValue, initialized]);
+
+  const handleModeSwitch = (newMode: 'ui' | 'toml') => {
+    if (newMode === 'toml' && mode === 'ui') {
+      onTomlChange(buildPixiToml(packages, workspaceName));
+    } else if (newMode === 'ui' && mode === 'toml') {
+      const parsed = parsePixiTomlDependencies(tomlValue);
+      if (parsed.length > 0) {
+        setPackages(parsed);
+      }
+    }
+    setMode(newMode);
+  };
+
+  const handleAddPackage = () => {
+    if (!newPackageName.trim()) return;
+    const updated = [...packages, { name: newPackageName, version: newPackageVersion }];
+    setPackages(updated);
+    setNewPackageName('');
+    setNewPackageVersion('');
+    onTomlChange(buildPixiToml(updated, workspaceName));
+  };
+
+  const handleRemovePackage = (index: number) => {
+    const updated = packages.filter((_, i) => i !== index);
+    setPackages(updated);
+    onTomlChange(buildPixiToml(updated, workspaceName));
+  };
+
+  return (
+    <>
+      <div className="flex gap-2 p-1 bg-muted rounded-lg w-fit">
+        <Button
+          type="button"
+          variant={mode === 'ui' ? 'default' : 'ghost'}
+          size="sm"
+          onClick={() => handleModeSwitch('ui')}
+          className="gap-2"
+        >
+          <Plus className="h-4 w-4" />
+          UI Mode
+        </Button>
+        <Button
+          type="button"
+          variant={mode === 'toml' ? 'default' : 'ghost'}
+          size="sm"
+          onClick={() => handleModeSwitch('toml')}
+          className="gap-2"
+        >
+          <FileCode className="h-4 w-4" />
+          TOML Mode
+        </Button>
+      </div>
+
+      {mode === 'ui' ? (
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Packages</label>
+            <div className="border rounded-lg overflow-hidden">
+              <table className="w-full">
+                <thead className="bg-muted/50 border-b">
+                  <tr>
+                    <th className="text-left p-3 text-sm font-medium">Name</th>
+                    <th className="text-left p-3 text-sm font-medium">Version Constraint</th>
+                    <th className="w-16"></th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  {packages.map((pkg, index) => (
+                    <tr key={index} className="hover:bg-muted/30">
+                      <td className="p-3">
+                        <span className="font-mono text-sm">{pkg.name}</span>
+                      </td>
+                      <td className="p-3">
+                        <span className="font-mono text-sm text-muted-foreground">
+                          {pkg.version || '-'}
+                        </span>
+                      </td>
+                      <td className="p-3">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleRemovePackage(index)}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div className="flex gap-2">
+            <Input
+              placeholder="Package name (e.g., numpy)"
+              value={newPackageName}
+              onChange={(e) => setNewPackageName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleAddPackage();
+                }
+              }}
+            />
+            <Input
+              placeholder="Version (e.g., >=1.24.0)"
+              value={newPackageVersion}
+              onChange={(e) => setNewPackageVersion(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleAddPackage();
+                }
+              }}
+              className="w-64"
+            />
+            <Button
+              type="button"
+              onClick={handleAddPackage}
+              disabled={!newPackageName.trim()}
+            >
+              <Plus className="h-4 w-4 mr-2" />
+              Add Package
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Add packages with optional version constraints (e.g., {'>'}=1.24.0, ~=2.0.0, 3.11.*)
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <label className="text-sm font-medium">pixi.toml Configuration</label>
+          <Textarea
+            placeholder="Enter your pixi.toml content"
+            value={tomlValue}
+            onChange={(e) => onTomlChange(e.target.value)}
+            rows={12}
+            required
+            className="font-mono text-sm"
+          />
+          <p className="text-xs text-muted-foreground">
+            Define your project dependencies and configuration in TOML format
+          </p>
+        </div>
+      )}
+    </>
+  );
+};

--- a/frontend/src/pages/WorkspaceDetail.tsx
+++ b/frontend/src/pages/WorkspaceDetail.tsx
@@ -16,6 +16,7 @@ import { ShareButton } from '@/components/sharing/ShareButton';
 import { PublishButton } from '@/components/publishing/PublishButton';
 import { RoleBadge } from '@/components/sharing/RoleBadge';
 import { VersionHistory } from '@/components/versions/VersionHistory';
+import { PixiTomlEditor } from '@/components/workspace/PixiTomlEditor';
 import { ArrowLeft, Loader2, Package, Plus, Trash2, Copy, Check, ExternalLink, Save, HardDrive, Pencil } from 'lucide-react';
 
 const statusColors: Record<string, string> = {
@@ -144,6 +145,34 @@ export const WorkspaceDetail = () => {
           <Badge className={statusColors[workspace.status]}>
             {workspace.status}
           </Badge>
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-2"
+            disabled={workspace.status !== 'ready'}
+            onClick={async () => {
+              if (!pixiToml) {
+                setLoadingToml(true);
+                try {
+                  const { content } = await workspacesApi.getPixiToml(wsId);
+                  setPixiToml(content);
+                  setEditedToml(content);
+                } catch {
+                  setError('Failed to load pixi.toml');
+                  return;
+                } finally {
+                  setLoadingToml(false);
+                }
+              } else {
+                setEditedToml(pixiToml);
+              }
+              setActiveTab('toml');
+              setIsEditingToml(true);
+            }}
+          >
+            <Pencil className="h-4 w-4" />
+            Edit
+          </Button>
           <PublishButton environmentId={wsId} environmentName={workspace.name} environmentStatus={workspace.status} />
           {!isLocalWs && isOwner && <ShareButton environmentId={wsId} />}
         </div>
@@ -357,7 +386,7 @@ export const WorkspaceDetail = () => {
               <div className="flex items-center justify-between">
                 <CardTitle>pixi.toml Configuration</CardTitle>
                 <div className="flex items-center gap-2">
-                  {isLocalWs && pixiToml && !isEditingToml && (
+                  {pixiToml && !isEditingToml && (
                     <Button
                       variant="outline"
                       size="sm"
@@ -439,10 +468,10 @@ export const WorkspaceDetail = () => {
                   <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
                 </div>
               ) : isEditingToml ? (
-                <textarea
-                  className="w-full h-96 bg-slate-900 text-slate-100 p-4 rounded-md font-mono text-sm resize-y border-0 focus:outline-none focus:ring-2 focus:ring-primary"
-                  value={editedToml}
-                  onChange={(e) => setEditedToml(e.target.value)}
+                <PixiTomlEditor
+                  tomlValue={editedToml}
+                  onTomlChange={setEditedToml}
+                  workspaceName={workspace.name}
                 />
               ) : pixiToml ? (
                 <pre className="bg-slate-900 text-slate-100 p-4 rounded-md overflow-x-auto font-mono text-sm whitespace-pre">


### PR DESCRIPTION
- Extracts a shared PixiTomlEditor component with UI Mode (packages table) and TOML Mode (raw editor), used in both workspace creation and detail editing.
- Also makes the Nebi logo clickable to navigate home and adds an Edit button to the workspace detail header.

https://github.com/user-attachments/assets/5f9aff92-0c91-4e86-862d-b3b67df21989


