### PR TITLE
Add version badge to UI layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
-.PHONY: help build build-frontend build-backend run swagger migrate test clean install-tools dev build-docker-pixi build-docker-uv build-docker test-pkgmgr build-all up down
+.PHONY: help build build-frontend build-backend run swagger migrate test clean install-tools dev build-docker-pixi build-docker-uv build-docker test-pkgmgr build-all build-desktop up down
 
 # Variables
 BINARY_NAME=nebi
 FRONTEND_DIR=frontend
 BUILD_DIR=bin
 VERSION=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
-LDFLAGS=-ldflags "-X main.Version=$(VERSION)"
+COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+LDFLAGS=-ldflags "-X main.Version=$(VERSION) -X main.Commit=$(COMMIT)"
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'
@@ -140,6 +141,11 @@ build-all: build-frontend ## Build binaries for all platforms
 	@echo "Building windows/amd64..."
 	@GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe ./cmd/nebi
 	@echo "All platform builds complete"
+
+build-desktop: build-frontend ## Build Wails desktop app with version info
+	@echo "Building desktop app..."
+	@wails build -ldflags "-X main.Version=$(VERSION) -X main.Commit=$(COMMIT)"
+	@echo "Desktop app built: build/bin/Nebi.app"
 
 # K3d Development Environment
 up: ## Create k3d cluster and start Tilt (recreates cluster if exists)

--- a/app.go
+++ b/app.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/nebari-dev/nebi/internal/api"
+	"github.com/nebari-dev/nebi/internal/api/handlers"
 	"github.com/nebari-dev/nebi/internal/config"
 	"github.com/nebari-dev/nebi/internal/db"
 	"github.com/nebari-dev/nebi/internal/executor"
@@ -182,6 +183,10 @@ func (a *App) startEmbeddedServer(cfg *config.Config, database *gorm.DB) {
 			logToFile(fmt.Sprintf("startEmbeddedServer: worker error: %v", err))
 		}
 	}()
+
+	// Pass version info to the API handler (parsed by resolveVersion on first request)
+	handlers.Version = Version
+	handlers.Commit = Commit
 
 	// Initialize API router
 	logToFile("startEmbeddedServer: initializing router...")

