### PR TITLE
Add Google Analytics (GA4) tracking to nebi.nebari.dev

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -41,6 +41,10 @@ const config: Config = {
     [
       'classic',
       {
+        gtag: {
+          trackingID: 'G-NXNMX83GGS',
+          anonymizeIP: true,
+        },
         docs: {
           sidebarPath: './sidebars.ts',
           sidebarCollapsible: true,


### PR DESCRIPTION
## Reference Issues or PRs

Related to #201 - Adding Google Analytics (GA4) tracking instead of Plausible for analytics capabilities.

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Any other comments?

This uses the same GA4 measurement ID as nebari.dev so both sites report into a single stream. Traffic can be filtered by hostname in GA4 reports. `anonymizeIP: true` is enabled to truncate visitor IP addresses for privacy/GDPR compliance.
