### PR TITLE
feat: add nebi info command

### DIFF
--- a/cmd/nebi/e2e_test.go
+++ b/cmd/nebi/e2e_test.go
@@ -178,6 +178,8 @@ func resetFlags() {
 	registryListJSON = false
 	// status.go
 	statusJSON = false
+	// info.go
+	infoJSON = false
 }
 
 // runCLI executes a CLI command in-process and captures output.
@@ -1822,5 +1824,108 @@ func TestE2E_PushJSON(t *testing.T) {
 	}
 	if _, ok := resp["content_hash"]; !ok {
 		t.Error("expected content_hash in push JSON response")
+	}
+}
+
+func TestE2E_Info(t *testing.T) {
+	dir := t.TempDir()
+
+	// Set env vars for server auth
+	os.Setenv("NEBI_AUTH_TOKEN", e2eEnv.token)
+	os.Setenv("NEBI_REMOTE_URL", e2eEnv.serverURL)
+	defer os.Unsetenv("NEBI_AUTH_TOKEN")
+	defer os.Unsetenv("NEBI_REMOTE_URL")
+
+	// Test basic info output
+	res := runCLI(t, dir, "info")
+	if res.ExitCode != 0 {
+		t.Fatalf("info failed (exit %d):\nstdout: %s\nstderr: %s", res.ExitCode, res.Stdout, res.Stderr)
+	}
+
+	// Verify all sections present
+	for _, section := range []string{"Nebi", "Server", "Auth"} {
+		if !strings.Contains(res.Stdout, section) {
+			t.Errorf("expected %q section in output, got: %s", section, res.Stdout)
+		}
+	}
+
+	if !strings.Contains(res.Stdout, "reachable") {
+		t.Errorf("expected server status 'reachable', got: %s", res.Stdout)
+	}
+	if !strings.Contains(res.Stdout, "yes") {
+		t.Errorf("expected logged in 'yes', got: %s", res.Stdout)
+	}
+	if !strings.Contains(res.Stdout, "environment variable") {
+		t.Errorf("expected auth source 'environment variable', got: %s", res.Stdout)
+	}
+
+	// Test JSON output
+	res = runCLI(t, dir, "info", "--json")
+	if res.ExitCode != 0 {
+		t.Fatalf("info --json failed (exit %d):\nstdout: %s\nstderr: %s", res.ExitCode, res.Stdout, res.Stderr)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(res.Stdout), &result); err != nil {
+		t.Fatalf("failed to parse JSON output: %v\nstdout: %s", err, res.Stdout)
+	}
+	if result["logged_in"] != true {
+		t.Errorf("expected logged_in=true, got: %v", result["logged_in"])
+	}
+	if result["auth_source"] != "environment variable" {
+		t.Errorf("expected auth_source='environment variable', got: %v", result["auth_source"])
+	}
+	if result["server_status"] != "reachable" {
+		t.Errorf("expected server_status='reachable', got: %v", result["server_status"])
+	}
+}
+
+func TestE2E_InfoWorkspace(t *testing.T) {
+	dir := t.TempDir()
+
+	os.Setenv("NEBI_AUTH_TOKEN", e2eEnv.token)
+	os.Setenv("NEBI_REMOTE_URL", e2eEnv.serverURL)
+	defer os.Unsetenv("NEBI_AUTH_TOKEN")
+	defer os.Unsetenv("NEBI_REMOTE_URL")
+
+	// Create a pixi.toml and init workspace
+	toml := "[project]\nname = \"info-ws-test\"\nchannels = [\"conda-forge\"]\nplatforms = [\"linux-64\"]\n"
+	os.WriteFile(filepath.Join(dir, "pixi.toml"), []byte(toml), 0644)
+
+	res := runCLI(t, dir, "init")
+	if res.ExitCode != 0 {
+		t.Fatalf("init failed (exit %d):\nstdout: %s\nstderr: %s", res.ExitCode, res.Stdout, res.Stderr)
+	}
+
+	// Info should now show workspace section
+	res = runCLI(t, dir, "info")
+	if res.ExitCode != 0 {
+		t.Fatalf("info failed (exit %d):\nstdout: %s\nstderr: %s", res.ExitCode, res.Stdout, res.Stderr)
+	}
+	if !strings.Contains(res.Stdout, "Workspace") {
+		t.Errorf("expected Workspace section in output, got: %s", res.Stdout)
+	}
+	if !strings.Contains(res.Stdout, "info-ws-test") {
+		t.Errorf("expected workspace name 'info-ws-test', got: %s", res.Stdout)
+	}
+}
+
+func TestE2E_InfoNoServer(t *testing.T) {
+	dir := t.TempDir()
+
+	// Clear any env vars
+	os.Unsetenv("NEBI_AUTH_TOKEN")
+	os.Unsetenv("NEBI_REMOTE_URL")
+
+	res := runCLI(t, dir, "info")
+	if res.ExitCode != 0 {
+		t.Fatalf("info failed (exit %d):\nstdout: %s\nstderr: %s", res.ExitCode, res.Stdout, res.Stderr)
+	}
+
+	if !strings.Contains(res.Stdout, "not configured") {
+		t.Errorf("expected 'not configured' for server URL, got: %s", res.Stdout)
+	}
+	if !strings.Contains(res.Stdout, "Logged in: no") {
+		t.Errorf("expected 'Logged in: no', got: %s", res.Stdout)
 	}
 }

