### PR TITLE
fix: redirect logout to gateway OIDC logout path when behind proxy

### DIFF
--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -26,9 +26,17 @@ export const Layout = () => {
   const location = useLocation();
   const isAdminPage = location.pathname.startsWith('/admin');
 
+  const logoutUrl = useModeStore((s) => s.logoutUrl);
+
   const handleLogout = () => {
     clearAuth();
-    navigate('/login');
+    if (logoutUrl) {
+      // Redirect to the gateway's OIDC logout path (e.g. Envoy's /logout)
+      // to clear IdToken cookies and terminate the Keycloak session.
+      window.location.href = logoutUrl;
+    } else {
+      navigate('/login');
+    }
   };
 
   return (

--- a/frontend/src/store/modeStore.ts
+++ b/frontend/src/store/modeStore.ts
@@ -4,6 +4,7 @@ import { apiClient } from '@/api/client';
 interface ModeState {
   mode: 'local' | 'team' | null;
   features: Record<string, boolean>;
+  logoutUrl: string | null;
   loading: boolean;
   fetchMode: () => Promise<void>;
   isLocalMode: () => boolean;
@@ -12,14 +13,15 @@ interface ModeState {
 export const useModeStore = create<ModeState>()((set, get) => ({
   mode: null,
   features: {},
+  logoutUrl: null,
   loading: true,
   fetchMode: async () => {
     try {
       const { data } = await apiClient.get('/version');
-      set({ mode: data.mode, features: data.features || {}, loading: false });
+      set({ mode: data.mode, features: data.features || {}, logoutUrl: data.logout_url || null, loading: false });
     } catch {
       // Default to team mode on error
-      set({ mode: 'team', features: {}, loading: false });
+      set({ mode: 'team', features: {}, logoutUrl: null, loading: false });
     }
   },
   isLocalMode: () => get().mode === 'local',

--- a/internal/api/handlers/version.go
+++ b/internal/api/handlers/version.go
@@ -96,6 +96,10 @@ func resolveVersion() (string, string) {
 // Mode is set by the router based on config (e.g. "local" or "team")
 var Mode = "team"
 
+// LogoutURL is set by the router when the deployment requires an external
+// logout redirect (e.g. Envoy Gateway's /logout path for OIDC session cleanup).
+var LogoutURL = ""
+
 // GetVersion godoc
 // @Summary Get version information
 // @Description Returns version information about the Nebi server
@@ -113,7 +117,7 @@ func GetVersion(c *gin.Context) {
 
 	version, commit := resolveVersion()
 
-	c.JSON(http.StatusOK, gin.H{
+	resp := gin.H{
 		"version":    version,
 		"commit":     commit,
 		"go_version": runtime.Version(),
@@ -121,5 +125,10 @@ func GetVersion(c *gin.Context) {
 		"arch":       runtime.GOARCH,
 		"mode":       Mode,
 		"features":   features,
-	})
+	}
+	if LogoutURL != "" {
+		resp["logout_url"] = LogoutURL
+	}
+
+	c.JSON(http.StatusOK, resp)
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -98,7 +98,10 @@ func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Exe
 	sessionBasicAuth := auth.NewBasicAuthenticator(db, cfg.Auth.JWTSecret)
 
 	// Wire OIDC ID token verifier into authenticators that handle proxy cookies.
+	// When OIDC is configured, logout requires redirecting to the gateway's
+	// /logout path to clear OIDC cookies and terminate the Keycloak session.
 	if oidcAuth != nil {
+		handlers.LogoutURL = basePath + "/logout"
 		sessionBasicAuth.SetIDTokenVerifier(oidcAuth.Verifier())
 		if ba, ok := authenticator.(*auth.BasicAuthenticator); ok {
 			ba.SetIDTokenVerifier(oidcAuth.Verifier())


### PR DESCRIPTION
## Summary

- Add `logout_url` field to `/api/v1/version` response when OIDC is configured (indicates deployment is behind an authenticating proxy)
- Frontend redirects to this URL on logout (Envoy Gateway's `/logout`), which clears OIDC cookies and terminates the Keycloak session
- Previously, logout only cleared the Nebi JWT from localStorage while the proxy's IdToken cookie persisted, causing immediate re-authentication

Ref: nebari-dev/nebari-nebi-pack#5