### PR TITLE
docs: remove inaccurate .env file instructions from server-setup

### DIFF
--- a/docs/docs/server-setup.md
+++ b/docs/docs/server-setup.md
@@ -16,25 +16,11 @@ Before starting the server for the first time, set `ADMIN_USERNAME` and `ADMIN_P
 
 You (and your team) will use these credentials to log in via `nebi login` or the web UI.
 
-You can set these credentials in your shell or in a `.env` file.
-
-### Option A: Export in your shell
-
-Set the variables directly in your terminal session before starting the server:
+Export the variables in your terminal session before starting the server:
 
 ```bash
 export ADMIN_USERNAME=admin
 export ADMIN_PASSWORD=your-password
-```
-
-### Option B: Use a `.env` file
-
-Create a `.env` file in the directory where you run `nebi serve`:
-
-```bash
-# .env
-ADMIN_USERNAME=admin
-ADMIN_PASSWORD=your-password
 ```
 
 ## Running the Server


### PR DESCRIPTION
## Reference Issues or PRs

N/A

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [x] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

`docs/docs/server-setup.md` previously offered two ways to set `ADMIN_USERNAME` / `ADMIN_PASSWORD`: exporting them in the shell, or creating a `.env` file in the directory where you run `nebi serve`. The second instruction is wrong: `nebi serve` does not load `.env` files.

Evidence:
- No `godotenv` (or any `.env` parser) dependency in `go.mod` / `go.sum`.
- `internal/db/admin.go:17-18` reads the credentials with bare `os.Getenv` calls, so they must already be in the process environment when the binary starts.
- `.env` works in this repo only because the `Makefile` `source`s it before exec'ing the binary (see `Makefile:54`). End users running `nebi serve` directly do not get that behavior.

A user reported the documented `.env` flow not working, which prompted this fix.

Changes:
- Removed Option B (the `.env` file instructions) from the "Admin Credentials" section.
- Removed the now-redundant "Option A" header so the export instructions read as the single, correct path.
- Tightened the lead-in sentence from "You can set these credentials in your shell or in a `.env` file" to a direct instruction to export the variables.

### Access-centered content checklist

#### Text styling

- [x] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [x] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [x] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [x] This content adheres to the Nebari style guides.

#### Non-text content

- [x] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [x] If there are emojis, there are not more than three in a row.
- [x] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [x] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

This PR touches the same file as #250 (`docs/flatten-server-docs`), but they edit different lines (the flatten adds intro content at the top of the file; this PR removes lines from the middle of the "Admin Credentials" section). Whichever lands second should auto-merge cleanly.

Follow-up worth considering separately: if `.env` support is actually a feature we want, the fix is to add `godotenv` (or equivalent) to the `nebi serve` startup path so the documented behavior matches reality. That is a code change, not a docs change, so out of scope here.