### PR TITLE
Add Save & Install to configuration tab, config-driven package management

### DIFF
--- a/frontend/src/api/workspaces.ts
+++ b/frontend/src/api/workspaces.ts
@@ -64,4 +64,9 @@ export const workspacesApi = {
   savePixiToml: async (id: string, content: string): Promise<void> => {
     await apiClient.put(`/workspaces/${id}/pixi-toml`, { content });
   },
+
+  solveWorkspace: async (id: string): Promise<Job> => {
+    const { data } = await apiClient.post(`/workspaces/${id}/solve`);
+    return data;
+  },
 };

--- a/frontend/src/components/workspace/PixiTomlEditor.tsx
+++ b/frontend/src/components/workspace/PixiTomlEditor.tsx
@@ -65,7 +65,7 @@ const parsePixiTomlDependencies = (toml: string): Package[] => {
 };
 
 export const PixiTomlEditor = ({ tomlValue, onTomlChange, workspaceName }: PixiTomlEditorProps) => {
-  const [mode, setMode] = useState<'ui' | 'toml'>('ui');
+  const [mode, setMode] = useState<'ui' | 'toml'>('toml');
   const [packages, setPackages] = useState<Package[]>([{ name: 'python', version: '>=3.11' }]);
   const [newPackageName, setNewPackageName] = useState('');
   const [newPackageVersion, setNewPackageVersion] = useState('');
@@ -113,16 +113,6 @@ export const PixiTomlEditor = ({ tomlValue, onTomlChange, workspaceName }: PixiT
       <div className="flex gap-2 p-1 bg-muted rounded-lg w-fit">
         <Button
           type="button"
-          variant={mode === 'ui' ? 'default' : 'ghost'}
-          size="sm"
-          onClick={() => handleModeSwitch('ui')}
-          className="gap-2"
-        >
-          <Plus className="h-4 w-4" />
-          UI Mode
-        </Button>
-        <Button
-          type="button"
           variant={mode === 'toml' ? 'default' : 'ghost'}
           size="sm"
           onClick={() => handleModeSwitch('toml')}
@@ -130,6 +120,16 @@ export const PixiTomlEditor = ({ tomlValue, onTomlChange, workspaceName }: PixiT
         >
           <FileCode className="h-4 w-4" />
           TOML Mode
+        </Button>
+        <Button
+          type="button"
+          variant={mode === 'ui' ? 'default' : 'ghost'}
+          size="sm"
+          onClick={() => handleModeSwitch('ui')}
+          className="gap-2"
+        >
+          <Plus className="h-4 w-4" />
+          UI Mode
         </Button>
       </div>
 

--- a/frontend/src/pages/WorkspaceDetail.tsx
+++ b/frontend/src/pages/WorkspaceDetail.tsx
@@ -2,20 +2,19 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { buildImportCommand } from '@/lib/registry';
 import { capitalize } from '@/lib/utils';
-import { useWorkspace } from '@/hooks/useWorkspaces';
+import { useWorkspace, useCreateWorkspace, useDeleteWorkspace } from '@/hooks/useWorkspaces';
 import { useModeStore } from '@/store/modeStore';
-import { usePackages, useInstallPackages, useRemovePackage } from '@/hooks/usePackages';
+import { usePackages } from '@/hooks/usePackages';
 import { useCollaborators } from '@/hooks/useAdmin';
 import { usePublications, useUpdatePublication } from '@/hooks/useRegistries';
 import { workspacesApi } from '@/api/workspaces';
 import { useAuthStore } from '@/store/authStore';
 import { useWorkspaceNavStore } from '@/store/workspaceNavStore';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
-import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { ShareButton } from '@/components/sharing/ShareButton';
 import { PublishButton } from '@/components/publishing/PublishButton';
 import { RoleBadge } from '@/components/sharing/RoleBadge';
@@ -23,7 +22,7 @@ import { VersionHistory } from '@/components/versions/VersionHistory';
 import { PixiTomlEditor } from '@/components/workspace/PixiTomlEditor';
 import { Jobs } from '@/components/jobs/Jobs';
 import { UserBadge } from '@/components/ui/user-badge';
-import { ArrowLeft, Loader2, Package, Plus, Trash2, Copy, Check, ExternalLink, Save, HardDrive, Pencil, Globe, Lock, User, Boxes, Users, Calendar, History, Fingerprint, FolderOpen, GitBranch, CircleQuestionMark, IdCard } from 'lucide-react';
+import { ArrowLeft, Loader2, Package, Copy, Check, ExternalLink, Save, HardDrive, Pencil, Globe, Lock, User, Boxes, Users, Calendar, History, Fingerprint, FolderOpen, GitBranch, CircleQuestionMark, IdCard } from 'lucide-react';
 
 const statusColors: Record<string, string> = {
   pending: 'bg-yellow-500/10 text-yellow-500 border-yellow-500/20',
@@ -43,20 +42,19 @@ export const WorkspaceDetail = () => {
   const { data: packages, isLoading: packagesLoading } = usePackages(wsId);
   const { data: collaborators } = useCollaborators(wsId);
   const { data: publications, isLoading: publicationsLoading } = usePublications(wsId);
-  const installMutation = useInstallPackages(wsId);
-  const removeMutation = useRemovePackage(wsId);
   const updatePubMutation = useUpdatePublication();
+  const createMutation = useCreateWorkspace();
+  const deleteMutation = useDeleteWorkspace();
   const currentUser = useAuthStore((state) => state.user);
 
   const [activeTab, setActiveTab] = useState(() => consumePendingTab() || 'overview');
-  const [showInstall, setShowInstall] = useState(false);
-  const [packageInput, setPackageInput] = useState('');
-  const [confirmRemovePackage, setConfirmRemovePackage] = useState<string | null>(null);
   const [error, setError] = useState('');
   const [pixiToml, setPixiToml] = useState<string>('');
   const [editedToml, setEditedToml] = useState<string>('');
   const [isEditingToml, setIsEditingToml] = useState(false);
   const [savingToml, setSavingToml] = useState(false);
+  const [recreateWorkspace, setRecreateWorkspace] = useState(false);
+  const [confirmRecreate, setConfirmRecreate] = useState(false);
   const [loadingToml, setLoadingToml] = useState(false);
   const [copiedToml, setCopiedToml] = useState(false);
   const [copiedPull, setCopiedPull] = useState(false);
@@ -111,37 +109,7 @@ export const WorkspaceDetail = () => {
     setTimeout(() => setCopiedImportId(null), 2000);
   };
 
-  const handleInstall = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!packageInput.trim()) return;
 
-    setError('');
-    const packageNames = packageInput.split(',').map(p => p.trim()).filter(Boolean);
-
-    try {
-      await installMutation.mutateAsync({ packages: packageNames });
-      setPackageInput('');
-      setShowInstall(false);
-    } catch (err) {
-      const error = err as { response?: { data?: { error?: string } } };
-      const errorMessage = error?.response?.data?.error || 'Failed to install package. Please try again.';
-      setError(errorMessage);
-    }
-  };
-
-  const handleRemove = async () => {
-    if (!confirmRemovePackage) return;
-
-    setError('');
-    try {
-      await removeMutation.mutateAsync(confirmRemovePackage);
-      setConfirmRemovePackage(null);
-    } catch (err) {
-      const error = err as { response?: { data?: { error?: string } } };
-      const errorMessage = error?.response?.data?.error || 'Failed to remove package. Please try again.';
-      setError(errorMessage);
-    }
-  };
 
   if (wsLoading) {
     return (
@@ -234,9 +202,9 @@ export const WorkspaceDetail = () => {
       }}>
         <TabsList>
           <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="packages">Packages</TabsTrigger>
           <TabsTrigger value="toml">Configuration</TabsTrigger>
           <TabsTrigger value="versions">Versions</TabsTrigger>
+          <TabsTrigger value="packages">Packages</TabsTrigger>
           <TabsTrigger value="jobs">Jobs</TabsTrigger>
           <TabsTrigger value="publications">
             Publications ({publications?.length || 0})
@@ -423,49 +391,12 @@ export const WorkspaceDetail = () => {
           <div className="space-y-4 my-3">
             <div className="flex justify-between items-center  mb-0">
               <h2 className="text-2xl font-bold">Packages</h2>
-              <Button
-                onClick={() => {
-                  setShowInstall(!showInstall);
-                  setError('');
-                }}
-                disabled={workspace.status !== 'ready'}
-              >
-                <Plus className="h-4 w-4 mr-2" />
-                Install Package
-              </Button>
             </div>
           <div>
           <p className="text-muted-foreground text-sm mt-1">
-            Manage packages for the current version. Editing packages will create a new version of the workspace.
+            Packages installed in the current version. Edit the configuration to change packages.
           </p>
         </div>
-
-        {showInstall && (
-          <Card>
-            <CardContent className="pt-6">
-              <form onSubmit={handleInstall} className="flex gap-2">
-                <Input
-                  placeholder="Package name (e.g., python=3.11, numpy)"
-                  value={packageInput}
-                  onChange={(e) => setPackageInput(e.target.value)}
-                  autoFocus
-                />
-                <Button type="submit" disabled={installMutation.isPending}>
-                  {installMutation.isPending ? 'Installing...' : 'Install'}
-                </Button>
-                <Button type="button" variant="outline" onClick={() => {
-                  setShowInstall(false);
-                  setError('');
-                }}>
-                  Cancel
-                </Button>
-              </form>
-              <p className="text-sm text-muted-foreground mt-2">
-                Separate multiple packages with commas
-              </p>
-            </CardContent>
-          </Card>
-        )}
 
         {error && (
           <div className="bg-red-500/10 border border-red-500/20 text-red-500 px-4 py-3 rounded">
@@ -486,13 +417,12 @@ export const WorkspaceDetail = () => {
                     <tr>
                       <th className="text-left p-4 font-medium">Package</th>
                       <th className="text-left p-4 font-medium">Installed Version</th>
-                      <th className="text-right p-4 font-medium">Actions</th>
                     </tr>
                   </thead>
                   <tbody className="divide-y">
                     {packages?.length === 0 ? (
                       <tr>
-                        <td colSpan={3} className="p-8 text-center text-muted-foreground">
+                        <td colSpan={2} className="p-8 text-center text-muted-foreground">
                           No packages installed
                         </td>
                       </tr>
@@ -508,16 +438,6 @@ export const WorkspaceDetail = () => {
                           <td className="p-4 text-muted-foreground font-mono text-sm">
                             {pkg.version || '-'}
                           </td>
-                          <td className="p-4 text-right">
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => setConfirmRemovePackage(pkg.name)}
-                              disabled={removeMutation.isPending || workspace.status !== 'ready'}
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </Button>
-                          </td>
                         </tr>
                       ))
                     )}
@@ -528,11 +448,6 @@ export const WorkspaceDetail = () => {
           </Card>
         )}
 
-            {packages?.length === 0 && !showInstall && (
-              <div className="text-center py-12">
-                <p className="text-muted-foreground">No packages installed yet</p>
-              </div>
-            )}
           </div>
         </TabsContent>
 
@@ -564,33 +479,41 @@ export const WorkspaceDetail = () => {
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={() => setIsEditingToml(false)}
+                      onClick={() => {
+                        setIsEditingToml(false);
+                        setRecreateWorkspace(false);
+                      }}
                     >
                       Cancel
                     </Button>
                     <Button
                       size="sm"
                       onClick={async () => {
+                        if (recreateWorkspace) {
+                          setConfirmRecreate(true);
+                          return;
+                        }
                         setSavingToml(true);
                         try {
                           await workspacesApi.savePixiToml(wsId, editedToml);
+                          await workspacesApi.solveWorkspace(wsId);
                           setPixiToml(editedToml);
                           setIsEditingToml(false);
                         } catch {
-                          setError('Failed to save pixi.toml');
+                          setError('Failed to save and install pixi.toml');
                         } finally {
                           setSavingToml(false);
                         }
                       }}
-                      disabled={savingToml}
+                      disabled={savingToml || createMutation.isPending || deleteMutation.isPending}
                       className="gap-2"
                     >
-                      {savingToml ? (
+                      {savingToml || createMutation.isPending || deleteMutation.isPending ? (
                         <Loader2 className="h-4 w-4 animate-spin" />
                       ) : (
                         <Save className="h-4 w-4" />
                       )}
-                      Save
+                      {recreateWorkspace ? 'Save & Recreate' : 'Save & Install'}
                     </Button>
                   </>
                 )}
@@ -625,11 +548,24 @@ export const WorkspaceDetail = () => {
                 <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
               </div>
             ) : isEditingToml ? (
-              <PixiTomlEditor
-                tomlValue={editedToml}
-                onTomlChange={setEditedToml}
-                workspaceName={workspace.name}
-              />
+              <>
+                <PixiTomlEditor
+                  tomlValue={editedToml}
+                  onTomlChange={setEditedToml}
+                  workspaceName={workspace.name}
+                />
+                {workspace.source !== 'local' && (
+                  <label className={`inline-flex items-center gap-2 mt-4 cursor-pointer select-none rounded-md px-3 h-9 text-sm font-medium ${recreateWorkspace ? 'bg-primary text-primary-foreground' : 'bg-secondary text-secondary-foreground'}`}>
+                    <input
+                      type="checkbox"
+                      checked={recreateWorkspace}
+                      onChange={(e) => setRecreateWorkspace(e.target.checked)}
+                      className="rounded accent-purple-500"
+                    />
+                    Recreate workspace
+                  </label>
+                )}
+              </>
             ) : pixiToml ? (
               <pre className="bg-slate-900 text-slate-100 p-4 rounded-md overflow-x-auto font-mono text-sm whitespace-pre">
                 {pixiToml}
@@ -799,12 +735,29 @@ export const WorkspaceDetail = () => {
       </Tabs>
 
       <ConfirmDialog
-        open={!!confirmRemovePackage}
-        onOpenChange={(open) => !open && setConfirmRemovePackage(null)}
-        onConfirm={handleRemove}
-        title="Remove Package"
-        description={`Are you sure you want to remove the package "${confirmRemovePackage}"? This will uninstall it from the workspace.`}
-        confirmText="Remove"
+        open={confirmRecreate}
+        onOpenChange={setConfirmRecreate}
+        onConfirm={async () => {
+          setSavingToml(true);
+          try {
+            await workspacesApi.savePixiToml(wsId, editedToml);
+            await deleteMutation.mutateAsync(wsId);
+            const ws = await createMutation.mutateAsync({
+              name: workspace.name,
+              package_manager: 'pixi',
+              pixi_toml: editedToml,
+            });
+            navigate(`/workspaces/${ws.id}`);
+          } catch {
+            setError('Failed to recreate workspace');
+          } finally {
+            setSavingToml(false);
+            setRecreateWorkspace(false);
+          }
+        }}
+        title="Recreate Workspace"
+        description="This will delete and recreate the workspace from scratch. All job history and version snapshots will be lost, and rollbacks to previous versions will no longer be available."
+        confirmText="Recreate"
         cancelText="Cancel"
         variant="destructive"
       />

--- a/frontend/src/pages/Workspaces.tsx
+++ b/frontend/src/pages/Workspaces.tsx
@@ -5,14 +5,13 @@ import { useRemoteServer, useRemoteWorkspaces, useCreateRemoteWorkspace, useDele
 import { useModeStore } from '@/store/modeStore';
 import { useViewModeStore } from '@/store/viewModeStore';
 import { useWorkspaceNavStore } from '@/store/workspaceNavStore';
-import { workspacesApi } from '@/api/workspaces';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { PixiTomlEditor } from '@/components/workspace/PixiTomlEditor';
-import { Loader2, Plus, Trash2, X, Edit, Copy, Check, Download } from 'lucide-react';
+import { Loader2, Plus, Trash2, X, Copy, Check, Download } from 'lucide-react';
 import { SplitButton } from '@/components/ui/split-button';
 import { capitalize } from '@/lib/utils';
 
@@ -68,11 +67,6 @@ export const Workspaces = () => {
   const [localPath, setLocalPath] = useState('');
   const [pixiToml, setPixiToml] = useState(DEFAULT_PIXI_TOML);
 
-  const [showEdit, setShowEdit] = useState(false);
-  const [editWsId, setEditWsId] = useState<string | null>(null);
-  const [editWsName, setEditWsName] = useState('');
-  const [editPixiToml, setEditPixiToml] = useState('');
-  const [loadingEdit, setLoadingEdit] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState<{ id: string; name: string; location: 'local' | 'remote' } | null>(null);
   const [error, setError] = useState('');
   const [copiedPullId, setCopiedPullId] = useState<string | null>(null);
@@ -191,51 +185,6 @@ export const Workspaces = () => {
     }
   };
 
-  const handleEdit = async (id: string, name: string) => {
-    setLoadingEdit(true);
-    setError('');
-    try {
-      const { content } = await workspacesApi.getPixiToml(id);
-      setEditWsId(id);
-      setEditWsName(name);
-      setEditPixiToml(content);
-      setShowEdit(true);
-    } catch (err) {
-      const error = err as { response?: { data?: { error?: string } } };
-      const errorMessage = error?.response?.data?.error || 'Failed to load pixi.toml content. Please try again.';
-      setError(errorMessage);
-    } finally {
-      setLoadingEdit(false);
-    }
-  };
-
-  const handleEditSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!editWsId || !editWsName.trim()) return;
-
-    setError('');
-    try {
-      await deleteMutation.mutateAsync(editWsId);
-
-      const ws = await createMutation.mutateAsync({
-        name: editWsName,
-        package_manager: 'pixi',
-        pixi_toml: editPixiToml
-      });
-
-      setShowEdit(false);
-      setEditWsId(null);
-      setEditWsName('');
-      setEditPixiToml('');
-
-      setPendingTab('jobs');
-      navigate(`/workspaces/${ws.id}`);
-    } catch (err) {
-      const error = err as { response?: { data?: { error?: string } } };
-      const errorMessage = error?.response?.data?.error || 'Failed to update workspace. Please try again.';
-      setError(errorMessage);
-    }
-  };
 
   const handleCopyPull = async (e: React.MouseEvent, wsName: string, wsId: string) => {
     e.stopPropagation();
@@ -353,53 +302,6 @@ export const Workspaces = () => {
         </Card>
       )}
 
-      {showEdit && (
-        <Card>
-          <CardHeader>
-            <div className="flex justify-between items-center">
-              <CardTitle>Edit Workspace - {editWsName}</CardTitle>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => setShowEdit(false)}
-              >
-                <X className="h-4 w-4" />
-              </Button>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <form onSubmit={handleEditSubmit} className="space-y-4">
-              <div className="space-y-2">
-                <label className="text-sm font-medium">Workspace Name</label>
-                <Input
-                  placeholder="e.g., my-data-project"
-                  value={editWsName}
-                  onChange={(e) => setEditWsName(e.target.value)}
-                  required
-                />
-              </div>
-
-              <PixiTomlEditor tomlValue={editPixiToml} onTomlChange={setEditPixiToml} workspaceName={editWsName || 'my-project'} />
-
-              <div className="flex gap-2 justify-end">
-                <Button type="button" variant="outline" onClick={() => setShowEdit(false)}>
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={createMutation.isPending || deleteMutation.isPending}>
-                  {createMutation.isPending || deleteMutation.isPending ? (
-                    <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Recreating...
-                    </>
-                  ) : (
-                    'Save & Recreate'
-                  )}
-                </Button>
-              </div>
-            </form>
-          </CardContent>
-        </Card>
-      )}
 
       <Card>
         <CardContent className="p-0">
@@ -463,24 +365,7 @@ export const Workspaces = () => {
                             )}
                           </Button>
                         )}
-                        {ws.location === 'local' && ws.source !== 'local' && (
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleEdit(ws.id, ws.name);
-                            }}
-                            disabled={loadingEdit || (ws.status !== 'ready' && ws.status !== 'failed')}
-                            title={
-                              ws.status === 'pending' || ws.status === 'creating' || ws.status === 'deleting'
-                                ? 'Cannot edit while workspace is being processed'
-                                : 'Edit pixi.toml'
-                            }
-                          >
-                            <Edit className="h-4 w-4" />
-                          </Button>
-                        )}
+
                         <Button
                           variant="ghost"
                           size="sm"
@@ -518,6 +403,7 @@ export const Workspaces = () => {
         cancelText="Cancel"
         variant="destructive"
       />
+
     </div>
   );
 };

