### PR TITLE
Fix: helpful error when configured server is unreachable

### DIFF
--- a/internal/cliclient/client.go
+++ b/internal/cliclient/client.go
@@ -191,7 +191,7 @@ type ConnectionError struct {
 
 func (e *ConnectionError) Error() string {
 	return fmt.Sprintf(
-		"server at %s is unreachable: %v\n\nHint: If the server should be running, check that it is started.\n  To work in local mode instead, use the --local flag.\n  To remove the configured server, run: nebi logout",
+		"server at %s is unreachable: %v\n\nHint: If the server should be running, check that it is started.\n  To run this command in local mode instead, use the --local flag.\n  To remove the configured server, run: nebi logout",
 		e.ServerURL, e.Err,
 	)
 }

--- a/internal/cliclient/client.go
+++ b/internal/cliclient/client.go
@@ -5,9 +5,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -63,7 +66,7 @@ func (c *Client) request(ctx context.Context, method, path string, body, result 
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, wrapConnectionError(err, c.serverURL())
 	}
 	defer resp.Body.Close()
 
@@ -121,7 +124,7 @@ func (c *Client) GetText(ctx context.Context, path string) (string, *http.Respon
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", nil, err
+		return "", nil, wrapConnectionError(err, c.serverURL())
 	}
 	defer resp.Body.Close()
 
@@ -172,6 +175,56 @@ func IsUnauthorized(err error) bool {
 		return apiErr.StatusCode == 401
 	}
 	return false
+}
+
+// serverURL returns the base server URL (without the /api/v1 suffix).
+func (c *Client) serverURL() string {
+	return strings.TrimSuffix(c.baseURL, "/api/v1")
+}
+
+// ConnectionError wraps a network error with a helpful message when the
+// server is unreachable.
+type ConnectionError struct {
+	ServerURL string
+	Err       error
+}
+
+func (e *ConnectionError) Error() string {
+	return fmt.Sprintf(
+		"server at %s is unreachable: %v\n\nHint: If the server should be running, check that it is started.\n  To work in local mode instead, use the --local flag.\n  To remove the configured server, run: nebi logout",
+		e.ServerURL, e.Err,
+	)
+}
+
+func (e *ConnectionError) Unwrap() error {
+	return e.Err
+}
+
+// IsConnectionError returns true if the error is a ConnectionError.
+func IsConnectionError(err error) bool {
+	var connErr *ConnectionError
+	return errors.As(err, &connErr)
+}
+
+// wrapConnectionError checks if err is a network-level connection failure
+// and wraps it with a helpful message. Non-connection errors pass through.
+func wrapConnectionError(err error, serverURL string) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		var opErr *net.OpError
+		if errors.As(urlErr, &opErr) {
+			return &ConnectionError{ServerURL: serverURL, Err: err}
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return &ConnectionError{ServerURL: serverURL, Err: err}
+		}
+		// DNS resolution failures
+		var dnsErr *net.DNSError
+		if errors.As(urlErr, &dnsErr) {
+			return &ConnectionError{ServerURL: serverURL, Err: err}
+		}
+	}
+	return err
 }
 
 // IsOIDCRedirect returns true if the error indicates the server is behind an

--- a/internal/cliclient/client_test.go
+++ b/internal/cliclient/client_test.go
@@ -1,0 +1,96 @@
+package cliclient
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"testing"
+)
+
+func TestWrapConnectionError_ConnectionRefused(t *testing.T) {
+	// Simulate a "connection refused" error chain: url.Error -> net.OpError
+	inner := &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Err: fmt.Errorf("connect: connection refused"),
+	}
+	urlErr := &url.Error{
+		Op:  "Post",
+		URL: "http://localhost:8460/api/v1/admin/registries",
+		Err: inner,
+	}
+
+	wrapped := wrapConnectionError(urlErr, "http://localhost:8460")
+
+	var connErr *ConnectionError
+	if !errors.As(wrapped, &connErr) {
+		t.Fatalf("expected ConnectionError, got %T: %v", wrapped, wrapped)
+	}
+	if connErr.ServerURL != "http://localhost:8460" {
+		t.Errorf("expected server URL http://localhost:8460, got %s", connErr.ServerURL)
+	}
+	if !errors.As(connErr, &connErr) {
+		t.Error("IsConnectionError should return true")
+	}
+
+	// Verify the message includes hints
+	msg := connErr.Error()
+	for _, want := range []string{"unreachable", "--local", "nebi logout"} {
+		if !contains(msg, want) {
+			t.Errorf("error message missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+func TestWrapConnectionError_DNSError(t *testing.T) {
+	dnsErr := &net.DNSError{
+		Err:  "no such host",
+		Name: "badhost.example.com",
+	}
+	urlErr := &url.Error{
+		Op:  "Get",
+		URL: "http://badhost.example.com/api/v1/workspaces",
+		Err: dnsErr,
+	}
+
+	wrapped := wrapConnectionError(urlErr, "http://badhost.example.com")
+
+	if !IsConnectionError(wrapped) {
+		t.Fatalf("expected ConnectionError for DNS error, got %T: %v", wrapped, wrapped)
+	}
+}
+
+func TestWrapConnectionError_NonNetworkError(t *testing.T) {
+	plainErr := fmt.Errorf("some other error")
+	result := wrapConnectionError(plainErr, "http://localhost:8460")
+
+	if IsConnectionError(result) {
+		t.Fatal("plain error should not be wrapped as ConnectionError")
+	}
+	if result != plainErr {
+		t.Error("non-network error should pass through unchanged")
+	}
+}
+
+func TestWrapConnectionError_APIError(t *testing.T) {
+	apiErr := &APIError{StatusCode: 500, Body: "internal server error"}
+	result := wrapConnectionError(apiErr, "http://localhost:8460")
+
+	if IsConnectionError(result) {
+		t.Fatal("API error should not be wrapped as ConnectionError")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- When a configured server is unreachable, CLI commands now show a clear error with actionable hints instead of a raw `connection refused` / DNS error
- Adds `ConnectionError` type and `wrapConnectionError` helper in `cliclient` that detects network-level failures (`net.OpError`, `net.DNSError`, timeout) and wraps them
- Applied at both `httpClient.Do()` call sites (`request()` and `GetText()`) so all API calls benefit

**Before:**
```
Error: creating registry: Post "http://localhost:8460/api/v1/admin/registries": dial tcp [::1]:8460: connect: connection refused
```

**After:**
```
Error: creating registry: server at http://localhost:8460 is unreachable: ...

Hint: If the server should be running, check that it is started.
  To run this command in local mode instead, use the --local flag.
  To remove the configured server, run: nebi logout
```

Closes #240

## Test plan
- [x] Unit tests for `wrapConnectionError` covering connection refused, DNS errors, non-network errors, and API errors
- [x] `go test ./internal/cliclient/...` passes
- [x] `go test ./internal/store/... ./cmd/nebi/...` passes
- [x] `go vet ./...` clean