### PR TITLE
Add clipboard copy commands and public toggle for publications

### DIFF
--- a/frontend/src/api/registries.ts
+++ b/frontend/src/api/registries.ts
@@ -49,6 +49,11 @@ export const registriesApi = {
     return data;
   },
 
+  updatePublication: async (workspaceId: string, pubId: string, isPublic: boolean): Promise<Publication> => {
+    const { data } = await apiClient.patch(`/workspaces/${workspaceId}/publications/${pubId}`, { is_public: isPublic });
+    return data;
+  },
+
   // Browse endpoints (for all authenticated users)
   listRepositories: async (registryId: string, search?: string): Promise<{ repositories: RegistryRepository[]; fallback: boolean }> => {
     const params = search ? { search } : {};

--- a/frontend/src/hooks/useRegistries.ts
+++ b/frontend/src/hooks/useRegistries.ts
@@ -97,6 +97,19 @@ export const usePublications = (workspaceId: string) => {
   });
 };
 
+// Mutation hook for updating publication visibility
+export const useUpdatePublication = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ workspaceId, pubId, isPublic }: { workspaceId: string; pubId: string; isPublic: boolean }) =>
+      registriesApi.updatePublication(workspaceId, pubId, isPublic),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['publications', variables.workspaceId] });
+    },
+  });
+};
+
 // Query hook for registry repositories (browse)
 export const useRegistryRepositories = (registryId: string, search?: string) => {
   return useQuery({

--- a/frontend/src/pages/Registries.tsx
+++ b/frontend/src/pages/Registries.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Loader2, ArrowLeft, Search, Download, Package, ChevronRight, X, Globe, Lock, Settings } from 'lucide-react';
+import { Loader2, ArrowLeft, Search, Download, Package, ChevronRight, X, Globe, Lock, Settings, Copy, Check } from 'lucide-react';
 
 export const Registries = () => {
   const navigate = useNavigate();
@@ -283,6 +283,7 @@ export const RegistryTags = () => {
   const [showImport, setShowImport] = useState(false);
   const [importTag, setImportTag] = useState('');
   const [importName, setImportName] = useState('');
+  const [copiedTag, setCopiedTag] = useState<string | null>(null);
 
   const { data: tagData, isLoading: tagsLoading } = useRepositoryTags(
     registryId || '',
@@ -316,6 +317,16 @@ export const RegistryTags = () => {
       const error = err as { response?: { data?: { error?: string } } };
       setError(error?.response?.data?.error || 'Failed to import environment.');
     }
+  };
+
+  const handleCopyImportCmd = async (tagName: string) => {
+    if (!selectedRegistry) return;
+    const host = selectedRegistry.url.replace(/^https?:\/\//, '').replace(/\/$/, '');
+    const repoPath = selectedRegistry.namespace ? `${selectedRegistry.namespace}/${repo}` : repo;
+    const cmd = `nebi import ${host}/${repoPath}:${tagName}`;
+    await navigator.clipboard.writeText(cmd);
+    setCopiedTag(tagName);
+    setTimeout(() => setCopiedTag(null), 2000);
   };
 
   if (registriesLoading) {
@@ -435,10 +446,25 @@ export const RegistryTags = () => {
                       <tr key={tag.name} className="border-b last:border-0 hover:bg-muted/50">
                         <td className="p-4 font-mono text-sm">{tag.name}</td>
                         <td className="p-4 text-right">
-                          <Button size="sm" onClick={() => handleOpenImport(tag.name)}>
-                            <Download className="mr-2 h-4 w-4" />
-                            Import
-                          </Button>
+                          <div className="flex items-center justify-end gap-2">
+                            <Button size="sm" variant="outline" onClick={() => handleCopyImportCmd(tag.name)}>
+                              {copiedTag === tag.name ? (
+                                <>
+                                  <Check className="mr-2 h-4 w-4" />
+                                  Copied
+                                </>
+                              ) : (
+                                <>
+                                  <Copy className="mr-2 h-4 w-4" />
+                                  nebi import
+                                </>
+                              )}
+                            </Button>
+                            <Button size="sm" onClick={() => handleOpenImport(tag.name)}>
+                              <Download className="mr-2 h-4 w-4" />
+                              Import
+                            </Button>
+                          </div>
                         </td>
                       </tr>
                     ))}

--- a/frontend/src/pages/Workspaces.tsx
+++ b/frontend/src/pages/Workspaces.tsx
@@ -11,7 +11,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { PixiTomlEditor } from '@/components/workspace/PixiTomlEditor';
-import { Loader2, Plus, Trash2, X, Edit } from 'lucide-react';
+import { Loader2, Plus, Trash2, X, Edit, Copy, Check } from 'lucide-react';
 
 type UnifiedWorkspace = {
   id: string;
@@ -71,6 +71,7 @@ export const Workspaces = () => {
   const [loadingEdit, setLoadingEdit] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState<{ id: string; name: string; location: 'local' | 'remote' } | null>(null);
   const [error, setError] = useState('');
+  const [copiedPullId, setCopiedPullId] = useState<string | null>(null);
 
   // Filter workspaces based on view mode (when remote connected) or show all local (when not)
   const displayedWorkspaces = useMemo<UnifiedWorkspace[]>(() => {
@@ -223,6 +224,15 @@ export const Workspaces = () => {
       const errorMessage = error?.response?.data?.error || 'Failed to update workspace. Please try again.';
       setError(errorMessage);
     }
+  };
+
+  const handleCopyPull = async (e: React.MouseEvent, wsName: string, wsId: string) => {
+    e.stopPropagation();
+    const serverUrl = window.location.origin;
+    const cmd = `nebi login ${serverUrl} && nebi pull ${wsName}`;
+    await navigator.clipboard.writeText(cmd);
+    setCopiedPullId(wsId);
+    setTimeout(() => setCopiedPullId(null), 2000);
   };
 
   const isCreatePending = createMutation.isPending || createRemoteMutation.isPending;
@@ -424,6 +434,21 @@ export const Workspaces = () => {
                     </td>
                     <td className="p-4">
                       <div className="flex justify-end gap-2">
+                        {ws.location === 'local' && ws.source !== 'local' && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="gap-1.5"
+                            onClick={(e) => handleCopyPull(e, ws.name, ws.id)}
+                            title="Copy nebi pull command"
+                          >
+                            {copiedPullId === ws.id ? (
+                              <Check className="h-4 w-4" />
+                            ) : (
+                              <Copy className="h-4 w-4" />
+                            )}
+                          </Button>
+                        )}
                         {ws.location === 'local' && ws.source !== 'local' && (
                           <Button
                             variant="ghost"

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -176,6 +176,7 @@ export interface Publication {
   repository: string;
   tag: string;
   digest: string;
+  is_public: boolean;
   published_by: string;
   published_at: string;
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -168,6 +168,7 @@ func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Exe
 			ws.POST("/push", middleware.RequireWorkspaceAccess("write", localMode), wsHandler.PushVersion)
 			ws.POST("/publish", middleware.RequireWorkspaceAccess("write", localMode), wsHandler.PublishWorkspace)
 			ws.GET("/publications", middleware.RequireWorkspaceAccess("read", localMode), wsHandler.ListPublications)
+			ws.PATCH("/publications/:pubId", middleware.RequireWorkspaceAccess("write", localMode), wsHandler.UpdatePublication)
 			ws.GET("/publish-defaults", middleware.RequireWorkspaceAccess("read", localMode), wsHandler.GetPublishDefaults)
 		}
 

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -34,6 +34,7 @@ type Publication struct {
 	Repository      string      `gorm:"not null" json:"repository"` // e.g., "myorg/myenv"
 	Tag             string      `gorm:"not null" json:"tag"`        // e.g., "v1.0.0"
 	Digest          string      `json:"digest"`                     // OCI manifest digest
+	IsPublic        bool        `gorm:"default:false" json:"is_public"`
 	PublishedBy     uuid.UUID   `gorm:"type:uuid;not null" json:"published_by"`
 	PublishedByUser User        `gorm:"foreignKey:PublishedBy" json:"published_by_user,omitempty"`
 	CreatedAt       time.Time   `json:"created_at"`

--- a/internal/swagger/docs.go
+++ b/internal/swagger/docs.go
@@ -1536,6 +1536,77 @@ const docTemplate = `{
                 }
             }
         },
+        "/workspaces/{id}/publications/{pubId}": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Toggle the public/private visibility of a publication",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Update a publication's visibility",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Publication ID",
+                        "name": "pubId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.UpdatePublicationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.PublicationResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces/{id}/publish": {
             "post": {
                 "security": [
@@ -2233,6 +2304,9 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "is_public": {
+                    "type": "boolean"
+                },
                 "published_at": {
                     "type": "string"
                 },
@@ -2407,6 +2481,17 @@ const docTemplate = `{
                 },
                 "user_id": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.UpdatePublicationRequest": {
+            "type": "object",
+            "required": [
+                "is_public"
+            ],
+            "properties": {
+                "is_public": {
+                    "type": "boolean"
                 }
             }
         },

--- a/internal/swagger/swagger.json
+++ b/internal/swagger/swagger.json
@@ -1530,6 +1530,77 @@
                 }
             }
         },
+        "/workspaces/{id}/publications/{pubId}": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Toggle the public/private visibility of a publication",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Update a publication's visibility",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Publication ID",
+                        "name": "pubId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.UpdatePublicationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.PublicationResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces/{id}/publish": {
             "post": {
                 "security": [
@@ -2227,6 +2298,9 @@
                 "id": {
                     "type": "string"
                 },
+                "is_public": {
+                    "type": "boolean"
+                },
                 "published_at": {
                     "type": "string"
                 },
@@ -2401,6 +2475,17 @@
                 },
                 "user_id": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.UpdatePublicationRequest": {
+            "type": "object",
+            "required": [
+                "is_public"
+            ],
+            "properties": {
+                "is_public": {
+                    "type": "boolean"
                 }
             }
         },

--- a/internal/swagger/swagger.yaml
+++ b/internal/swagger/swagger.yaml
@@ -135,6 +135,8 @@ definitions:
         type: string
       id:
         type: string
+      is_public:
+        type: boolean
       published_at:
         type: string
       published_by:
@@ -251,6 +253,13 @@ definitions:
     required:
     - role
     - user_id
+    type: object
+  handlers.UpdatePublicationRequest:
+    properties:
+      is_public:
+        type: boolean
+    required:
+    - is_public
     type: object
   handlers.UpdateRegistryRequest:
     properties:
@@ -1480,6 +1489,52 @@ paths:
       security:
       - BearerAuth: []
       summary: List publications for an workspace
+      tags:
+      - workspaces
+  /workspaces/{id}/publications/{pubId}:
+    patch:
+      consumes:
+      - application/json
+      description: Toggle the public/private visibility of a publication
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Publication ID
+        in: path
+        name: pubId
+        required: true
+        type: string
+      - description: Update request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.UpdatePublicationRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.PublicationResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Update a publication's visibility
       tags:
       - workspaces
   /workspaces/{id}/publish:


### PR DESCRIPTION
## Summary
- Add "nebi pull" copy button to workspace detail header (non-local workspaces only) that copies `nebi login <url> && nebi pull <name>`
- Add "nebi import" copy buttons to publications tab and registry tags page that copy `nebi import <registry>/<repo>:<tag>`
- Add public/private visibility toggle on publications with Globe/Lock badges, backed by a new `PATCH /workspaces/:id/publications/:pubId` endpoint
- Best-effort Quay.io API integration to sync visibility when toggling