### PR TITLE
docs: link nebi-components sections to their detailed docs

### DIFF
--- a/docs/docs/nebi-components.md
+++ b/docs/docs/nebi-components.md
@@ -8,7 +8,7 @@ It has three components: a **CLI**, a **desktop app**, and a **team server**. Al
 
 ## CLI
 
-The CLI is a standalone tool for managing and tracking Pixi workspaces on your local machines. If you have a team server, the CLI can connect to it.
+The CLI is a standalone tool for managing and tracking Pixi workspaces on your local machines, both for [solo use](./cli-local.md) and for [team workflows](./cli-team.md) backed by a Nebi server. Every command is documented in the [CLI reference](./cli-reference.md).
 
 - **Local database**: Track workspace names, paths, and versions in a local database
 - **Pixi shell/run**: Open a pixi shell or run pixi tasks by workspace name
@@ -18,11 +18,11 @@ The CLI is a standalone tool for managing and tracking Pixi workspaces on your l
 
 ## Desktop application
 
-The desktop app is another tool for managing Pixi workspaces on your local machines. It supports all the CLI workflows through a graphical / app interface.
+The [desktop app](./desktop.md) is another tool for managing Pixi workspaces on your local machines. It supports all the CLI workflows through a graphical / app interface.
 
 ## OCI Registries
 
-Nebi can publish workspace specifications (`pixi.toml` & `pixi.lock`) as OCI artifacts to any OCI-compliant registry such as GitHub Container Registry, Quay.io, or self-hosted registries.
+Nebi can publish workspace specifications (`pixi.toml` & `pixi.lock`) as OCI artifacts to any [OCI-compliant registry](./registry-setup.md) such as GitHub Container Registry, Quay.io, or self-hosted registries.
 
 - Publishing can be done from the CLI (`nebi publish`) or triggered from the desktop app or server
 - The desktop app and server UI includes a registry browser for discovering and pulling published workspaces
@@ -31,7 +31,7 @@ Specs are packed into an OCI Image Manifest with custom media types (`applicatio
 
 ## Nebi Server
 
-The server is the team deployment of Nebi. It runs the desktop app interface but in a **server and team mode** with full multi-user support.
+The [Nebi server](./server-setup.md) is the team deployment of Nebi. It runs the desktop app interface but in a **server and team mode** with full multi-user support.
 
 - **Authentication**: JWT-based sessions with pluggable backends — basic auth, OIDC, or proxy auth
 - **Role-based AC**: Apache Casbin-based access control with per-workspace permissions (read, write, admin) for users
@@ -39,3 +39,5 @@ The server is the team deployment of Nebi. It runs the desktop app interface but
 - **Central database**: SQLite (default) or PostgreSQL for workspace and user tracking
 - **Background worker**: Background processor for async operations like workspace creation and package installation
 - **Job queue**: In-memory queue (single instance) or Valkey (distributed deployments) to process workspace creation and updating requests.
+
+Learn more: [Nebi server setup](./server-setup.md).


### PR DESCRIPTION
## Reference Issues or PRs

N/A

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [x] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

`docs/docs/nebi-components.md` describes Nebi's four components (CLI, desktop, OCI registries, server) but didn't link anywhere for readers who wanted to go deeper. This PR weaves one link per component into the existing prose so the components page becomes a jump-off point into the rest of the docs.

Changes (all in `docs/docs/nebi-components.md`):
- **CLI** — three inline links integrated into the intro sentence: [solo use](./cli-local.md), [team workflows](./cli-team.md), and the [CLI reference](./cli-reference.md).
- **Desktop application** — "desktop app" links to `desktop.md`.
- **OCI Registries** — "OCI-compliant registry" links to `registry-setup.md`.
- **Nebi Server** — "Nebi server" links to `server-setup.md`.

Links are woven into the existing sentences rather than added as a trailing "Learn more" line, so the page still reads as a reference description rather than a link hub.

### Access-centered content checklist

#### Text styling

- [x] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [x] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [x] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [x] This content adheres to the Nebari style guides.

#### Non-text content

- [x] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [x] If there are emojis, there are not more than three in a row.
- [x] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [x] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

Companion PR: `docs/flatten-server-docs` collapses `server-overview.md` into `server-setup.md`. This PR already links to `server-setup.md`, so ordering between the two PRs doesn't matter.