### PR TITLE
Add shell tab completion for workspace names

### DIFF
--- a/cmd/nebi/completion.go
+++ b/cmd/nebi/completion.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/nebari-dev/nebi/internal/store"
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate shell completion scripts",
+	Long: `Generate shell completion scripts for nebi.
+
+To load completions:
+
+Bash:
+  $ source <(nebi completion bash)
+  # To load completions for each session, execute once:
+  # Linux:
+  $ nebi completion bash > /etc/bash_completion.d/nebi
+  # macOS:
+  $ nebi completion bash > $(brew --prefix)/etc/bash_completion.d/nebi
+
+Zsh:
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it. You can execute the following once:
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ nebi completion zsh > "${fpath[1]}/_nebi"
+
+  # You will need to start a new shell for this setup to take effect.
+
+Fish:
+  $ nebi completion fish | source
+  # To load completions for each session, execute once:
+  $ nebi completion fish > ~/.config/fish/completions/nebi.fish
+
+PowerShell:
+  PS> nebi completion powershell | Out-String | Invoke-Expression
+  # To load completions for every new session, run:
+  PS> nebi completion powershell > nebi.ps1
+  # and source this file from your PowerShell profile.
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "bash":
+			return cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			return cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			return cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			return cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+		}
+		return nil
+	},
+}
+
+// completeWorkspaceNames returns completion for tracked workspace names.
+func completeWorkspaceNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	s, err := store.New()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	defer s.Close()
+
+	workspaces, err := s.ListWorkspaces()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	var names []string
+	for _, ws := range workspaces {
+		if strings.HasPrefix(ws.Name, toComplete) {
+			names = append(names, ws.Name)
+		}
+	}
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeWorkspaceNamesOrPaths returns completion for workspace names with file fallback.
+// This allows both workspace names and directory paths.
+func completeWorkspaceNamesOrPaths(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+
+	// If it looks like a path, let shell handle it
+	if strings.HasPrefix(toComplete, "/") || strings.HasPrefix(toComplete, "./") || strings.HasPrefix(toComplete, "../") {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+
+	s, err := store.New()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+	defer s.Close()
+
+	workspaces, err := s.ListWorkspaces()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+
+	var names []string
+	for _, ws := range workspaces {
+		if strings.HasPrefix(ws.Name, toComplete) {
+			names = append(names, ws.Name)
+		}
+	}
+
+	// Allow file completion as fallback
+	return names, cobra.ShellCompDirectiveDefault
+}
+
+// completeServerWorkspaceNames returns completion for server workspace names.
+// This makes a network call to the configured server.
+func completeServerWorkspaceNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	client, err := getAuthenticatedClient()
+	if err != nil {
+		// Not logged in or no server configured - fail silently
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	ctx := context.Background()
+	workspaces, err := client.ListWorkspaces(ctx)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var names []string
+	for _, ws := range workspaces {
+		if strings.HasPrefix(ws.Name, toComplete) {
+			names = append(names, ws.Name)
+		}
+	}
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeWorkspaceRemove returns completion based on --remote flag.
+// Uses server workspaces if --remote is set, otherwise local workspaces.
+func completeWorkspaceRemove(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	// Check if --remote flag is set
+	remote, _ := cmd.Flags().GetBool("remote")
+	if remote {
+		return completeServerWorkspaceNames(cmd, args, toComplete)
+	}
+	return completeWorkspaceNamesOrPaths(cmd, args, toComplete)
+}
+
+// completeServerWorkspaceRef returns completion for server workspace:tag refs.
+// Completes workspace names from the server with NoSpace for tag addition.
+func completeServerWorkspaceRef(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	// If completing a tag (after colon), could fetch tags but skip for now
+	if strings.Contains(toComplete, ":") {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	client, err := getAuthenticatedClient()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	ctx := context.Background()
+	workspaces, err := client.ListWorkspaces(ctx)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var names []string
+	for _, ws := range workspaces {
+		if strings.HasPrefix(ws.Name, toComplete) {
+			names = append(names, ws.Name)
+		}
+	}
+	return names, cobra.ShellCompDirectiveNoSpace
+}

--- a/cmd/nebi/diff.go
+++ b/cmd/nebi/diff.go
@@ -39,8 +39,9 @@ Examples:
   nebi diff myworkspace:v1 ./local-dir         # server vs local dir
 
 Use --lock to also compare pixi.lock files.`,
