### PR TITLE
Add groups as a first-class concept

### DIFF
--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -1,5 +1,5 @@
 import { apiClient } from './client';
-import type { User, CreateUserRequest, AuditLog, Collaborator, ShareWorkspaceRequest, DashboardStats } from '@/types/models';
+import type { User, CreateUserRequest, AuditLog, Collaborator, ShareWorkspaceRequest, ShareGroupRequest, DashboardStats } from '@/types/models';
 
 export const adminApi = {
   // User Management
@@ -39,6 +39,20 @@ export const adminApi = {
 
   unshareWorkspace: async (workspaceId: string, userId: string): Promise<void> => {
     await apiClient.delete(`/workspaces/${workspaceId}/share/${userId}`);
+  },
+
+  // Group Sharing
+  getGroups: async (): Promise<string[]> => {
+    const response = await apiClient.get('/groups');
+    return response.data;
+  },
+
+  shareWorkspaceWithGroup: async (workspaceId: string, data: ShareGroupRequest): Promise<void> => {
+    await apiClient.post(`/workspaces/${workspaceId}/share-group`, data);
+  },
+
+  unshareWorkspaceFromGroup: async (workspaceId: string, groupName: string): Promise<void> => {
+    await apiClient.delete(`/workspaces/${workspaceId}/share-group/${groupName}`);
   },
 
   // Dashboard Stats

--- a/frontend/src/components/sharing/ShareDialog.tsx
+++ b/frontend/src/components/sharing/ShareDialog.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useCollaborators, useShareWorkspace, useUnshareWorkspace } from '@/hooks/useAdmin';
+import { useCollaborators, useShareWorkspace, useUnshareWorkspace, useGroups, useShareWorkspaceWithGroup, useUnshareWorkspaceFromGroup } from '@/hooks/useAdmin';
 import { useUsers } from '@/hooks/useAdmin';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/select-v2';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { RoleBadge } from './RoleBadge';
-import { Loader2, X } from 'lucide-react';
+import { Loader2, Users, X } from 'lucide-react';
 
 interface ShareDialogProps {
   open: boolean;
@@ -23,16 +23,26 @@ interface ShareDialogProps {
 export const ShareDialog = ({ open, onOpenChange, environmentId }: ShareDialogProps) => {
   const [selectedUser, setSelectedUser] = useState('');
   const [selectedRole, setSelectedRole] = useState<'editor' | 'viewer'>('viewer');
-  const [confirmRemove, setConfirmRemove] = useState<{ userId: string; username: string } | null>(null);
+  const [selectedGroup, setSelectedGroup] = useState('');
+  const [selectedGroupRole, setSelectedGroupRole] = useState<'editor' | 'viewer'>('viewer');
+  const [confirmRemove, setConfirmRemove] = useState<{ userId?: string; groupName?: string; displayName: string } | null>(null);
   const [error, setError] = useState('');
 
   const { data: collaborators, isLoading: collaboratorsLoading } = useCollaborators(environmentId, open);
   const { data: allUsers } = useUsers();
+  const { data: allGroups } = useGroups();
   const shareMutation = useShareWorkspace(environmentId);
   const unshareMutation = useUnshareWorkspace(environmentId);
+  const shareGroupMutation = useShareWorkspaceWithGroup(environmentId);
+  const unshareGroupMutation = useUnshareWorkspaceFromGroup(environmentId);
 
   const availableUsers = allUsers?.filter(
-    (user) => !collaborators?.some((c) => c.user_id === user.id)
+    (user) => !collaborators?.some((c) => !c.is_group && c.user_id === user.id)
+  );
+
+  // Filter out groups that already have access
+  const availableGroups = allGroups?.filter(
+    (group) => !collaborators?.some((c) => c.is_group && c.group_name === group)
   );
 
   const handleShare = async (e: React.FormEvent) => {
@@ -55,12 +65,36 @@ export const ShareDialog = ({ open, onOpenChange, environmentId }: ShareDialogPr
     }
   };
 
+  const handleShareGroup = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedGroup) return;
+
+    setError('');
+    try {
+      await shareGroupMutation.mutateAsync({
+        group_name: selectedGroup,
+        role: selectedGroupRole,
+      });
+
+      setSelectedGroup('');
+      setSelectedGroupRole('viewer');
+    } catch (err) {
+      const error = err as { response?: { data?: { error?: string } } };
+      const errorMessage = error?.response?.data?.error || 'Failed to share with group. Please try again.';
+      setError(errorMessage);
+    }
+  };
+
   const handleUnshare = async () => {
     if (!confirmRemove) return;
 
     setError('');
     try {
-      await unshareMutation.mutateAsync(confirmRemove.userId);
+      if (confirmRemove.groupName) {
+        await unshareGroupMutation.mutateAsync(confirmRemove.groupName);
+      } else if (confirmRemove.userId) {
+        await unshareMutation.mutateAsync(confirmRemove.userId);
+      }
       setConfirmRemove(null);
     } catch (err) {
       const error = err as { response?: { data?: { error?: string } } };
@@ -69,6 +103,9 @@ export const ShareDialog = ({ open, onOpenChange, environmentId }: ShareDialogPr
       setConfirmRemove(null);
     }
   };
+
+  const userCollaborators = collaborators?.filter((c) => !c.is_group) ?? [];
+  const groupCollaborators = collaborators?.filter((c) => c.is_group) ?? [];
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -95,7 +132,7 @@ export const ShareDialog = ({ open, onOpenChange, environmentId }: ShareDialogPr
             <div className="space-y-3">
               <h3 className="text-sm font-semibold">Current Access</h3>
               <div className="space-y-2 max-h-64 overflow-y-auto">
-                {collaborators?.map((collab) => (
+                {userCollaborators.map((collab) => (
                   <div
                     key={collab.user_id}
                     className="flex justify-between items-center p-3 border rounded-lg"
@@ -106,16 +143,38 @@ export const ShareDialog = ({ open, onOpenChange, environmentId }: ShareDialogPr
                     </div>
                     <div className="flex items-center gap-2">
                       <RoleBadge role={collab.role} />
-                      {!collab.is_owner && (
+                      {!collab.is_owner && collab.user_id && (
                         <Button
                           variant="ghost"
                           size="sm"
-                          onClick={() => setConfirmRemove({ userId: collab.user_id, username: collab.username })}
+                          onClick={() => setConfirmRemove({ userId: collab.user_id, displayName: collab.username || '' })}
                           disabled={unshareMutation.isPending}
                         >
                           <X className="h-4 w-4" />
                         </Button>
                       )}
+                    </div>
+                  </div>
+                ))}
+                {groupCollaborators.map((collab) => (
+                  <div
+                    key={`group-${collab.group_name}`}
+                    className="flex justify-between items-center p-3 border rounded-lg"
+                  >
+                    <div className="flex-1 flex items-center gap-2">
+                      <Users className="h-4 w-4 text-muted-foreground" />
+                      <div className="font-medium">{collab.group_name}</div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <RoleBadge role={collab.role} />
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setConfirmRemove({ groupName: collab.group_name, displayName: collab.group_name || '' })}
+                        disabled={unshareGroupMutation.isPending}
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
                     </div>
                   </div>
                 ))}
@@ -175,6 +234,60 @@ export const ShareDialog = ({ open, onOpenChange, environmentId }: ShareDialogPr
                 </form>
               </div>
             )}
+
+            {availableGroups && availableGroups.length > 0 && (
+              <div className="space-y-3">
+                <h3 className="text-sm font-semibold">Add Group</h3>
+                <form onSubmit={handleShareGroup} className="space-y-3">
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Group</label>
+                    <SelectRoot value={selectedGroup} onValueChange={setSelectedGroup}>
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Select group..." />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {availableGroups.map((group) => (
+                          <SelectItem key={group} value={group}>
+                            {group}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </SelectRoot>
+                  </div>
+
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Access Level</label>
+                    <SelectRoot
+                      value={selectedGroupRole}
+                      onValueChange={(value) => setSelectedGroupRole(value as 'editor' | 'viewer')}
+                    >
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="viewer">Viewer (Read-only)</SelectItem>
+                        <SelectItem value="editor">Editor (Can modify)</SelectItem>
+                      </SelectContent>
+                    </SelectRoot>
+                  </div>
+
+                  <Button
+                    type="submit"
+                    disabled={!selectedGroup || shareGroupMutation.isPending}
+                    className="w-full"
+                  >
+                    {shareGroupMutation.isPending ? (
+                      <>
+                        <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                        Adding...
+                      </>
+                    ) : (
+                      'Add Group'
+                    )}
+                  </Button>
+                </form>
+              </div>
+            )}
           </div>
         )}
       </DialogContent>
@@ -183,8 +296,12 @@ export const ShareDialog = ({ open, onOpenChange, environmentId }: ShareDialogPr
         open={!!confirmRemove}
         onOpenChange={(open) => !open && setConfirmRemove(null)}
         onConfirm={handleUnshare}
-        title="Remove Collaborator"
-        description={`Are you sure you want to remove ${confirmRemove?.username} from this workspace? They will lose access immediately.`}
+        title={confirmRemove?.groupName ? 'Remove Group Access' : 'Remove Collaborator'}
+        description={
+          confirmRemove?.groupName
+            ? `Are you sure you want to remove the group "${confirmRemove.displayName}" from this workspace? All group members will lose access immediately.`
+            : `Are you sure you want to remove ${confirmRemove?.displayName} from this workspace? They will lose access immediately.`
+        }
         confirmText="Remove"
         cancelText="Cancel"
         variant="destructive"

--- a/frontend/src/hooks/useAdmin.ts
+++ b/frontend/src/hooks/useAdmin.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { adminApi } from '@/api/admin';
-import type { CreateUserRequest, ShareWorkspaceRequest } from '@/types/models';
+import type { CreateUserRequest, ShareWorkspaceRequest, ShareGroupRequest } from '@/types/models';
 
 // Check if current user is admin
 export const useIsAdmin = () => {
@@ -89,6 +89,36 @@ export const useUnshareWorkspace = (workspaceId: string) => {
   return useMutation({
     mutationFn: (userId: string) =>
       adminApi.unshareWorkspace(workspaceId, userId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['collaborators', workspaceId] });
+    },
+  });
+};
+
+// Groups Hooks
+export const useGroups = () => {
+  return useQuery({
+    queryKey: ['groups'],
+    queryFn: adminApi.getGroups,
+  });
+};
+
+export const useShareWorkspaceWithGroup = (workspaceId: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: ShareGroupRequest) =>
+      adminApi.shareWorkspaceWithGroup(workspaceId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['collaborators', workspaceId] });
+    },
+  });
+};
+
+export const useUnshareWorkspaceFromGroup = (workspaceId: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (groupName: string) =>
+      adminApi.unshareWorkspaceFromGroup(workspaceId, groupName),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['collaborators', workspaceId] });
     },