--- a/internal/api/handlers/workspace.go
+++ b/internal/api/handlers/workspace.go
@@ -212,6 +212,55 @@ func (h *WorkspaceHandler) SavePixiToml(c *gin.Context) {
 	c.JSON(http.StatusOK, PixiTomlResponse(req))
 }
 
+// SolveWorkspace godoc
+// @Summary Solve and install environment from current pixi.toml
+// @Tags workspaces
+// @Security BearerAuth
+// @Produce json
+// @Param id path string true "Workspace ID"
+// @Success 202 {object} models.Job
+// @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /workspaces/{id}/solve [post]
+func (h *WorkspaceHandler) SolveWorkspace(c *gin.Context) {
+	userID := getUserID(c)
+	wsID := c.Param("id")
+
+	var ws models.Workspace
+	if err := h.db.Where("id = ?", wsID).First(&ws).Error; err != nil {
+		c.JSON(http.StatusNotFound, ErrorResponse{Error: "Workspace not found"})
+		return
+	}
+
+	if ws.Status != models.WsStatusReady {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Workspace is not ready"})
+		return
+	}
+
+	job := &models.Job{
+		Type:        models.JobTypeUpdate,
+		WorkspaceID: ws.ID,
+		Status:      models.JobStatusPending,
+		Metadata:    map[string]interface{}{},
+	}
+
+	if err := h.db.Create(job).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to create job"})
+		return
+	}
+
+	if err := h.queue.Enqueue(c.Request.Context(), job); err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to queue job"})
+		return
+	}
+
+	audit.LogAction(h.db, userID, audit.ActionSolveWorkspace, fmt.Sprintf("ws:%s", ws.ID.String()), nil)
+
+	c.JSON(http.StatusAccepted, job)
+}
+
 // PushVersion godoc
 // @Summary Push a new version to the server
 // @Description Create a new workspace version and assign a tag

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -206,6 +206,7 @@ func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Exe
 			ws.PUT("/pixi-toml", middleware.RequireWorkspaceAccess("write", localMode), wsHandler.SavePixiToml)
 			ws.DELETE("", middleware.RequireWorkspaceAccess("write", localMode), wsHandler.DeleteWorkspace)
 			ws.POST("/packages", middleware.RequireWorkspaceAccess("write", localMode), wsHandler.InstallPackages)