--- a/cmd/nebi/main.go
+++ b/cmd/nebi/main.go
@@ -11,6 +11,9 @@ import (
 // Version is set via ldflags at build time
 var Version = "dev"
 
+// Commit is the git commit hash, set via ldflags at build time
+var Commit = ""
+
 var rootCmd = &cobra.Command{
 	Use:   "nebi",
 	Short: "Nebi - Local-first workspace management for Pixi",

--- a/cmd/nebi/serve.go
+++ b/cmd/nebi/serve.go
@@ -53,6 +53,7 @@ func runServe(cmd *cobra.Command, args []string) {
 		Port:    servePort,
 		Mode:    serveMode,
 		Version: Version,
+		Commit:  Commit,
 	}
 
 	if err := server.RunWithSignalHandling(cfg); err != nil {

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -6,6 +6,7 @@ import { useIsAdmin } from '@/hooks/useAdmin';
 import { useRemoteServer } from '@/hooks/useRemote';
 import { useVersion } from '@/hooks/useVersion';
 import { Button } from '@/components/ui/button';
+
 import { LogOut, Boxes, ListTodo, Shield, Settings } from 'lucide-react';
 import { useState } from 'react';
 
@@ -26,7 +27,7 @@ export const Layout = () => {
   };
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background flex flex-col">
       <header className="border-b bg-card">
         <div className="container mx-auto px-4 py-4">
           <div className="flex items-center justify-between">
@@ -170,18 +171,24 @@ export const Layout = () => {
           </div>
         </div>
       </header>
-      <main className="container mx-auto px-4 py-8">
+      <main className="container mx-auto px-4 py-8 flex-1">
         <Outlet />
       </main>
       {versionInfo?.version && (
-        <a
-          href={`https://github.com/nebari-dev/nebi/releases/tag/v${versionInfo.version}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="fixed bottom-6 left-8 text-sm text-muted-foreground/60 hover:text-muted-foreground transition-colors"
-        >
-          v{versionInfo.version}
-        </a>
+        <footer className="border-t border-border/60 py-4 px-8">
+          <a
+            href={
+              versionInfo.commit
+                ? `https://github.com/nebari-dev/nebi/commit/${versionInfo.commit}`
+                : `https://github.com/nebari-dev/nebi/releases/tag/v${versionInfo.version}`
+            }
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-muted-foreground/60 hover:text-muted-foreground transition-colors"
+          >
+            v{versionInfo.version}
+          </a>
+        </footer>
       )}
     </div>
   );

--- a/frontend/src/hooks/useVersion.ts
+++ b/frontend/src/hooks/useVersion.ts
@@ -3,6 +3,7 @@ import { apiClient } from '@/api/client';
 
 interface VersionInfo {
   version: string;
+  commit: string;
   mode: string;
 }
 

--- a/internal/api/handlers/version.go
+++ b/internal/api/handlers/version.go
@@ -2,13 +2,96 @@ package handlers
 
 import (
 	"net/http"
+	"os/exec"
+	"regexp"
 	"runtime"
+	"strings"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 )
 
 // Version is set via ldflags at build time
 var Version = "dev"
+
+// Commit is the git commit hash, set via ldflags at build time
+var Commit = ""
+
+var versionOnce sync.Once
+var resolvedVersion string
+var resolvedCommit string
+
+// gitDescribeRe matches the git describe suffix: -N-g<hash> with optional -dirty.
+// Examples: "-1-gf9e7962", "-5-gabc1234-dirty"
+var gitDescribeRe = regexp.MustCompile(`-(\d+)-g([0-9a-f]+)(-dirty)?$`)
+
+// parseGitDescribe parses a git describe string into a clean version and commit.
+// Examples:
+//
+//	"v0.7-1-gf9e7962-dirty" → ("0.7.dev+f9e7962", "f9e7962")
+//	"v0.7-dirty"            → ("0.7.dev", "")
+//	"v0.7"                  → ("0.7", "")
+//	"v0.7.0-rc1-3-gabc1234" → ("0.7.0-rc1.dev+abc1234", "abc1234")
+//	"f9e7962"               → ("dev+f9e7962", "f9e7962")
+func parseGitDescribe(desc string) (version string, commit string) {
+	desc = strings.TrimSpace(desc)
+	desc = strings.TrimPrefix(desc, "v")
+
+	// Match -N-g<hash>(-dirty)? suffix (commits after a tag)
+	if m := gitDescribeRe.FindStringSubmatchIndex(desc); m != nil {
+		tag := desc[:m[0]]
+		hash := desc[m[4]:m[5]]
+		return tag + ".dev+" + hash, hash
+	}
+
+	// Exact tag with -dirty
+	if clean, ok := strings.CutSuffix(desc, "-dirty"); ok {
+		return clean + ".dev", ""
+	}
+
+	// Exact tag (e.g. "0.7.0", "0.7.0-rc1") or bare hash (e.g. "f9e7962")
+	if strings.Contains(desc, ".") {
+		return desc, ""
+	}
+	return "dev+" + desc, desc
+}
+
+// resolveVersion computes version and commit strings once.
+// It handles three cases:
+//  1. ldflags set a raw git describe string → parse it
+//  2. Version == "dev" (no ldflags) → run git describe at runtime
+//  3. ldflags set a clean version (e.g. release tag) → use as-is
+func resolveVersion() (string, string) {
+	versionOnce.Do(func() {
+		v := Version
+		c := Commit
+
+		if v == "dev" {
+			// No ldflags — try git at runtime
+			out, err := exec.Command("git", "describe", "--tags", "--always", "--dirty").Output()
+			if err == nil {
+				v = strings.TrimSpace(string(out))
+			} else {
+				out, err = exec.Command("git", "rev-parse", "--short", "HEAD").Output()
+				if err == nil {
+					c = strings.TrimSpace(string(out))
+					resolvedVersion = "dev+" + c
+					resolvedCommit = c
+					return
+				}
+				resolvedVersion = "dev"
+				return
+			}
+		}
+
+		// Parse git describe format (works for both ldflags and runtime git)
+		resolvedVersion, resolvedCommit = parseGitDescribe(v)
+		if c != "" && resolvedCommit == "" {
+			resolvedCommit = c
+		}
+	})
+	return resolvedVersion, resolvedCommit
+}
 
 // Mode is set by the router based on config (e.g. "local" or "team")
 var Mode = "team"
@@ -28,8 +111,11 @@ func GetVersion(c *gin.Context) {
 		"local_storage": Mode == "local",
 	}
 
+	version, commit := resolveVersion()
+
 	c.JSON(http.StatusOK, gin.H{
-		"version":    Version,
+		"version":    version,
+		"commit":     commit,
 		"go_version": runtime.Version(),
 		"os":         runtime.GOOS,
 		"arch":       runtime.GOARCH,

--- a/internal/api/handlers/version_test.go
+++ b/internal/api/handlers/version_test.go
@@ -1,0 +1,49 @@
+package handlers
+
+import "testing"
+
+func TestParseGitDescribe(t *testing.T) {
+	tests := []struct {
+		input       string
+		wantVersion string
+		wantCommit  string
+	}{
+		// Release tags (exact match)
+		{"v0.7", "0.7", ""},
+		{"v0.7.0", "0.7.0", ""},
+		{"v1.2.3", "1.2.3", ""},
+
+		// Dev builds (commits after tag)
+		{"v0.7-1-gf9e7962", "0.7.dev+f9e7962", "f9e7962"},
+		{"v0.7.0-5-gabc1234", "0.7.0.dev+abc1234", "abc1234"},
+
+		// Dirty working tree
+		{"v0.7-dirty", "0.7.dev", ""},
+		{"v0.7-1-gf9e7962-dirty", "0.7.dev+f9e7962", "f9e7962"},
+
+		// Pre-release tags
+		{"v0.7.0-rc1", "0.7.0-rc1", ""},
+		{"v0.7.0-rc1-3-gabc1234", "0.7.0-rc1.dev+abc1234", "abc1234"},
+		{"v0.7.0-beta.1-2-g1234567", "0.7.0-beta.1.dev+1234567", "1234567"},
+
+		// Bare commit hash (no tags in repo)
+		{"f9e7962", "dev+f9e7962", "f9e7962"},
+		{"abc1234", "dev+abc1234", "abc1234"},
+
+		// Without v prefix
+		{"0.7.0", "0.7.0", ""},
+		{"0.7.0-1-gf9e7962", "0.7.0.dev+f9e7962", "f9e7962"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			gotVersion, gotCommit := parseGitDescribe(tt.input)
+			if gotVersion != tt.wantVersion {
+				t.Errorf("parseGitDescribe(%q) version = %q, want %q", tt.input, gotVersion, tt.wantVersion)
+			}
+			if gotCommit != tt.wantCommit {
+				t.Errorf("parseGitDescribe(%q) commit = %q, want %q", tt.input, gotCommit, tt.wantCommit)
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,6 +31,7 @@ type Config struct {
 	Port    int    // Port to run the server on (0 = use config default)
 	Mode    string // Run mode: server, worker, or both
 	Version string // Version string to report
+	Commit  string // Git commit hash
 }
 
 // Run starts the server with the given configuration and blocks until the context is canceled.
@@ -38,6 +39,9 @@ func Run(ctx context.Context, cfg Config) error {
 	// Set version in handlers
 	if cfg.Version != "" {
 		handlers.Version = cfg.Version
+	}
+	if cfg.Commit != "" {
+		handlers.Commit = cfg.Commit
 	}
 
 	// Load configuration

--- a/main.go
+++ b/main.go
@@ -8,6 +8,10 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
 )
 
+// Version and Commit are set via ldflags at build time
+var Version = "dev"
+var Commit = ""
+
 //go:embed all:frontend/dist
 var assets embed.FS
 
@@ -18,8 +22,8 @@ func main() {
 	// Run Wails application
 	err := wails.Run(&options.App{
 		Title:  "Nebi - Environment Manager",
-		Width:  1280,
-		Height: 800,
+		Width:  1440,
+		Height: 900,
 		AssetServer: &assetserver.Options{
 			Assets:  assets,
 			Handler: app.Handler(),


### PR DESCRIPTION
## Summary
- Display the app version from `GET /api/v1/version` as a small fixed-position badge in the bottom-right corner of every page
- Uses TanStack Query with `staleTime: Infinity` since version doesn't change during a session
- Only renders when version data is available

<img width="1512" height="853" alt="Screenshot 2026-02-24 at 22 26 17" src="https://github.com/user-attachments/assets/9a92805c-b5d5-4ef1-bbe5-412d63b7a942" />