--- a/frontend/src/pages/admin/UserManagement.tsx
+++ b/frontend/src/pages/admin/UserManagement.tsx
@@ -98,6 +98,7 @@ export const UserManagement = () => {
                   <th className="text-left p-4 font-medium">Username</th>
                   <th className="text-left p-4 font-medium">Email</th>
                   <th className="text-left p-4 font-medium">Role</th>
+                  <th className="text-left p-4 font-medium">Groups</th>
                   <th className="text-left p-4 font-medium">Created</th>
                   <th className="text-right p-4 font-medium">Actions</th>
                 </tr>
@@ -120,6 +121,19 @@ export const UserManagement = () => {
                         </Badge>
                       ) : (
                         <Badge variant="outline">User</Badge>
+                      )}
+                    </td>
+                    <td className="p-4">
+                      {user.groups && user.groups.length > 0 ? (
+                        <div className="flex flex-wrap gap-1">
+                          {user.groups.map((group) => (
+                            <Badge key={group} variant="outline" className="text-xs">
+                              {group}
+                            </Badge>
+                          ))}
+                        </div>
+                      ) : (
+                        <span className="text-sm text-muted-foreground">-</span>
                       )}
                     </td>
                     <td className="p-4 text-sm text-muted-foreground">

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -3,6 +3,7 @@ export interface User {
   username: string;
   email: string;
   avatar_url?: string;
+  groups?: string[];
   is_admin?: boolean;
   created_at: string;
   updated_at: string;
@@ -93,15 +94,22 @@ export interface AuditLog {
 }
 
 export interface Collaborator {
-  user_id: string;
-  username: string;
-  email: string;
+  user_id?: string;
+  group_name?: string;
+  username?: string;
+  email?: string;
   role: 'owner' | 'editor' | 'viewer';
   is_owner: boolean;
+  is_group?: boolean;
 }
 
 export interface ShareWorkspaceRequest {
   user_id: string;
+  role: 'editor' | 'viewer';
+}
+
+export interface ShareGroupRequest {
+  group_name: string;
   role: 'editor' | 'viewer';
 }
 

--- a/internal/api/middleware/rbac.go
+++ b/internal/api/middleware/rbac.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/nebari-dev/nebi/internal/models"
 	"github.com/nebari-dev/nebi/internal/rbac"
+	"gorm.io/gorm"
 )
 
 // RequireAdmin ensures the user is an admin.