-	Args: cobra.RangeArgs(0, 2),
-	RunE: runDiff,
+	Args:              cobra.RangeArgs(0, 2),
+	RunE:              runDiff,
+	ValidArgsFunction: completeWorkspaceNamesOrPaths,
 }
 
 func init() {

--- a/cmd/nebi/main.go
+++ b/cmd/nebi/main.go
@@ -64,6 +64,7 @@ func init() {
 	rootCmd.AddCommand(registryCmd)
 	rootCmd.AddCommand(serveCmd)
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(completionCmd)
 }
 
 func main() {

--- a/cmd/nebi/publish.go
+++ b/cmd/nebi/publish.go
@@ -30,8 +30,9 @@ Examples:
   nebi publish myworkspace
   nebi publish myworkspace --tag v1.0.0
   nebi publish myworkspace --repo custom-name --registry ghcr`,
-	Args: cobra.MaximumNArgs(1),
-	RunE: runWorkspacePublish,
+	Args:              cobra.MaximumNArgs(1),
+	RunE:              runWorkspacePublish,
+	ValidArgsFunction: completeServerWorkspaceNames,
 }
 
 func init() {

--- a/cmd/nebi/pull.go
+++ b/cmd/nebi/pull.go
@@ -34,8 +34,9 @@ Examples:
   nebi pull myworkspace:v1.0
   nebi pull                                # re-pull from origin
   nebi pull myworkspace -o ./my-project`,
-	Args: cobra.RangeArgs(0, 1),
-	RunE: runPull,
+	Args:              cobra.RangeArgs(0, 1),
+	RunE:              runPull,
+	ValidArgsFunction: completeServerWorkspaceRef,
 }
 
 func init() {

--- a/cmd/nebi/push.go
+++ b/cmd/nebi/push.go
@@ -36,6 +36,7 @@ Examples:
   nebi push myworkspace:v2.0 --force       # overwrite existing user tag`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runPush,
+	// No completion - workspace name is user-provided, not selected from existing
 }
 
 func init() {

--- a/cmd/nebi/run.go
+++ b/cmd/nebi/run.go
@@ -31,6 +31,7 @@ Examples:
   nebi run -e dev my-task             # run with a specific pixi environment`,
 	DisableFlagParsing: true,
 	RunE:               runRun,
+	ValidArgsFunction:  completeWorkspaceNames,
 }
 
 func runRun(cmd *cobra.Command, args []string) error {

--- a/cmd/nebi/shell.go
+++ b/cmd/nebi/shell.go
@@ -36,6 +36,7 @@ Examples:
   nebi shell data-science -e dev   # activate with a specific pixi environment`,
 	DisableFlagParsing: true,
 	RunE:               runShell,
+	ValidArgsFunction:  completeWorkspaceNames,
 }
 
 func runShell(cmd *cobra.Command, args []string) error {

--- a/cmd/nebi/workspace.go
+++ b/cmd/nebi/workspace.go
@@ -41,8 +41,9 @@ var workspaceTagsCmd = &cobra.Command{
 
 Examples:
   nebi workspace tags myworkspace`,
-	Args: cobra.ExactArgs(1),
-	RunE: runWorkspaceTags,
+	Args:              cobra.ExactArgs(1),
+	RunE:              runWorkspaceTags,
+	ValidArgsFunction: completeServerWorkspaceNames,
 }
 
 var wsRemoveRemote bool
@@ -66,8 +67,9 @@ Examples:
   nebi workspace remove data-science        # remove workspace by name
   nebi workspace remove ./my-project        # remove workspace by path
   nebi workspace remove myenv --remote      # delete workspace from server`,
-	Args: cobra.MaximumNArgs(1),
-	RunE: runWorkspaceRemove,
+	Args:              cobra.MaximumNArgs(1),
+	RunE:              runWorkspaceRemove,
+	ValidArgsFunction: completeWorkspaceRemove,
 }
 
 var workspacePruneCmd = &cobra.Command{


### PR DESCRIPTION
## Summary

- Adds `nebi completion` command that generates shell completion scripts (bash/zsh/fish/powershell)
- Enables tab completion for workspace names across CLI commands
- Server-dependent commands query the remote server for completions
- Local commands use the local workspace database

## Commands with completion

| Command | Completion Source |
|---------|-------------------|
| `pull` | Server workspaces (with `:tag` support) |
| `workspace tags` | Server workspaces |
| `publish` | Server workspaces |
| `workspace remove` | Local (or server with `--remote`) |
| `diff` | Local workspaces + file paths |
| `shell` | Local workspaces |
| `run` | Local workspaces |

## Commands without completion

| Command | Reason |
|---------|--------|
| `push` | Workspace name is user-provided, not selected from existing |

## Usage

```bash
# Bash
source <(nebi completion bash)

# Zsh
nebi completion zsh > "${fpath[1]}/_nebi"

# Fish
nebi completion fish | source
```

## Test plan

- [x] `go build ./cmd/nebi/...` compiles
- [x] `go test ./cmd/nebi/...` passes
- [x] `go vet ./...` clean
- [x] `nebi completion bash` generates valid script
- [x] `nebi __complete pull ""` queries server
- [x] `nebi __complete push ""` returns no completions (correct)
- [x] `nebi __complete workspace remove ""` returns local workspaces
- [x] `nebi __complete workspace remove --remote ""` queries server
- [x] Rebased on main (includes workspace naming changes from #142)