+			ws.POST("/solve", middleware.RequireWorkspaceAccess("write", localMode), wsHandler.SolveWorkspace)
 			ws.DELETE("/packages/:package", middleware.RequireWorkspaceAccess("write", localMode), wsHandler.RemovePackages)
 			ws.POST("/rollback", middleware.RequireWorkspaceAccess("write", localMode), wsHandler.RollbackToVersion)
 

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -40,6 +40,7 @@ const (
 	ActionDeleteWorkspace  = "delete_workspace"
 	ActionInstallPackage   = "install_package"
 	ActionRemovePackage    = "remove_package"
+	ActionSolveWorkspace   = "solve_workspace"
 	ActionPublishWorkspace = "publish_workspace"
 	ActionPush             = "push"
 	ActionReassignTag      = "reassign_tag"

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -21,6 +21,9 @@ type Executor interface {
 	// DeleteWorkspace removes a workspace
 	DeleteWorkspace(ctx context.Context, ws *models.Workspace, logWriter io.Writer) error
 
+	// SolveEnvironment runs pixi install to solve and install the current pixi.toml
+	SolveEnvironment(ctx context.Context, ws *models.Workspace, logWriter io.Writer) error
+
 	// GetWorkspacePath returns the filesystem path for a workspace
 	GetWorkspacePath(ws *models.Workspace) string
 }

--- a/internal/executor/local.go
+++ b/internal/executor/local.go
@@ -220,6 +220,42 @@ func (e *LocalExecutor) RemovePackages(ctx context.Context, ws *models.Workspace
 	return nil
 }
 
+// SolveEnvironment runs pixi install to solve and install the current pixi.toml
+func (e *LocalExecutor) SolveEnvironment(ctx context.Context, ws *models.Workspace, logWriter io.Writer) error {
+	envPath := e.GetWorkspacePath(ws)
+
+	fmt.Fprintf(logWriter, "Running pixi install to solve environment...\n")
+
+	// Get pixi binary path
+	pmType := ws.PackageManager
+	if pmType == "" {
+		pmType = e.config.PackageManager.DefaultType
+	}
+
+	pixiBinary := "pixi"
+	if pmType == "pixi" && e.config.PackageManager.PixiPath != "" {
+		pm, err := pkgmgr.NewWithPath(pmType, e.config.PackageManager.PixiPath)
+		if err == nil {
+			if pixiMgr, ok := pm.(*pixi.PixiManager); ok {
+				pixiBinary = pixiMgr.BinaryPath()
+			}
+		}
+	}
+
+	cmd := exec.CommandContext(ctx, pixiBinary, "install", "-v")
+	cmd.Dir = envPath
+	cmd.Stdout = logWriter
+	cmd.Stderr = logWriter
+
+	fmt.Fprintf(logWriter, "Running: pixi install -v\n")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("pixi install failed: %w", err)
+	}
+
+	fmt.Fprintf(logWriter, "Environment solved and installed successfully\n")
+	return nil
+}
+
 // DeleteWorkspace removes a workspace from the filesystem.
 // For source=="local" workspaces the directory belongs to the user, so we
 // only deregister (the caller handles DB cleanup) and never touch the filesystem.