@@ -39,7 +40,9 @@ func RequireAdmin(localMode bool) gin.HandlerFunc {
 
 // RequireWorkspaceAccess checks if user can access a workspace.
 // When localMode is true the check is unconditionally skipped.
-func RequireWorkspaceAccess(action string, localMode bool) gin.HandlerFunc {
+// It first checks Casbin RBAC policies (individual access), then falls back
+// to checking group-based permissions in the database.
+func RequireWorkspaceAccess(action string, localMode bool, db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if localMode {
 			c.Next()
@@ -61,8 +64,10 @@ func RequireWorkspaceAccess(action string, localMode bool) gin.HandlerFunc {
 			return
 		}
 
-		userID := user.(*models.User).ID
+		u := user.(*models.User)
+		userID := u.ID
 
+		// Check individual RBAC access first
 		var hasAccess bool
 		if action == "read" {
 			hasAccess, err = rbac.CanReadWorkspace(userID, wsID)
@@ -70,12 +75,48 @@ func RequireWorkspaceAccess(action string, localMode bool) gin.HandlerFunc {
 			hasAccess, err = rbac.CanWriteWorkspace(userID, wsID)
 		}
 
-		if err != nil || !hasAccess {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
-			c.Abort()
+		if err == nil && hasAccess {
+			c.Next()
 			return
 		}
 
-		c.Next()
+		// Fallback: check group-based permissions
+		if len(u.Groups) > 0 && db != nil {
+			if checkGroupAccess(db, u.Groups, wsID, action) {
+				c.Next()
+				return
+			}
+		}
+
+		c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+		c.Abort()
 	}
+}
+
+// checkGroupAccess checks whether any of the user's groups have the required
+// access level to the workspace via GroupPermission records.
+func checkGroupAccess(db *gorm.DB, groups []string, wsID uuid.UUID, action string) bool {
+	var groupPerms []models.GroupPermission
+	if err := db.Preload("Role").
+		Where("group_name IN ? AND workspace_id = ?", groups, wsID).
+		Find(&groupPerms).Error; err != nil {
+		return false
+	}
+
+	for _, gp := range groupPerms {
+		switch action {
+		case "read":
+			// Any role grants read access
+			if gp.Role.Name == "viewer" || gp.Role.Name == "editor" || gp.Role.Name == "owner" {
+				return true
+			}
+		case "write":
+			// Only editor and owner grant write access
+			if gp.Role.Name == "editor" || gp.Role.Name == "owner" {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/internal/cliclient/types.go
+++ b/internal/cliclient/types.go
@@ -19,6 +19,7 @@ type User struct {
 	ID        string    `json:"id"`
 	Username  string    `json:"username"`
 	Email     string    `json:"email"`
+	Groups    []string  `json:"groups,omitempty"`
 	IsAdmin   bool      `json:"is_admin"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -103,6 +103,7 @@ func Migrate(db *gorm.DB) error {
 		&models.Workspace{},
 		&models.Job{},
 		&models.Permission{},
+		&models.GroupPermission{},
 		&models.Template{},
 		&models.Package{},
 		&models.AuditLog{},

--- a/internal/models/group_permission.go
+++ b/internal/models/group_permission.go
@@ -1,0 +1,22 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// GroupPermission represents group-level access to a workspace.
+// Groups are IdP-managed (synced from Keycloak), not managed within Nebi.
+type GroupPermission struct {
+	ID          uint           `gorm:"primarykey" json:"id"`
+	GroupName   string         `gorm:"not null;index" json:"group_name"`
+	WorkspaceID uuid.UUID      `gorm:"type:text;not null;index" json:"workspace_id"`
+	Workspace   Workspace      `gorm:"foreignKey:WorkspaceID" json:"workspace,omitempty"`
+	RoleID      uint           `gorm:"not null" json:"role_id"`
+	Role        Role           `gorm:"foreignKey:RoleID" json:"role,omitempty"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+	DeletedAt   gorm.DeletedAt `gorm:"index" json:"-"`
+}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -14,6 +14,7 @@ type User struct {
 	PasswordHash string         `gorm:"not null" json:"-"`
 	Email        string         `gorm:"uniqueIndex;not null" json:"email"`
 	AvatarURL    string         `json:"avatar_url"`
+	Groups       []string       `gorm:"serializer:json" json:"groups"`
 	CreatedAt    time.Time      `json:"created_at"`
 	UpdatedAt    time.Time      `json:"updated_at"`
 	DeletedAt    gorm.DeletedAt `gorm:"index" json:"-"`

--- a/internal/service/workspace_test.go
+++ b/internal/service/workspace_test.go
@@ -190,7 +190,7 @@ func TestList_LocalModeReturnsAll(t *testing.T) {
 	svc.Create(context.Background(), CreateRequest{Name: "ws-bob"}, bob)
 
 	// In local mode, any user sees all workspaces
-	workspaces, err := svc.List(alice)
+	workspaces, err := svc.List(alice, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestList_TeamModeFiltersToOwner(t *testing.T) {
 	svc.Create(context.Background(), CreateRequest{Name: "ws-alice"}, alice)
 	svc.Create(context.Background(), CreateRequest{Name: "ws-bob"}, bob)
 
-	workspaces, err := svc.List(alice)
+	workspaces, err := svc.List(alice, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/swagger/docs.go
+++ b/internal/swagger/docs.go
@@ -755,6 +755,33 @@ const docTemplate = `{
                 }
             }
         },
+        "/groups": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "List all known groups across all users",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "description": "Returns the health status of the service",
@@ -1800,6 +1827,85 @@ const docTemplate = `{
                 }
             }
         },
+        "/workspaces/{id}/share-group": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Share workspace with a group (owner only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Group share details",
+                        "name": "share",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ShareGroupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.GroupPermission"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/share-group/{group_name}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Revoke group access to workspace (owner only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Group name to revoke",
+                        "name": "group_name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
         "/workspaces/{id}/share/{user_id}": {
             "delete": {
                 "security": [
@@ -2059,6 +2165,12 @@ const docTemplate = `{
             "properties": {
                 "email": {
                     "type": "string"
+                },
+                "group_name": {
+                    "type": "string"
+                },
+                "is_group": {
+                    "type": "boolean"
                 },
                 "is_owner": {
                     "type": "boolean"
@@ -2394,6 +2506,22 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.ShareGroupRequest": {
+            "type": "object",
+            "required": [
+                "group_name",
+                "role"
+            ],
+            "properties": {
+                "group_name": {
+                    "type": "string"
+                },
+                "role": {
+                    "description": "\"viewer\" or \"editor\"",
+                    "type": "string"
+                }
+            }
+        },
         "handlers.ShareWorkspaceRequest": {
             "type": "object",
             "required": [
@@ -2447,6 +2575,12 @@ const docTemplate = `{
                 },
                 "email": {
                     "type": "string"
+                },
+                "groups": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "id": {
                     "type": "string"
@@ -2504,6 +2638,35 @@ const docTemplate = `{
                     "$ref": "#/definitions/models.User"
                 },
                 "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.GroupPermission": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "group_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "role": {
+                    "$ref": "#/definitions/models.Role"
+                },
+                "role_id": {
+                    "type": "integer"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "workspace": {
+                    "$ref": "#/definitions/models.Workspace"
+                },
+                "workspace_id": {
                     "type": "string"
                 }
             }
@@ -2669,6 +2832,12 @@ const docTemplate = `{
                 },
                 "email": {
                     "type": "string"
+                },
+                "groups": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "id": {
                     "type": "string"

--- a/internal/swagger/swagger.json
+++ b/internal/swagger/swagger.json
@@ -749,6 +749,33 @@
                 }
             }
         },
+        "/groups": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "List all known groups across all users",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "description": "Returns the health status of the service",
@@ -1794,6 +1821,85 @@
                 }
             }
         },
+        "/workspaces/{id}/share-group": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Share workspace with a group (owner only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Group share details",
+                        "name": "share",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ShareGroupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.GroupPermission"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/share-group/{group_name}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Revoke group access to workspace (owner only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Group name to revoke",
+                        "name": "group_name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
         "/workspaces/{id}/share/{user_id}": {
             "delete": {
                 "security": [
@@ -2053,6 +2159,12 @@
             "properties": {
                 "email": {
                     "type": "string"
+                },
+                "group_name": {
+                    "type": "string"
+                },
+                "is_group": {
+                    "type": "boolean"
                 },
                 "is_owner": {
                     "type": "boolean"
@@ -2388,6 +2500,22 @@
                 }
             }
         },
+        "handlers.ShareGroupRequest": {
+            "type": "object",
+            "required": [
+                "group_name",
+                "role"
+            ],
+            "properties": {
+                "group_name": {
+                    "type": "string"
+                },
+                "role": {
+                    "description": "\"viewer\" or \"editor\"",
+                    "type": "string"
+                }
+            }
+        },
         "handlers.ShareWorkspaceRequest": {
             "type": "object",
             "required": [
@@ -2441,6 +2569,12 @@
                 },
                 "email": {
                     "type": "string"
+                },
+                "groups": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "id": {
                     "type": "string"
@@ -2498,6 +2632,35 @@
                     "$ref": "#/definitions/models.User"
                 },
                 "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.GroupPermission": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "group_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "role": {
+                    "$ref": "#/definitions/models.Role"
+                },
+                "role_id": {
+                    "type": "integer"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "workspace": {
+                    "$ref": "#/definitions/models.Workspace"
+                },
+                "workspace_id": {
                     "type": "string"
                 }
             }
@@ -2663,6 +2826,12 @@
                 },
                 "email": {
                     "type": "string"
+                },
+                "groups": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "id": {
                     "type": "string"

--- a/internal/swagger/swagger.yaml
+++ b/internal/swagger/swagger.yaml
@@ -21,6 +21,10 @@ definitions:
     properties:
       email:
         type: string
+      group_name:
+        type: string
+      is_group:
+        type: boolean
       is_owner:
         type: boolean
       role:
@@ -241,6 +245,17 @@ definitions:
     required:
     - content
     type: object
+  handlers.ShareGroupRequest:
+    properties:
+      group_name:
+        type: string
+      role:
+        description: '"viewer" or "editor"'
+        type: string
+    required:
+    - group_name
+    - role
+    type: object
   handlers.ShareWorkspaceRequest:
     properties:
       role:
@@ -277,6 +292,10 @@ definitions:
         type: string
       email:
         type: string
+      groups:
+        items:
+          type: string
+        type: array
       id:
         type: string
       is_admin:
@@ -315,6 +334,25 @@ definitions:
       user:
         $ref: '#/definitions/models.User'
       user_id:
+        type: string
+    type: object
+  models.GroupPermission:
+    properties:
+      created_at:
+        type: string
+      group_name:
+        type: string
+      id:
+        type: integer
+      role:
+        $ref: '#/definitions/models.Role'
+      role_id:
+        type: integer
+      updated_at:
+        type: string
+      workspace:
+        $ref: '#/definitions/models.Workspace'
+      workspace_id:
         type: string
     type: object
   models.Job:
@@ -430,6 +468,10 @@ definitions:
         type: string
       email:
         type: string
+      groups:
+        items:
+          type: string
+        type: array
       id:
         type: string
       updated_at:
@@ -989,6 +1031,22 @@ paths:
       summary: Check proxy session
       tags:
       - auth
+  /groups:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              type: string
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List all known groups across all users
+      tags:
+      - groups
   /health:
     get:
       description: Returns the health status of the service
@@ -1647,6 +1705,55 @@ paths:
       security:
       - BearerAuth: []
       summary: Share workspace with another user (owner only)
+      tags:
+      - workspaces
+  /workspaces/{id}/share-group:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Group share details
+        in: body
+        name: share
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.ShareGroupRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.GroupPermission'
+      security:
+      - BearerAuth: []
+      summary: Share workspace with a group (owner only)
+      tags:
+      - workspaces
+  /workspaces/{id}/share-group/{group_name}:
+    delete:
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Group name to revoke
+        in: path
+        name: group_name
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+      security:
+      - BearerAuth: []
+      summary: Revoke group access to workspace (owner only)
       tags:
       - workspaces
   /workspaces/{id}/share/{user_id}:


### PR DESCRIPTION
Add groups as a first-class concept: persist IdP groups, display in admin UI, share workspaces with groups

Groups from the IdP (Keycloak) are now persisted on users and can be used to share workspaces, in addition to individual user sharing.

- Persist groups on the User model (synced from IdP on every proxy auth login)
- New GroupPermission model for group-level workspace access
- API endpoints: GET /groups, POST/DELETE /workspaces/:id/share-group
- RBAC middleware falls back to group permissions when individual access is denied
- Workspace list includes workspaces shared via groups
- Admin UI shows groups column in User Management
- ShareDialog supports adding/removing group collaborators