### PR TITLE
Re-order README sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 ## What is Nebi?
 
 Nebi is a server and CLI for managing [Pixi](https://prefix.dev/) environments in multi-user settings. The server handles environment creation, versioning, and access control, while the local-first CLI lets you track workspaces, push/pull versioned specs, and diff environments across machines or teams.
+
 **Key features:**
 - Server with async job queue, RBAC, and PostgreSQL/Valkey backend
 - Local-first CLI for workspace tracking (no server required for basic use)
@@ -44,6 +45,8 @@ Nebi is a server and CLI for managing [Pixi](https://prefix.dev/) environments i
 - Publish environments from the server to OCI registries (Quay.io, GHCR, etc.)
 - Diff specs between local directories or server versions
 - Single-server connection with token-based authentication
+
+<a href="https://nebi.nebari.dev/">Read the documentation →</a>
 
 ## Quick Start
 
@@ -59,14 +62,16 @@ curl -fsSL https://nebi.nebari.dev/install.sh | sh
 irm https://nebi.nebari.dev/install.ps1 | iex
 ```
 
+**Build from source:**
+```sh
+go install github.com/nebari-dev/nebi/cmd/nebi@latest
+```
+
 See `install.sh --help` or the script source for advanced options (`--version`, `--install-dir`, `--desktop`).
 
 ### CLI Quick Start
 
 ```bash
-# Install nebi CLI (download from releases or build from source)
-go install github.com/nebari-dev/nebi/cmd/nebi@latest
-
 # Authenticate with a server
 nebi login https://nebi.company.com
 
@@ -87,28 +92,87 @@ nebi pull myworkspace:v1.0
 nebi status
 ```
 
-### Local Development
+## CLI Usage
+
+### Workspace Commands
 
 ```bash
-# Install development tools
-make install-tools
+# Track a pixi workspace (runs pixi init if no pixi.toml exists)
+cd my-project
+nebi init
 
-# Run with hot reload (frontend + backend)
-# Frontend dependencies will be automatically installed if needed
-ADMIN_USERNAME=admin ADMIN_PASSWORD=<your-password> make dev
+# Check sync status
+nebi status
+
+# List tracked workspaces
+nebi workspace list
+
+# Compare pixi specs between directories or server versions
+nebi diff                                # local vs last pushed/pulled origin
+nebi diff ./project-a ./project-b
+nebi diff ./project-a ./project-b --lock    # also compare pixi.lock
+nebi diff myworkspace:v1 myworkspace:v2
+
+# Push/pull versioned specs
+nebi push myworkspace                    # auto-tags: sha-<hash> + latest
+nebi push myworkspace:v1.0               # also adds user tag v1.0
+nebi push                                # reuse workspace name from origin
+nebi pull myworkspace:v1.0
+nebi pull                                # re-pull from last origin
+
+# List workspaces and tags on a server
+nebi workspace list --remote
+nebi workspace tags myworkspace
+
+# Run pixi tasks and shells by workspace name
+nebi shell data-science                 # open pixi shell in a workspace by name
+nebi shell data-science -e dev          # args pass through to pixi shell
+nebi run my-task                        # run a pixi task (auto-initializes workspace)
+nebi run data-science my-task           # run a task in a named workspace
+nebi workspace remove data-science      # remove a workspace from tracking
+nebi workspace remove myenv --remote   # remove a workspace from a server
+nebi workspace prune                   # clean up workspaces with missing paths
+
+# Diff using workspace names
+nebi diff data-science ./my-project
+nebi diff data-science ml-pipeline
+
+# Publish a workspace to an OCI registry (uses content hash tag by default)
+nebi publish myworkspace
+nebi publish myworkspace --tag v1.0.0
+nebi publish myworkspace --registry ghcr --repo myorg/myenv
 ```
 
-This will start:
-- **Frontend dev server** at http://localhost:8461 (with hot reload)
-- **Backend API** at http://localhost:8460 (with hot reload)
-- **API docs** at http://localhost:8460/docs
+### Connection Commands
 
-**Admin Credentials:**
-Set `ADMIN_USERNAME` and `ADMIN_PASSWORD` environment variables to create the admin user on first startup.
+```bash
+# Authenticate with a server
+nebi login https://nebi.company.com
+nebi login https://nebi.company.com --token <api-token>
 
-> **Note**: The admin user is automatically created on first startup when `ADMIN_USERNAME` and `ADMIN_PASSWORD` environment variables are set. If you start the server without these variables, no admin user will be created and you won't be able to log in.
+# List OCI registries on the server
+nebi registry list
+```
 
-> **Tip**: Access the app at http://localhost:8461 for the best development experience with instant hot reload of frontend changes!
+### Admin Commands
+
+```bash
+# Run a server instance
+nebi serve
+nebi serve --port 8080 --mode server
+```
+
+### Shell Completion
+
+Nebi supports tab completion for bash, zsh, fish, and PowerShell. Run `nebi completion --help` for setup instructions.
+
+### Configuration command
+
+Run `nebi login <server-url>` to configure the server. All server-dependent commands (`push`, `pull`, `diff`, `workspace tags`, etc.) use the configured server.
+
+Nebi stores data in platform-standard directories:
+- **Data** (`~/.local/share/nebi/`): index and credentials
+- **Config** (`~/.config/nebi/config.yaml`): default server and user preferences
 
 ## API Usage
 
@@ -193,88 +257,6 @@ The CLI works without changes — just include the full path when connecting:
 nebi login https://hub.example.com/proxy/8460
 ```
 
-## CLI Usage
-
-### Workspace Commands
-
-```bash
-# Track a pixi workspace (runs pixi init if no pixi.toml exists)
-cd my-project
-nebi init
-
-# Check sync status
-nebi status
-
-# List tracked workspaces
-nebi workspace list
-
-# Compare pixi specs between directories or server versions
-nebi diff                                # local vs last pushed/pulled origin
-nebi diff ./project-a ./project-b
-nebi diff ./project-a ./project-b --lock    # also compare pixi.lock
-nebi diff myworkspace:v1 myworkspace:v2
-
-# Push/pull versioned specs
-nebi push myworkspace                    # auto-tags: sha-<hash> + latest
-nebi push myworkspace:v1.0               # also adds user tag v1.0
-nebi push                                # reuse workspace name from origin
-nebi pull myworkspace:v1.0
-nebi pull                                # re-pull from last origin
-
-# List workspaces and tags on a server
-nebi workspace list --remote
-nebi workspace tags myworkspace
-
-# Run pixi tasks and shells by workspace name
-nebi shell data-science                 # open pixi shell in a workspace by name
-nebi shell data-science -e dev          # args pass through to pixi shell
-nebi run my-task                        # run a pixi task (auto-initializes workspace)
-nebi run data-science my-task           # run a task in a named workspace
-nebi workspace remove data-science      # remove a workspace from tracking
-nebi workspace remove myenv --remote   # remove a workspace from a server
-nebi workspace prune                   # clean up workspaces with missing paths
-
-# Diff using workspace names
-nebi diff data-science ./my-project
-nebi diff data-science ml-pipeline
-
-# Publish a workspace to an OCI registry (uses content hash tag by default)
-nebi publish myworkspace
-nebi publish myworkspace --tag v1.0.0
-nebi publish myworkspace --registry ghcr --repo myorg/myenv
-```
-
-### Connection Commands
-
-```bash
-# Authenticate with a server
-nebi login https://nebi.company.com
-nebi login https://nebi.company.com --token <api-token>
-
-# List OCI registries on the server
-nebi registry list
-```
-
-### Admin Commands
-
-```bash
-# Run a server instance
-nebi serve
-nebi serve --port 8080 --mode server
-```
-
-### Shell Completion
-
-Nebi supports tab completion for bash, zsh, fish, and PowerShell. Run `nebi completion --help` for setup instructions.
-
-### Configuration
-
-Nebi stores data in platform-standard directories:
-- **Data** (`~/.local/share/nebi/`): index and credentials
-- **Config** (`~/.config/nebi/config.yaml`): default server and user preferences
-
-Run `nebi login <server-url>` to configure the server. All server-dependent commands (`push`, `pull`, `diff`, `workspace tags`, etc.) use the configured server.
-
 ## Development
 
 ```bash
@@ -284,6 +266,29 @@ make build          # Build binary
 make test           # Run tests
 make swagger        # Generate API docs
 ```
+
+### Local setup
+
+```bash
+# Install development tools
+make install-tools
+
+# Run with hot reload (frontend + backend)
+# Frontend dependencies will be automatically installed if needed
+ADMIN_USERNAME=admin ADMIN_PASSWORD=<your-password> make dev
+```
+
+This will start:
+- **Frontend dev server** at http://localhost:8461 (with hot reload)
+- **Backend API** at http://localhost:8460 (with hot reload)
+- **API docs** at http://localhost:8460/docs
+
+**Admin Credentials:**
+Set `ADMIN_USERNAME` and `ADMIN_PASSWORD` environment variables to create the admin user on first startup.
+
+> **Note**: The admin user is automatically created on first startup when `ADMIN_USERNAME` and `ADMIN_PASSWORD` environment variables are set. If you start the server without these variables, no admin user will be created and you won't be able to log in.
+
+> **Tip**: Access the app at http://localhost:8461 for the best development experience with instant hot reload of frontend changes!
 
 ### Desktop App
 
@@ -322,7 +327,7 @@ wails build
 
 The built application will be in `build/bin/`.
 
-## Project Structure
+### Project Structure
 
 ```
 nebi/
@@ -340,4 +345,3 @@ nebi/
 │   └── pkgmgr/           # Pixi abstractions
 └── frontend/             # React web UI
 ```
-


### PR DESCRIPTION
Re-order some sections in the README to prioritize end-user docs.

- Moved development docs to end
- Moved CLI guide before API 
- Added a link to the docs