--- a/cmd/nebi/info.go
+++ b/cmd/nebi/info.go
@@ -1,0 +1,276 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nebari-dev/nebi/internal/cliclient"
+	"github.com/nebari-dev/nebi/internal/store"
+	"github.com/spf13/cobra"
+)
+
+var infoJSON bool
+
+func init() {
+	infoCmd.Flags().BoolVar(&infoJSON, "json", false, "Output as JSON")
+}
+
+var infoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Show nebi system information",
+	Long: `Display comprehensive information about the nebi CLI, server connection,
+authentication status, and current workspace.
+
+Examples:
+  nebi info
+  nebi info --json`,
+	Args: cobra.NoArgs,
+	RunE: runInfo,
+}
+
+type infoResult struct {
+	// Nebi section
+	Version  string `json:"version"`
+	Platform string `json:"platform"`
+	DataDir  string `json:"data_dir"`
+
+	// Server section
+	ServerURL      string `json:"server_url"`
+	ServerStatus   string `json:"server_status,omitempty"`
+	ServerVersion  string `json:"server_version,omitempty"`
+	ServerMode     string `json:"server_mode,omitempty"`
+	ServerFeatures string `json:"server_features,omitempty"`
+
+	// Auth section
+	LoggedIn   bool   `json:"logged_in"`
+	Username   string `json:"username,omitempty"`
+	AuthSource string `json:"auth_source"`
+
+	// Workspace section (empty when not in a tracked workspace)
+	Workspace      string `json:"workspace,omitempty"`
+	WorkspacePath  string `json:"workspace_path,omitempty"`
+	PackageManager string `json:"package_manager,omitempty"`
+	Origin         string `json:"origin,omitempty"`
+	LocalEdits     string `json:"local_edits,omitempty"`
+}
+
+func runInfo(cmd *cobra.Command, args []string) error {
+	result := infoResult{
+		Version:  Version,
+		Platform: runtime.GOOS + "-" + runtime.GOARCH,
+	}
+
+	// Data dir
+	dataDir, err := store.DefaultDataDir()
+	if err == nil {
+		home, _ := os.UserHomeDir()
+		result.DataDir = shortenPath(dataDir, home)
+	}
+
+	// Resolve server URL, token, username from local sources (no API calls)
+	serverURL, token, username, authSource := resolveInfoAuth()
+	result.AuthSource = authSource
+	if token != "" {
+		result.LoggedIn = true
+		result.Username = username
+	}
+
+	if serverURL != "" {
+		result.ServerURL = serverURL
+	} else {
+		result.ServerURL = "not configured"
+	}
+
+	// Check server version (short timeout, public endpoint) — only if configured
+	if serverURL != "" {
+		result.ServerStatus = "unreachable"
+		client := cliclient.NewWithoutAuth(serverURL)
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+
+		sv, err := client.GetServerVersion(ctx)
+		if err == nil {
+			result.ServerStatus = "reachable"
+			vStr := sv.Version
+			if sv.Commit != "" && !strings.Contains(sv.Version, sv.Commit) {
+				vStr += " (" + sv.Commit + ")"
+			}
+			result.ServerVersion = vStr
+			result.ServerMode = sv.Mode
+			result.ServerFeatures = formatFeatures(sv.Features)
+		}
+	}
+
+	// Workspace section
+	fillWorkspaceInfo(&result)
+
+	if infoJSON {
+		return writeJSON(result)
+	}
+
+	printInfo(result)
+	return nil
+}
+
+func resolveInfoAuth() (serverURL, token, username, source string) {
+	if envToken := os.Getenv("NEBI_AUTH_TOKEN"); envToken != "" {
+		if envURL := os.Getenv("NEBI_REMOTE_URL"); envURL != "" {
+			return envURL, envToken, "", "environment variable"
+		}
+	}
+
+	s, err := store.New()
+	if err != nil {
+		return "", "", "", "none"
+	}
+	defer s.Close()
+
+	url, _ := s.LoadServerURL()
+	creds, _ := s.LoadCredentials()
+
+	if url == "" && (creds == nil || creds.Token == "") {
+		return "", "", "", "none"
+	}
+	if creds != nil && creds.Token != "" {
+		return url, creds.Token, creds.Username, "stored credentials"
+	}
+	return url, "", "", "none"
+}
+
+func fillWorkspaceInfo(result *infoResult) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+
+	// Check for pixi.toml in current directory
+	pixiPath := filepath.Join(cwd, "pixi.toml")
+	if _, err := os.Stat(pixiPath); err != nil {
+		return
+	}
+
+	s, err := store.New()
+	if err != nil {
+		return
+	}
+	defer s.Close()
+
+	ws, err := s.FindWorkspaceByPath(cwd)
+	if err != nil || ws == nil {
+		return
+	}
+
+	result.Workspace = ws.Name
+	result.WorkspacePath = ws.Path
+	result.PackageManager = ws.PackageManager
+
+	if ws.OriginName != "" {
+		action := ws.OriginAction
+		if action == "push" {
+			action = "pushed"
+		} else if action == "pull" {
+			action = "pulled"
+		}
+		result.Origin = fmt.Sprintf("%s:%s (%s)", ws.OriginName, ws.OriginTag, action)
+
+		// Check local edits
+		var edits []string
+		localToml, _ := os.ReadFile(filepath.Join(cwd, "pixi.toml"))
+		localLock, _ := os.ReadFile(filepath.Join(cwd, "pixi.lock"))
+		tomlHash, hashErr := store.TomlContentHash(string(localToml))
+		if hashErr == nil && ws.OriginTomlHash != "" && ws.OriginTomlHash != tomlHash {
+			edits = append(edits, "pixi.toml modified")
+		}
+		lockHash := store.ContentHash(string(localLock))
+		if ws.OriginLockHash != "" && ws.OriginLockHash != lockHash {
+			edits = append(edits, "pixi.lock modified")
+		}
+		if len(edits) > 0 {
+			result.LocalEdits = strings.Join(edits, ", ")
+		} else {
+			result.LocalEdits = "none"
+		}
+	} else {
+		result.Origin = "none"
+	}
+}
+
+func formatFeatures(features map[string]bool) string {
+	var enabled []string
+	for k, v := range features {
+		if v {
+			enabled = append(enabled, k)
+		}
+	}
+	if len(enabled) == 0 {
+		return "none"
+	}
+	sort.Strings(enabled)
+	return strings.Join(enabled, ", ")
+}
+
+func shortenPath(path, home string) string {
+	if home != "" && strings.HasPrefix(path, home) {
+		return "~" + path[len(home):]
+	}
+	return path
+}
+
+func printInfo(r infoResult) {
+	fmt.Println("Nebi")
+	fmt.Println("──────────────")
+	printField("Version", r.Version)
+	printField("Platform", r.Platform)
+	printField("Data dir", r.DataDir)
+
+	fmt.Println()
+	fmt.Println("Server")
+	fmt.Println("──────────────")
+	printField("URL", r.ServerURL)
+	if r.ServerURL != "not configured" {
+		printField("Status", r.ServerStatus)
+		if r.ServerVersion != "" {
+			printField("Server version", r.ServerVersion)
+		}
+		if r.ServerMode != "" {
+			printField("Mode", r.ServerMode)
+		}
+		if r.ServerFeatures != "" {
+			printField("Features", r.ServerFeatures)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("Auth")
+	fmt.Println("──────────────")
+	if r.LoggedIn {
+		printField("Logged in", "yes")
+		printField("Username", r.Username)
+	} else {
+		printField("Logged in", "no")
+	}
+	printField("Auth source", r.AuthSource)
+
+	if r.Workspace != "" {
+		fmt.Println()
+		fmt.Println("Workspace")
+		fmt.Println("──────────────")
+		printField("Name", r.Workspace)
+		printField("Path", r.WorkspacePath)
+		printField("Package manager", r.PackageManager)
+		printField("Origin", r.Origin)
+		if r.LocalEdits != "" {
+			printField("Local edits", r.LocalEdits)
+		}
+	}
+}
+
+func printField(label, value string) {
+	fmt.Fprintf(os.Stdout, "%16s: %s\n", label, value)
+}

--- a/cmd/nebi/main.go
+++ b/cmd/nebi/main.go
@@ -68,6 +68,7 @@ func init() {
 	rootCmd.AddCommand(serveCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(completionCmd)
+	rootCmd.AddCommand(infoCmd)
 }
 
 func main() {

--- a/internal/cliclient/auth.go
+++ b/internal/cliclient/auth.go
@@ -44,6 +44,26 @@ func (c *Client) RequestDeviceCode(ctx context.Context) (*DeviceCodeResponse, er
 	return &resp, nil
 }
 
+// GetServerVersion calls GET /version (public, no auth required).
+func (c *Client) GetServerVersion(ctx context.Context) (*ServerVersion, error) {
+	var sv ServerVersion
+	_, err := c.Get(ctx, "/version", &sv)
+	if err != nil {
+		return nil, err
+	}
+	return &sv, nil
+}
+
+// GetCurrentUser calls GET /auth/me to get the authenticated user.
+func (c *Client) GetCurrentUser(ctx context.Context) (*User, error) {
+	var user User
+	_, err := c.Get(ctx, "/auth/me", &user)
+	if err != nil {
+		return nil, err
+	}
+	return &user, nil
+}
+
 // PollDeviceCode checks whether the device code has been completed.
 func (c *Client) PollDeviceCode(ctx context.Context, code string) (*DevicePollResponse, error) {
 	var resp DevicePollResponse

--- a/internal/cliclient/types.go
+++ b/internal/cliclient/types.go
@@ -181,6 +181,17 @@ type AuditLog struct {
 	User        *User       `json:"user,omitempty"`
 }
 
+// ServerVersion represents the response from GET /version.
+type ServerVersion struct {
+	Version   string          `json:"version"`
+	Commit    string          `json:"commit"`
+	GoVersion string          `json:"go_version"`
+	OS        string          `json:"os"`
+	Arch      string          `json:"arch"`
+	Mode      string          `json:"mode"`
+	Features  map[string]bool `json:"features"`
+}
+
 // DashboardStats represents admin dashboard statistics.
 type DashboardStats struct {
 	TotalDiskUsageBytes     int64  `json:"total_disk_usage_bytes"`


### PR DESCRIPTION
## Summary

- Add `nebi info` command that displays comprehensive system, server, auth, and workspace information (similar to `conda info` / `pixi info`)
- Add `GetServerVersion` and `GetCurrentUser` helper methods to cliclient
- Auth info is read entirely from local store — no running server required
- Server version check is optional (3s timeout, graceful degradation)
- Supports `--json` flag for machine-readable output

Example output:
```
Nebi
──────────────
         Version: 0.9.dev+2849dba
        Platform: darwin-arm64
        Data dir: ~/Library/Application Support/nebi

Server
──────────────
             URL: http://localhost:8460
          Status: reachable
  Server version: 0.9.dev+2849dba
            Mode: team
        Features: auth, rbac

Auth
──────────────
       Logged in: yes
        Username: admin
     Auth source: stored credentials

Workspace
──────────────
            Name: nebi
            Path: /Users/aktech/work/nebi
 Package manager: pixi
          Origin: none
```