### PR TITLE
Fix nebi import button URL by stripping protocol prefix

### DIFF
--- a/frontend/src/pages/WorkspaceDetail.tsx
+++ b/frontend/src/pages/WorkspaceDetail.tsx
@@ -93,8 +93,9 @@ export const WorkspaceDetail = () => {
   };
 
   const handleCopyImport = async (pub: { registry_url: string; registry_namespace: string; repository: string; tag: string; id: string }) => {
+    const host = pub.registry_url.replace(/^https?:\/\//, '').replace(/\/$/, '');
     const repoPath = pub.registry_namespace ? `${pub.registry_namespace}/${pub.repository}` : pub.repository;
-    const cmd = `nebi import ${pub.registry_url}/${repoPath}:${pub.tag}`;
+    const cmd = `nebi import ${host}/${repoPath}:${pub.tag}`;
     await navigator.clipboard.writeText(cmd);
     setCopiedImportId(pub.id);
     setTimeout(() => setCopiedImportId(null), 2000);
@@ -550,7 +551,7 @@ export const WorkspaceDetail = () => {
                         <div className="flex-1 space-y-2">
                           <div className="flex items-center gap-2">
                             <a
-                              href={`https://${pub.registry_url}/repository/${pub.registry_namespace ? pub.registry_namespace + '/' : ''}${pub.repository}?tab=tags`}
+                              href={`https://${pub.registry_url.replace(/^https?:\/\//, '').replace(/\/$/, '')}/repository/${pub.registry_namespace ? pub.registry_namespace + '/' : ''}${pub.repository}?tab=tags`}
                               target="_blank"
                               rel="noopener noreferrer"
                               className="font-medium text-lg hover:underline text-primary flex items-center gap-1"


### PR DESCRIPTION
## Summary
- Fixed `handleCopyImport` in WorkspaceDetail to strip `https://` protocol prefix from registry URL before building the `nebi import` CLI command
- Fixed the publication link `href` which had the same issue (would produce `https://https://...` if registry URL included protocol)
- Matches how Registries.tsx already handles this correctly

## Test plan
- [ ] Create a registry with URL including protocol (e.g., `https://quay.io`)
- [ ] Publish a workspace and click the "nebi import" copy button
- [ ] Verify the copied command has the correct format: `nebi import quay.io/namespace/repo:tag` (no protocol prefix)
- [ ] Verify the publication title link navigates to the correct registry page