--- a/internal/swagger/docs.go
+++ b/internal/swagger/docs.go
@@ -2003,6 +2003,63 @@ const docTemplate = `{
                 }
             }
         },
+        "/workspaces/{id}/solve": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Solve and install environment from current pixi.toml",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/models.Job"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces/{id}/tags": {
             "get": {
                 "security": [

--- a/internal/swagger/swagger.json
+++ b/internal/swagger/swagger.json
@@ -1997,6 +1997,63 @@
                 }
             }
         },
+        "/workspaces/{id}/solve": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Solve and install environment from current pixi.toml",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/models.Job"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces/{id}/tags": {
             "get": {
                 "security": [

--- a/internal/swagger/swagger.yaml
+++ b/internal/swagger/swagger.yaml
@@ -1793,6 +1793,42 @@ paths:
       summary: Revoke user access to workspace (owner only)
       tags:
       - workspaces
+  /workspaces/{id}/solve:
+    post:
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/models.Job'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Solve and install environment from current pixi.toml
+      tags:
+      - workspaces
   /workspaces/{id}/tags:
     get:
       parameters:

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -378,6 +378,27 @@ func (w *Worker) executeJob(ctx context.Context, job *models.Job, logWriter io.W
 			w.logger.Error("Failed to create version snapshot", "error", err)
 		}
 
+	case models.JobTypeUpdate:
+		fmt.Fprintf(logWriter, "Solving environment from current pixi.toml...\n")
+
+		if err := w.executor.SolveEnvironment(ctx, &ws, logWriter); err != nil {
+			return err
+		}
+
+		// Sync packages from environment
+		if err := w.syncPackagesFromWorkspace(ctx, &ws); err != nil {
+			w.logger.Error("Failed to sync packages after solve", "error", err)
+		}
+
+		// Update workspace size
+		w.updateWorkspaceSize(&ws)
+		w.db.Save(&ws)
+
+		// Create version snapshot
+		if err := w.createVersionSnapshot(ctx, &ws, job, "Solved environment from updated pixi.toml"); err != nil {
+			w.logger.Error("Failed to create version snapshot", "error", err)
+		}
+
 	case models.JobTypeDelete:
 		ws.Status = models.WsStatusDeleting
 		w.db.Save(&ws)


### PR DESCRIPTION
## Summary

- **Save & Install on Configuration tab**: Saving the pixi.toml now triggers a `pixi install` job to solve and apply the environment, replacing the old per-package install workflow.
- **Recreate workspace checkbox**: A toggle on the Configuration tab lets users opt into a full delete-and-recreate flow (with a destructive confirmation dialog warning that job history and rollbacks will be lost).
- **Packages tab is now read-only**: Install/delete buttons removed — packages are managed through the Configuration tab's TOML editor.
- **Edit workspace screen removed**: The edit button and edit card on the workspace list page are removed. Editing is now done on the workspace's Configuration tab.
- **UX improvements**: TOML Mode is now the default editor mode (moved to the left), and the tab order is reordered to Overview | Configuration | Versions | Packages | Jobs | ...

### Backend changes
- `SolveEnvironment` added to the `Executor` interface and `LocalExecutor` (runs `pixi install -v`)
- `JobTypeUpdate` handled in the worker (solve, sync packages, create version snapshot)
- `POST /workspaces/:id/solve` endpoint with RBAC and audit logging

### Frontend changes
- `solveWorkspace` API client method
- Configuration tab Save button triggers save + solve
- "Recreate workspace" checkbox with styled toggle and destructive confirmation dialog
- Packages tab stripped to read-only display
- Edit workspace screen and buttons removed from workspace list

## Test plan
- [x] Edit pixi.toml on Configuration tab, click Save & Install — verify solve job runs and packages sync
- [x] Check "Recreate workspace", click Save & Recreate — verify warning dialog appears, workspace is deleted and recreated
- [x] Verify Packages tab is read-only (no install/delete buttons)
- [x] Verify no Edit button on workspace list page
- [x] Verify TOML Mode is the default when clicking Edit on Configuration tab