### PR TITLE
refactor: extract AdminService, RegistryService, JobService from handlers

### DIFF
--- a/internal/api/handlers/admin.go
+++ b/internal/api/handlers/admin.go
@@ -1,24 +1,20 @@
 package handlers
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"github.com/nebari-dev/nebi/internal/audit"
 	"github.com/nebari-dev/nebi/internal/models"
-	"github.com/nebari-dev/nebi/internal/rbac"
-	"golang.org/x/crypto/bcrypt"
-	"gorm.io/gorm"
+	"github.com/nebari-dev/nebi/internal/service"
 )
 
 type AdminHandler struct {
-	db *gorm.DB
+	svc *service.AdminService
 }
 
-func NewAdminHandler(db *gorm.DB) *AdminHandler {
-	return &AdminHandler{db: db}
+func NewAdminHandler(svc *service.AdminService) *AdminHandler {
+	return &AdminHandler{svc: svc}
 }
 
 // ListUsers godoc
@@ -26,32 +22,15 @@ func NewAdminHandler(db *gorm.DB) *AdminHandler {
 // @Tags admin
 // @Security BearerAuth
 // @Produce json
-// @Success 200 {array} UserWithAdminStatus
+// @Success 200 {array} service.UserWithAdmin
 // @Router /admin/users [get]
 func (h *AdminHandler) ListUsers(c *gin.Context) {
-	var users []models.User
-	if err := h.db.Find(&users).Error; err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to fetch users"})
-		return
-	}
-
-	// Get all admin user IDs in ONE Casbin call
-	adminUserIDs, err := rbac.GetAllAdminUserIDs()
+	users, err := h.svc.ListUsers()
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to check admin status"})
+		handleServiceError(c, err)
 		return
 	}
-
-	// Build response with admin status using O(1) map lookup
-	usersWithStatus := make([]UserWithAdminStatus, len(users))
-	for i, user := range users {
-		usersWithStatus[i] = UserWithAdminStatus{
-			User:    user,
-			IsAdmin: adminUserIDs[user.ID],
-		}
-	}
-
-	c.JSON(http.StatusOK, usersWithStatus)
+	c.JSON(http.StatusOK, users)
 }
 
 // CreateUser godoc
@@ -64,47 +43,22 @@ func (h *AdminHandler) ListUsers(c *gin.Context) {
 // @Success 201 {object} models.User
 // @Router /admin/users [post]
 func (h *AdminHandler) CreateUser(c *gin.Context) {
-	adminUser := c.MustGet("user").(*models.User)
-
 	var req CreateUserRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
 		return
 	}
 
-	// Hash password
-	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	user, err := h.svc.CreateUser(service.CreateUserRequest{
+		Username: req.Username,
+		Email:    req.Email,
+		Password: req.Password,
+		IsAdmin:  req.IsAdmin,
+	}, getAdminUserID(c))
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to hash password"})
+		handleServiceError(c, err)
 		return
 	}
-
-	user := models.User{
-		Username:     req.Username,
-		Email:        req.Email,
-		PasswordHash: string(hashedPassword),
-	}
-
-	if err := h.db.Create(&user).Error; err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to create user"})
-		return
-	}
-
-	// If admin flag is set, grant admin permissions
-	if req.IsAdmin {
-		if err := rbac.MakeAdmin(user.ID); err != nil {
-			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to grant admin permissions"})
-			return
-		}
-	}
-
-	// Audit log
-	audit.LogAction(h.db, adminUser.ID, audit.ActionCreateUser, "user:"+user.ID.String(), map[string]interface{}{
-		"username": user.Username,
-		"email":    user.Email,
-		"is_admin": req.IsAdmin,
-	})
-
 	c.JSON(http.StatusCreated, user)
 }
 
@@ -113,29 +67,21 @@ func (h *AdminHandler) CreateUser(c *gin.Context) {
 // @Tags admin
 // @Security BearerAuth
 // @Param id path string true "User UUID"
-// @Success 200 {object} UserWithAdminStatus
+// @Success 200 {object} service.UserWithAdmin
 // @Router /admin/users/{id} [get]
 func (h *AdminHandler) GetUser(c *gin.Context) {
-	userIDStr := c.Param("id")
-	userID, err := uuid.Parse(userIDStr)
+	userID, err := uuid.Parse(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Invalid user ID"})
 		return
 	}
 
-	var user models.User
-	if err := h.db.First(&user, "id = ?", userID).Error; err != nil {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "User not found"})
+	user, err := h.svc.GetUser(userID)
+	if err != nil {
+		handleServiceError(c, err)
 		return
 	}
-
-	// Check if user is admin
-	isAdmin, _ := rbac.IsAdmin(user.ID)
-
-	c.JSON(http.StatusOK, UserWithAdminStatus{
-		User:    user,
-		IsAdmin: isAdmin,
-	})
+	c.JSON(http.StatusOK, user)
 }
 
 // ToggleAdmin godoc
@@ -143,46 +89,21 @@ func (h *AdminHandler) GetUser(c *gin.Context) {
 // @Tags admin
 // @Security BearerAuth
 // @Param id path string true "User UUID"
-// @Success 200 {object} UserWithAdminStatus
+// @Success 200 {object} service.UserWithAdmin
 // @Router /admin/users/{id}/toggle-admin [post]
 func (h *AdminHandler) ToggleAdmin(c *gin.Context) {
-	adminUser := c.MustGet("user").(*models.User)
-	userIDStr := c.Param("id")
-
-	userID, err := uuid.Parse(userIDStr)
+	userID, err := uuid.Parse(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Invalid user ID"})
 		return
 	}
 
-	var user models.User
-	if err := h.db.First(&user, "id = ?", userID).Error; err != nil {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "User not found"})
+	result, err := h.svc.ToggleAdmin(userID, getAdminUserID(c))
+	if err != nil {
+		handleServiceError(c, err)
 		return
 	}
-
-	// Check current admin status
-	isAdmin, _ := rbac.IsAdmin(user.ID)
-
-	// Toggle admin status
-	if isAdmin {
-		if err := rbac.RevokeAdmin(user.ID); err != nil {
-			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to revoke admin"})
-			return
-		}
-		audit.LogAction(h.db, adminUser.ID, audit.ActionRevokeAdmin, "user:"+user.ID.String(), nil)
-	} else {
-		if err := rbac.MakeAdmin(user.ID); err != nil {
-			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to make admin"})
-			return
-		}
-		audit.LogAction(h.db, adminUser.ID, audit.ActionMakeAdmin, "user:"+user.ID.String(), nil)
-	}
-
-	c.JSON(http.StatusOK, UserWithAdminStatus{
-		User:    user,
-		IsAdmin: !isAdmin,
-	})
+	c.JSON(http.StatusOK, result)
 }
 
 // DeleteUser godoc
@@ -193,37 +114,16 @@ func (h *AdminHandler) ToggleAdmin(c *gin.Context) {
 // @Success 204
 // @Router /admin/users/{id} [delete]
 func (h *AdminHandler) DeleteUser(c *gin.Context) {
-	adminUser := c.MustGet("user").(*models.User)
-	userIDStr := c.Param("id")
-
-	userID, err := uuid.Parse(userIDStr)
+	userID, err := uuid.Parse(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Invalid user ID"})
 		return
 	}
 
-	// Can't delete yourself
-	if userID == adminUser.ID {
-		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Cannot delete yourself"})
+	if err := h.svc.DeleteUser(userID, getAdminUserID(c)); err != nil {
+		handleServiceError(c, err)
 		return
 	}
-
-	var user models.User
-	if err := h.db.First(&user, "id = ?", userID).Error; err != nil {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "User not found"})
-		return
-	}
-
-	if err := h.db.Delete(&user).Error; err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to delete user"})
-		return
-	}
-
-	// Audit log
-	audit.LogAction(h.db, adminUser.ID, audit.ActionDeleteUser, "user:"+user.ID.String(), map[string]interface{}{
-		"username": user.Username,
-	})
-
 	c.Status(http.StatusNoContent)
 }
 
@@ -235,12 +135,11 @@ func (h *AdminHandler) DeleteUser(c *gin.Context) {
 // @Success 200 {array} models.Role
 // @Router /admin/roles [get]
 func (h *AdminHandler) ListRoles(c *gin.Context) {
-	var roles []models.Role
-	if err := h.db.Find(&roles).Error; err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to fetch roles"})
+	roles, err := h.svc.ListRoles()
+	if err != nil {
+		handleServiceError(c, err)
 		return
 	}
-
 	c.JSON(http.StatusOK, roles)
 }
 
@@ -254,61 +153,18 @@ func (h *AdminHandler) ListRoles(c *gin.Context) {
 // @Success 201 {object} models.Permission
 // @Router /admin/permissions [post]
 func (h *AdminHandler) GrantPermission(c *gin.Context) {
-	adminUser := c.MustGet("user").(*models.User)
-
 	var req GrantPermissionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
 		return
 	}
 
-	// Verify user exists
-	var user models.User
-	if err := h.db.First(&user, "id = ?", req.UserID).Error; err != nil {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "User not found"})
+	perm, err := h.svc.GrantPermission(req.UserID, req.WorkspaceID, req.RoleID, getAdminUserID(c))
+	if err != nil {
+		handleServiceError(c, err)
 		return
 	}
-
-	// Verify workspace exists
-	var ws models.Workspace
-	if err := h.db.First(&ws, "id = ?", req.WorkspaceID).Error; err != nil {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "Workspace not found"})
-		return
-	}
-
-	// Verify role exists
-	var role models.Role
-	if err := h.db.First(&role, req.RoleID).Error; err != nil {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "Role not found"})
-		return
-	}
-
-	// Create permission record
-	permission := models.Permission{
-		UserID:      req.UserID,
-		WorkspaceID: req.WorkspaceID,
-		RoleID:      req.RoleID,
-	}
-
-	if err := h.db.Create(&permission).Error; err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to create permission"})
-		return
-	}
-
-	// Grant in RBAC
-	if err := rbac.GrantWorkspaceAccess(user.ID, ws.ID, role.Name); err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to grant RBAC permission"})
-		return
-	}
-
-	// Audit log
-	audit.LogAction(h.db, adminUser.ID, audit.ActionGrantPermission, "permission:"+string(rune(permission.ID)), map[string]interface{}{
-		"user_id":      req.UserID,
-		"workspace_id": req.WorkspaceID,
-		"role":         role.Name,
-	})
-
-	c.JSON(http.StatusCreated, permission)
+	c.JSON(http.StatusCreated, perm)
 }
 
 // ListPermissions godoc
@@ -319,12 +175,11 @@ func (h *AdminHandler) GrantPermission(c *gin.Context) {
 // @Success 200 {array} models.Permission
 // @Router /admin/permissions [get]
 func (h *AdminHandler) ListPermissions(c *gin.Context) {
-	var permissions []models.Permission
-	if err := h.db.Preload("User").Preload("Workspace").Preload("Role").Find(&permissions).Error; err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to fetch permissions"})
+	permissions, err := h.svc.ListPermissions()
+	if err != nil {
+		handleServiceError(c, err)
 		return
 	}
-
 	c.JSON(http.StatusOK, permissions)
 }
 
@@ -336,33 +191,10 @@ func (h *AdminHandler) ListPermissions(c *gin.Context) {
 // @Success 204
 // @Router /admin/permissions/{id} [delete]
 func (h *AdminHandler) RevokePermission(c *gin.Context) {
-	adminUser := c.MustGet("user").(*models.User)
-	permissionID := c.Param("id")
-
-	var permission models.Permission
-	if err := h.db.Preload("User").Preload("Workspace").First(&permission, permissionID).Error; err != nil {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "Permission not found"})
+	if err := h.svc.RevokePermission(c.Param("id"), getAdminUserID(c)); err != nil {
+		handleServiceError(c, err)
 		return
 	}
-
-	// Revoke from RBAC
-	if err := rbac.RevokeWorkspaceAccess(permission.UserID, permission.WorkspaceID); err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to revoke RBAC permission"})
-		return
-	}
-
-	// Delete permission record
-	if err := h.db.Delete(&permission).Error; err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to delete permission"})
-		return
-	}
-
-	// Audit log
-	audit.LogAction(h.db, adminUser.ID, audit.ActionRevokePermission, "permission:"+permissionID, map[string]interface{}{
-		"user_id":      permission.UserID,
-		"workspace_id": permission.WorkspaceID,
-	})
-
 	c.Status(http.StatusNoContent)
 }
 
@@ -376,22 +208,11 @@ func (h *AdminHandler) RevokePermission(c *gin.Context) {
 // @Success 200 {array} models.AuditLog
 // @Router /admin/audit-logs [get]
 func (h *AdminHandler) ListAuditLogs(c *gin.Context) {
-	query := h.db.Preload("User").Order("timestamp DESC").Limit(100)
-
-	if userID := c.Query("user_id"); userID != "" {
-		query = query.Where("user_id = ?", userID)
-	}
-
-	if action := c.Query("action"); action != "" {
-		query = query.Where("action = ?", action)
-	}
-
-	var logs []models.AuditLog
-	if err := query.Find(&logs).Error; err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to fetch audit logs"})
+	logs, err := h.svc.ListAuditLogs(c.Query("user_id"), c.Query("action"))
+	if err != nil {
+		handleServiceError(c, err)
 		return
 	}
-
 	c.JSON(http.StatusOK, logs)
 }
 
@@ -400,29 +221,19 @@ func (h *AdminHandler) ListAuditLogs(c *gin.Context) {
 // @Tags admin
 // @Security BearerAuth
 // @Produce json
-// @Success 200 {object} DashboardStatsResponse
+// @Success 200 {object} service.DashboardStats
 // @Router /admin/dashboard/stats [get]
 func (h *AdminHandler) GetDashboardStats(c *gin.Context) {
-	// Get total disk usage
-	var totalDiskUsage struct {
-		TotalBytes int64
+	stats, err := h.svc.GetDashboardStats()
+	if err != nil {
+		handleServiceError(c, err)
+		return
 	}
-	h.db.Model(&models.Workspace{}).
-		Select("COALESCE(SUM(size_bytes), 0) as total_bytes").
-		Scan(&totalDiskUsage)
-
-	// Format size
-	totalSizeFormatted := formatBytes(totalDiskUsage.TotalBytes)
-
-	stats := DashboardStatsResponse{
-		TotalDiskUsageBytes:     totalDiskUsage.TotalBytes,
-		TotalDiskUsageFormatted: totalSizeFormatted,
-	}
-
 	c.JSON(http.StatusOK, stats)
 }
 
-// Request types
+// --- Request types ---
+
 type CreateUserRequest struct {
 	Username string `json:"username" binding:"required"`
 	Email    string `json:"email" binding:"required,email"`
@@ -436,26 +247,11 @@ type GrantPermissionRequest struct {
 	RoleID      uint      `json:"role_id" binding:"required"`
 }
 
-type UserWithAdminStatus struct {
-	models.User
-	IsAdmin bool `json:"is_admin"`
-}
-
-type DashboardStatsResponse struct {
-	TotalDiskUsageBytes     int64  `json:"total_disk_usage_bytes"`
-	TotalDiskUsageFormatted string `json:"total_disk_usage_formatted"`
-}
-
-// formatBytes converts bytes to human-readable format
-func formatBytes(bytes int64) string {
-	const unit = 1024
-	if bytes < unit {
-		return fmt.Sprintf("%d B", bytes)
+// getAdminUserID extracts the admin user ID from context.
+func getAdminUserID(c *gin.Context) uuid.UUID {
+	user, exists := c.Get("user")
+	if !exists {
+		return uuid.Nil
 	}
-	div, exp := int64(unit), 0
-	for n := bytes / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %ciB", float64(bytes)/float64(div), "KMGTPE"[exp])
+	return user.(*models.User).ID
 }

--- a/internal/api/handlers/job.go
+++ b/internal/api/handlers/job.go
@@ -8,23 +8,23 @@ import (
 	"github.com/google/uuid"
 	"github.com/nebari-dev/nebi/internal/logstream"
 	"github.com/nebari-dev/nebi/internal/models"
+	"github.com/nebari-dev/nebi/internal/service"
 	"github.com/valkey-io/valkey-go"
-	"gorm.io/gorm"
 )
 
 type JobHandler struct {
-	db           *gorm.DB
+	svc          *service.JobService
 	broker       *logstream.LogBroker
 	valkeyClient valkey.Client
 }
 
-func NewJobHandler(db *gorm.DB, broker *logstream.LogBroker, valkeyClient interface{}) *JobHandler {
+func NewJobHandler(svc *service.JobService, broker *logstream.LogBroker, valkeyClient interface{}) *JobHandler {
 	var client valkey.Client
 	if valkeyClient != nil {
 		client, _ = valkeyClient.(valkey.Client)
 	}
 	return &JobHandler{
-		db:           db,
+		svc:          svc,
 		broker:       broker,
 		valkeyClient: client,
 	}
@@ -40,21 +40,11 @@ func NewJobHandler(db *gorm.DB, broker *logstream.LogBroker, valkeyClient interf
 // @Failure 500 {object} ErrorResponse
 // @Router /jobs [get]
 func (h *JobHandler) ListJobs(c *gin.Context) {
-	userID := getUserID(c)
-
-	var jobs []models.Job
-	err := h.db.
-		Select("jobs.*").
-		Joins("JOIN workspaces ON workspaces.id = jobs.workspace_id").
-		Where("workspaces.owner_id = ?", userID).
-		Order("jobs.created_at DESC").
-		Find(&jobs).Error
-
+	jobs, err := h.svc.ListJobs(getUserID(c))
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to fetch jobs"})
+		handleServiceError(c, err)
 		return
 	}
-
 	c.JSON(http.StatusOK, jobs)
 }
 
@@ -70,25 +60,11 @@ func (h *JobHandler) ListJobs(c *gin.Context) {
 // @Failure 500 {object} ErrorResponse
 // @Router /jobs/{id} [get]
 func (h *JobHandler) GetJob(c *gin.Context) {
-	userID := getUserID(c)
-	jobID := c.Param("id")
-
-	var job models.Job
-	err := h.db.
-		Select("jobs.*").
-		Joins("JOIN workspaces ON workspaces.id = jobs.workspace_id").
-		Where("jobs.id = ? AND workspaces.owner_id = ?", jobID, userID).
-		First(&job).Error
-
+	job, err := h.svc.GetJob(c.Param("id"), getUserID(c))
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
-			c.JSON(http.StatusNotFound, ErrorResponse{Error: "Job not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to fetch job"})
+		handleServiceError(c, err)
 		return
 	}
-
 	c.JSON(http.StatusOK, job)
 }
 
@@ -104,31 +80,17 @@ func (h *JobHandler) GetJob(c *gin.Context) {
 // @Failure 404 {object} ErrorResponse
 // @Router /jobs/{id}/logs/stream [get]
 func (h *JobHandler) StreamJobLogs(c *gin.Context) {
-	// Get userID from context (set by auth middleware)
 	userID := getUserID(c)
-	jobID := c.Param("id")
 
-	// Parse job UUID
-	jobUUID, err := uuid.Parse(jobID)
+	jobUUID, err := uuid.Parse(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Invalid job ID"})
 		return
 	}
 
-	// Verify job exists and user has access
-	var job models.Job
-	err = h.db.
-		Select("jobs.*").
-		Joins("JOIN workspaces ON workspaces.id = jobs.workspace_id").
-		Where("jobs.id = ? AND workspaces.owner_id = ?", jobUUID, userID).
-		First(&job).Error
-
+	job, err := h.svc.GetJobForStreaming(jobUUID, userID)
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
-			c.JSON(http.StatusNotFound, ErrorResponse{Error: "Job not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to fetch job"})
+		handleServiceError(c, err)
 		return
 	}
 
@@ -136,7 +98,7 @@ func (h *JobHandler) StreamJobLogs(c *gin.Context) {
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")
 	c.Header("Connection", "keep-alive")
-	c.Header("X-Accel-Buffering", "no") // Disable nginx buffering
+	c.Header("X-Accel-Buffering", "no")
 
 	// If job is already completed or failed, send historical logs and close
 	if job.Status == models.JobStatusCompleted || job.Status == models.JobStatusFailed {
@@ -154,14 +116,12 @@ func (h *JobHandler) StreamJobLogs(c *gin.Context) {
 		c.Writer.Flush()
 	}
 
-	// Use Valkey pub/sub for distributed log streaming if available
+	// Stream real-time logs
 	if h.valkeyClient != nil {
 		h.streamLogsFromValkey(c, jobUUID)
 	} else if h.broker != nil {
-		// Fallback to in-memory broker
 		h.streamLogsFromBroker(c, jobUUID)
 	} else {
-		// No streaming available, poll database
 		fmt.Fprintf(c.Writer, "event: error\ndata: Log streaming not available\n\n")
 		c.Writer.Flush()
 	}
@@ -172,20 +132,16 @@ func (h *JobHandler) streamLogsFromValkey(c *gin.Context, jobID uuid.UUID) {
 	channel := fmt.Sprintf("logs:%s", jobID.String())
 	ctx := c.Request.Context()
 
-	// Subscribe to Valkey pub/sub channel and receive messages
 	subscribeCmd := h.valkeyClient.B().Subscribe().Channel(channel).Build()
 
 	err := h.valkeyClient.Receive(ctx, subscribeCmd, func(msg valkey.PubSubMessage) {
-		// Get log line from message
 		logLine := msg.Message
 
-		// Send log line to client via SSE
 		fmt.Fprintf(c.Writer, "data: %s\n\n", logLine)
 		if flusher, ok := c.Writer.(http.Flusher); ok {
 			flusher.Flush()
 		}
 
-		// Check if this is a completion message
 		if logLine == "\n[COMPLETED] Job finished successfully\n" ||
 			(len(logLine) > 7 && logLine[:7] == "\n[ERROR]") {
 			fmt.Fprintf(c.Writer, "event: done\ndata: Job completed\n\n")
@@ -194,8 +150,6 @@ func (h *JobHandler) streamLogsFromValkey(c *gin.Context, jobID uuid.UUID) {
 	})
 
 	if err != nil {
-		// Error subscribing or streaming (includes context cancellation)
-		// This is normal when client disconnects
 		if err.Error() != "context canceled" {
 			fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n", err.Error())
 			c.Writer.Flush()
@@ -205,26 +159,21 @@ func (h *JobHandler) streamLogsFromValkey(c *gin.Context, jobID uuid.UUID) {
 
 // streamLogsFromBroker streams logs from in-memory broker (fallback)
 func (h *JobHandler) streamLogsFromBroker(c *gin.Context, jobID uuid.UUID) {
-	// Subscribe to real-time log stream
 	logChan := h.broker.Subscribe(jobID)
 	defer h.broker.Unsubscribe(jobID, logChan)
 
-	// Stream logs as they arrive
 	clientGone := c.Request.Context().Done()
 	for {
 		select {
 		case <-clientGone:
-			// Client disconnected
 			return
 		case logLine, ok := <-logChan:
 			if !ok {
-				// Channel closed, job completed
 				fmt.Fprintf(c.Writer, "event: done\ndata: Stream ended\n\n")
 				c.Writer.Flush()
 				return
 			}
 
-			// Send log line to client
 			fmt.Fprintf(c.Writer, "data: %s\n\n", logLine)
 			if flusher, ok := c.Writer.(http.Flusher); ok {
 				flusher.Flush()

--- a/internal/api/handlers/registry.go
+++ b/internal/api/handlers/registry.go
@@ -1,30 +1,175 @@
 package handlers
 
 import (
-	"fmt"
-	"log/slog"
 	"net/http"
-	"strings"
 
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
-	nebicrypto "github.com/nebari-dev/nebi/internal/crypto"
 	"github.com/nebari-dev/nebi/internal/models"
-	"gorm.io/gorm"
+	"github.com/nebari-dev/nebi/internal/service"
 )
 
 // RegistryHandler handles OCI registry operations
 type RegistryHandler struct {
-	db     *gorm.DB
-	encKey []byte
+	svc *service.RegistryService
 }
 
 // NewRegistryHandler creates a new registry handler
-func NewRegistryHandler(db *gorm.DB, encKey []byte) *RegistryHandler {
-	return &RegistryHandler{db: db, encKey: encKey}
+func NewRegistryHandler(svc *service.RegistryService) *RegistryHandler {
+	return &RegistryHandler{svc: svc}
 }
 
-// Request/Response types
+// ListRegistries godoc
+// @Summary List all OCI registries
+// @Description Get list of all configured OCI registries (admin only)
+// @Tags admin
+// @Security BearerAuth
+// @Produce json
+// @Success 200 {array} service.RegistryResult
+// @Failure 500 {object} ErrorResponse
+// @Router /admin/registries [get]
+func (h *RegistryHandler) ListRegistries(c *gin.Context) {
+	registries, err := h.svc.ListRegistries()
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, registries)
+}
+
+// CreateRegistry godoc
+// @Summary Create a new OCI registry
+// @Description Add a new OCI registry configuration (admin only)
+// @Tags admin
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param registry body CreateRegistryRequest true "Registry details"
+// @Success 201 {object} service.RegistryResult
+// @Failure 400 {object} ErrorResponse
+// @Failure 409 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /admin/registries [post]
+func (h *RegistryHandler) CreateRegistry(c *gin.Context) {
+	var req CreateRegistryRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+		return
+	}
+
+	user, exists := c.Get("user")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "User not found"})
+		return
+	}
+	userID := user.(*models.User).ID
+
+	result, err := h.svc.CreateRegistry(service.CreateRegistryReq{
+		Name:      req.Name,
+		URL:       req.URL,
+		Username:  req.Username,
+		Password:  req.Password,
+		APIToken:  req.APIToken,
+		IsDefault: req.IsDefault,
+		Namespace: req.Namespace,
+		CreatedBy: userID,
+	})
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, result)
+}
+
+// GetRegistry godoc
+// @Summary Get a registry by ID
+// @Description Get details of a specific OCI registry (admin only)
+// @Tags admin
+// @Security BearerAuth
+// @Produce json
+// @Param id path string true "Registry ID"
+// @Success 200 {object} service.RegistryResult
+// @Failure 404 {object} ErrorResponse
+// @Router /admin/registries/{id} [get]
+func (h *RegistryHandler) GetRegistry(c *gin.Context) {
+	result, err := h.svc.GetRegistry(c.Param("id"))
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+// UpdateRegistry godoc
+// @Summary Update a registry
+// @Description Update OCI registry details (admin only)
+// @Tags admin
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param id path string true "Registry ID"
+// @Param registry body UpdateRegistryRequest true "Registry updates"
+// @Success 200 {object} service.RegistryResult
+// @Failure 400 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Router /admin/registries/{id} [put]
+func (h *RegistryHandler) UpdateRegistry(c *gin.Context) {
+	var req UpdateRegistryRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+		return
+	}
+
+	result, err := h.svc.UpdateRegistry(c.Param("id"), service.UpdateRegistryReq{
+		Name:      req.Name,
+		URL:       req.URL,
+		Username:  req.Username,
+		Password:  req.Password,
+		APIToken:  req.APIToken,
+		IsDefault: req.IsDefault,
+		Namespace: req.Namespace,
+	})
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+// DeleteRegistry godoc
+// @Summary Delete a registry
+// @Description Delete an OCI registry configuration (admin only)
+// @Tags admin
+// @Security BearerAuth
+// @Param id path string true "Registry ID"
+// @Success 204
+// @Failure 404 {object} ErrorResponse
+// @Router /admin/registries/{id} [delete]
+func (h *RegistryHandler) DeleteRegistry(c *gin.Context) {
+	if err := h.svc.DeleteRegistry(c.Param("id")); err != nil {
+		handleServiceError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// ListPublicRegistries godoc
+// @Summary List available registries (public info only)
+// @Description Get list of registries for users to select from (no credentials exposed)
+// @Tags registries
+// @Security BearerAuth
+// @Produce json
+// @Success 200 {array} service.RegistryResult
+// @Router /registries [get]
+func (h *RegistryHandler) ListPublicRegistries(c *gin.Context) {
+	registries, err := h.svc.ListPublicRegistries()
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, registries)
+}
+
+// --- Request types ---
 
 type CreateRegistryRequest struct {
 	Name      string `json:"name" binding:"required"`
@@ -44,314 +189,4 @@ type UpdateRegistryRequest struct {
 	APIToken  *string `json:"api_token"`
 	IsDefault *bool   `json:"is_default"`
 	Namespace *string `json:"namespace"`
-}
-
-type RegistryResponse struct {
-	ID          uuid.UUID `json:"id"`
-	Name        string    `json:"name"`
-	URL         string    `json:"url"`
-	Username    string    `json:"username"`
-	HasAPIToken bool      `json:"has_api_token"`
-	IsDefault   bool      `json:"is_default"`
-	Namespace   string    `json:"namespace"`
-	CreatedAt   string    `json:"created_at"`
-}
-
-// ListRegistries godoc
-// @Summary List all OCI registries
-// @Description Get list of all configured OCI registries (admin only)
-// @Tags admin
-// @Security BearerAuth
-// @Accept json
-// @Produce json
-// @Success 200 {array} RegistryResponse
-// @Failure 500 {object} ErrorResponse
-// @Router /admin/registries [get]
-func (h *RegistryHandler) ListRegistries(c *gin.Context) {
-	var registries []models.OCIRegistry
-	if err := h.db.Find(&registries).Error; err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to fetch registries"})
-		return
-	}
-
-	response := make([]RegistryResponse, len(registries))
-	for i, reg := range registries {
-		// Decrypt to check HasAPIToken accurately (encrypted values are non-empty but not real tokens)
-		apiToken, err := nebicrypto.DecryptField(reg.APIToken, h.encKey)
-		if err != nil {
-			slog.Error("Failed to decrypt API token", "registry_id", reg.ID, "error", err)
-		}
-		response[i] = RegistryResponse{
-			ID:          reg.ID,
-			Name:        reg.Name,
-			URL:         reg.URL,
-			Username:    reg.Username,
-			HasAPIToken: apiToken != "",
-			IsDefault:   reg.IsDefault,
-			Namespace:   reg.Namespace,
-			CreatedAt:   reg.CreatedAt.Format("2006-01-02 15:04:05"),
-		}
-	}
-
-	c.JSON(http.StatusOK, response)
-}
-
-// CreateRegistry godoc
-// @Summary Create a new OCI registry
-// @Description Add a new OCI registry configuration (admin only)
-// @Tags admin
-// @Security BearerAuth
-// @Accept json
-// @Produce json
-// @Param registry body CreateRegistryRequest true "Registry details"
-// @Success 201 {object} RegistryResponse
-// @Failure 400 {object} ErrorResponse
-// @Failure 500 {object} ErrorResponse
-// @Router /admin/registries [post]
-func (h *RegistryHandler) CreateRegistry(c *gin.Context) {
-	var req CreateRegistryRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
-		return
-	}
-
-	// Get current user from context
-	user, exists := c.Get("user")
-	if !exists {
-		c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "User not found"})
-		return
-	}
-	userID := user.(*models.User).ID
-
-	// If setting as default, unset other defaults
-	if req.IsDefault {
-		h.db.Model(&models.OCIRegistry{}).Where("is_default = ?", true).Update("is_default", false)
-	}
-
-	encPassword, err := nebicrypto.EncryptField(req.Password, h.encKey)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to encrypt credentials"})
-		return
-	}
-	encAPIToken, err := nebicrypto.EncryptField(req.APIToken, h.encKey)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to encrypt credentials"})
-		return
-	}
-
-	registry := models.OCIRegistry{
-		Name:      req.Name,
-		URL:       req.URL,
-		Username:  req.Username,
-		Password:  encPassword,
-		APIToken:  encAPIToken,
-		IsDefault: req.IsDefault,
-		Namespace: req.Namespace,
-		CreatedBy: userID,
-	}
-
-	if err := h.db.Create(&registry).Error; err != nil {
-		if strings.Contains(err.Error(), "UNIQUE") || strings.Contains(err.Error(), "duplicate") {
-			c.JSON(http.StatusConflict, ErrorResponse{Error: fmt.Sprintf("Registry with name '%s' already exists", req.Name)})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to create registry"})
-		return
-	}
-
-	c.JSON(http.StatusCreated, RegistryResponse{
-		ID:          registry.ID,
-		Name:        registry.Name,
-		URL:         registry.URL,
-		Username:    registry.Username,
-		HasAPIToken: req.APIToken != "",
-		IsDefault:   registry.IsDefault,
-		Namespace:   registry.Namespace,
-		CreatedAt:   registry.CreatedAt.Format("2006-01-02 15:04:05"),
-	})
-}
-
-// GetRegistry godoc
-// @Summary Get a registry by ID
-// @Description Get details of a specific OCI registry (admin only)
-// @Tags admin
-// @Security BearerAuth
-// @Accept json
-// @Produce json
-// @Param id path string true "Registry ID"
-// @Success 200 {object} RegistryResponse
-// @Failure 404 {object} ErrorResponse
-// @Router /admin/registries/{id} [get]
-func (h *RegistryHandler) GetRegistry(c *gin.Context) {
-	id := c.Param("id")
-
-	var registry models.OCIRegistry
-	if err := h.db.Where("id = ?", id).First(&registry).Error; err != nil {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "Registry not found"})
-		return
-	}
-
-	apiToken, err := nebicrypto.DecryptField(registry.APIToken, h.encKey)
-	if err != nil {
-		slog.Error("Failed to decrypt API token", "registry_id", registry.ID, "error", err)
-	}
-
-	c.JSON(http.StatusOK, RegistryResponse{
-		ID:          registry.ID,
-		Name:        registry.Name,
-		URL:         registry.URL,
-		Username:    registry.Username,
-		HasAPIToken: apiToken != "",
-		IsDefault:   registry.IsDefault,
-		Namespace:   registry.Namespace,
-		CreatedAt:   registry.CreatedAt.Format("2006-01-02 15:04:05"),
-	})
-}
-
-// UpdateRegistry godoc
-// @Summary Update a registry
-// @Description Update OCI registry details (admin only)
-// @Tags admin
-// @Security BearerAuth
-// @Accept json
-// @Produce json
-// @Param id path string true "Registry ID"
-// @Param registry body UpdateRegistryRequest true "Registry updates"
-// @Success 200 {object} RegistryResponse
-// @Failure 400 {object} ErrorResponse
-// @Failure 404 {object} ErrorResponse
-// @Router /admin/registries/{id} [put]
-func (h *RegistryHandler) UpdateRegistry(c *gin.Context) {
-	id := c.Param("id")
-
-	var req UpdateRegistryRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
-		return
-	}
-
-	var registry models.OCIRegistry
-	if err := h.db.Where("id = ?", id).First(&registry).Error; err != nil {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "Registry not found"})
-		return
-	}
-
-	// Update fields
-	if req.Name != nil {
-		registry.Name = *req.Name
-	}
-	if req.URL != nil {
-		registry.URL = *req.URL
-	}
-	if req.Username != nil {
-		registry.Username = *req.Username
-	}
-	if req.Password != nil {
-		encPwd, err := nebicrypto.EncryptField(*req.Password, h.encKey)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to encrypt credentials"})
-			return
-		}
-		registry.Password = encPwd
-	}
-	if req.APIToken != nil {
-		encToken, err := nebicrypto.EncryptField(*req.APIToken, h.encKey)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to encrypt credentials"})
-			return
-		}
-		registry.APIToken = encToken
-	}
-	if req.IsDefault != nil {
-		if *req.IsDefault {
-			// Unset other defaults
-			h.db.Model(&models.OCIRegistry{}).Where("is_default = ?", true).Update("is_default", false)
-		}
-		registry.IsDefault = *req.IsDefault
-	}
-	if req.Namespace != nil {
-		registry.Namespace = *req.Namespace
-	}
-
-	if err := h.db.Save(&registry).Error; err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to update registry"})
-		return
-	}
-
-	updatedAPIToken, err := nebicrypto.DecryptField(registry.APIToken, h.encKey)
-	if err != nil {
-		slog.Error("Failed to decrypt API token", "registry_id", registry.ID, "error", err)
-	}
-
-	c.JSON(http.StatusOK, RegistryResponse{
-		ID:          registry.ID,
-		Name:        registry.Name,
-		URL:         registry.URL,
-		Username:    registry.Username,
-		HasAPIToken: updatedAPIToken != "",
-		IsDefault:   registry.IsDefault,
-		Namespace:   registry.Namespace,
-		CreatedAt:   registry.CreatedAt.Format("2006-01-02 15:04:05"),
-	})
-}
-
-// DeleteRegistry godoc
-// @Summary Delete a registry
-// @Description Delete an OCI registry configuration (admin only)
-// @Tags admin
-// @Security BearerAuth
-// @Accept json
-// @Produce json
-// @Param id path string true "Registry ID"
-// @Success 204
-// @Failure 404 {object} ErrorResponse
-// @Router /admin/registries/{id} [delete]
-func (h *RegistryHandler) DeleteRegistry(c *gin.Context) {
-	id := c.Param("id")
-
-	var registry models.OCIRegistry
-	if err := h.db.Where("id = ?", id).First(&registry).Error; err != nil {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "Registry not found"})
-		return
-	}
-
-	if err := h.db.Delete(&registry).Error; err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to delete registry"})
-		return
-	}
-
-	c.Status(http.StatusNoContent)
-}
-
-// ListPublicRegistries godoc
-// @Summary List available registries (public info only)
-// @Description Get list of registries for users to select from (no credentials exposed)
-// @Tags registries
-// @Security BearerAuth
-// @Accept json
-// @Produce json
-// @Success 200 {array} RegistryResponse
-// @Router /registries [get]
-func (h *RegistryHandler) ListPublicRegistries(c *gin.Context) {
-	var registries []models.OCIRegistry
-	if err := h.db.Find(&registries).Error; err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to fetch registries"})
-		return
-	}
-
-	response := make([]RegistryResponse, len(registries))
-	for i, reg := range registries {
-		response[i] = RegistryResponse{
-			ID:          reg.ID,
-			Name:        reg.Name,
-			URL:         reg.URL,
-			Username:    "",    // Don't expose username to regular users
-			HasAPIToken: false, // Don't expose token info to regular users
-			IsDefault:   reg.IsDefault,
-			Namespace:   reg.Namespace,
-			CreatedAt:   reg.CreatedAt.Format("2006-01-02 15:04:05"),
-		}
-	}
-
-	c.JSON(http.StatusOK, response)
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -171,10 +171,14 @@ func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Exe
 		panic(err)
 	}
 
-	// Initialize service and handlers
+	// Initialize services and handlers
 	svc := service.New(db, q, exec, localMode, encKey)
+	adminSvc := service.NewAdminService(db)
+	registrySvc := service.NewRegistryService(db, encKey)
+	jobSvc := service.NewJobService(db)
+
 	wsHandler := handlers.NewWorkspaceHandler(svc)
-	jobHandler := handlers.NewJobHandler(db, logBroker, valkeyClient)
+	jobHandler := handlers.NewJobHandler(jobSvc, logBroker, valkeyClient)
 
 	// Protected routes (require authentication)
 	protected := base.Group("/api/v1")
@@ -234,7 +238,7 @@ func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Exe
 		protected.POST("/templates", handlers.NotImplemented)
 
 		// OCI Registry endpoints (for users to view available registries)
-		registryHandler := handlers.NewRegistryHandler(db, encKey)
+		registryHandler := handlers.NewRegistryHandler(registrySvc)
 		protected.GET("/registries", registryHandler.ListPublicRegistries)
 
 		// Registry browse & import endpoints (for all authenticated users)
@@ -244,7 +248,7 @@ func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Exe
 		protected.POST("/registries/:id/import", browseHandler.ImportEnvironment)
 
 		// Admin endpoints (require admin role)
-		adminHandler := handlers.NewAdminHandler(db)
+		adminHandler := handlers.NewAdminHandler(adminSvc)
 		admin := protected.Group("/admin")
 		admin.Use(middleware.RequireAdmin(localMode))
 		{

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -1,0 +1,290 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/nebari-dev/nebi/internal/audit"
+	"github.com/nebari-dev/nebi/internal/models"
+	"github.com/nebari-dev/nebi/internal/rbac"
+	"github.com/nebari-dev/nebi/internal/utils"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
+)
+
+// AdminService contains business logic for admin operations.
+type AdminService struct {
+	db *gorm.DB
+}
+
+// NewAdminService creates a new AdminService.
+func NewAdminService(db *gorm.DB) *AdminService {
+	return &AdminService{db: db}
+}
+
+// UserWithAdmin wraps a user with their admin status.
+type UserWithAdmin struct {
+	models.User
+	IsAdmin bool `json:"is_admin"`
+}
+
+// CreateUserRequest holds parameters for creating a user.
+type CreateUserRequest struct {
+	Username string
+	Email    string
+	Password string
+	IsAdmin  bool
+}
+
+// DashboardStats holds admin dashboard statistics.
+type DashboardStats struct {
+	TotalDiskUsageBytes     int64  `json:"total_disk_usage_bytes"`
+	TotalDiskUsageFormatted string `json:"total_disk_usage_formatted"`
+}
+
+// ListUsers returns all users with their admin status.
+func (s *AdminService) ListUsers() ([]UserWithAdmin, error) {
+	var users []models.User
+	if err := s.db.Find(&users).Error; err != nil {
+		return nil, fmt.Errorf("fetch users: %w", err)
+	}
+
+	adminUserIDs, err := rbac.GetAllAdminUserIDs()
+	if err != nil {
+		return nil, fmt.Errorf("check admin status: %w", err)
+	}
+
+	result := make([]UserWithAdmin, len(users))
+	for i, user := range users {
+		result[i] = UserWithAdmin{
+			User:    user,
+			IsAdmin: adminUserIDs[user.ID],
+		}
+	}
+	return result, nil
+}
+
+// CreateUser creates a new user, optionally granting admin, and writes an audit log.
+func (s *AdminService) CreateUser(req CreateUserRequest, adminUserID uuid.UUID) (*models.User, error) {
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	if err != nil {
+		return nil, fmt.Errorf("hash password: %w", err)
+	}
+
+	user := models.User{
+		Username:     req.Username,
+		Email:        req.Email,
+		PasswordHash: string(hashedPassword),
+	}
+
+	if err := s.db.Create(&user).Error; err != nil {
+		return nil, fmt.Errorf("create user: %w", err)
+	}
+
+	if req.IsAdmin {
+		if err := rbac.MakeAdmin(user.ID); err != nil {
+			return nil, fmt.Errorf("grant admin: %w", err)
+		}
+	}
+
+	audit.LogAction(s.db, adminUserID, audit.ActionCreateUser, "user:"+user.ID.String(), map[string]any{
+		"username": user.Username,
+		"email":    user.Email,
+		"is_admin": req.IsAdmin,
+	})
+
+	return &user, nil
+}
+
+// GetUser returns a user by ID with admin status.
+func (s *AdminService) GetUser(userID uuid.UUID) (*UserWithAdmin, error) {
+	var user models.User
+	if err := s.db.First(&user, "id = ?", userID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	isAdmin, _ := rbac.IsAdmin(user.ID)
+	return &UserWithAdmin{User: user, IsAdmin: isAdmin}, nil
+}
+
+// ToggleAdmin toggles admin status for a user and writes an audit log.
+func (s *AdminService) ToggleAdmin(userID uuid.UUID, adminUserID uuid.UUID) (*UserWithAdmin, error) {
+	var user models.User
+	if err := s.db.First(&user, "id = ?", userID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	isAdmin, _ := rbac.IsAdmin(user.ID)
+
+	if isAdmin {
+		if err := rbac.RevokeAdmin(user.ID); err != nil {
+			return nil, fmt.Errorf("revoke admin: %w", err)
+		}
+		audit.LogAction(s.db, adminUserID, audit.ActionRevokeAdmin, "user:"+user.ID.String(), nil)
+	} else {
+		if err := rbac.MakeAdmin(user.ID); err != nil {
+			return nil, fmt.Errorf("make admin: %w", err)
+		}
+		audit.LogAction(s.db, adminUserID, audit.ActionMakeAdmin, "user:"+user.ID.String(), nil)
+	}
+
+	return &UserWithAdmin{User: user, IsAdmin: !isAdmin}, nil
+}
+
+// DeleteUser deletes a user and writes an audit log. Cannot delete self.
+func (s *AdminService) DeleteUser(userID uuid.UUID, adminUserID uuid.UUID) error {
+	if userID == adminUserID {
+		return &ValidationError{Message: "Cannot delete yourself"}
+	}
+
+	var user models.User
+	if err := s.db.First(&user, "id = ?", userID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return ErrNotFound
+		}
+		return err
+	}
+
+	if err := s.db.Delete(&user).Error; err != nil {
+		return fmt.Errorf("delete user: %w", err)
+	}
+
+	audit.LogAction(s.db, adminUserID, audit.ActionDeleteUser, "user:"+user.ID.String(), map[string]any{
+		"username": user.Username,
+	})
+
+	return nil
+}
+
+// ListRoles returns all roles.
+func (s *AdminService) ListRoles() ([]models.Role, error) {
+	var roles []models.Role
+	if err := s.db.Find(&roles).Error; err != nil {
+		return nil, fmt.Errorf("fetch roles: %w", err)
+	}
+	return roles, nil
+}
+
+// GrantPermission creates a permission record and grants RBAC access.
+func (s *AdminService) GrantPermission(userID, workspaceID uuid.UUID, roleID uint, adminUserID uuid.UUID) (*models.Permission, error) {
+	var user models.User
+	if err := s.db.First(&user, "id = ?", userID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, &ValidationError{Message: "User not found"}
+		}
+		return nil, err
+	}
+
+	var ws models.Workspace
+	if err := s.db.First(&ws, "id = ?", workspaceID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, &ValidationError{Message: "Workspace not found"}
+		}
+		return nil, err
+	}
+
+	var role models.Role
+	if err := s.db.First(&role, roleID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, &ValidationError{Message: "Role not found"}
+		}
+		return nil, err
+	}
+
+	permission := models.Permission{
+		UserID:      userID,
+		WorkspaceID: workspaceID,
+		RoleID:      roleID,
+	}
+	if err := s.db.Create(&permission).Error; err != nil {
+		return nil, fmt.Errorf("create permission: %w", err)
+	}
+
+	if err := rbac.GrantWorkspaceAccess(user.ID, ws.ID, role.Name); err != nil {
+		return nil, fmt.Errorf("grant RBAC permission: %w", err)
+	}
+
+	audit.LogAction(s.db, adminUserID, audit.ActionGrantPermission, fmt.Sprintf("permission:%d", permission.ID), map[string]any{
+		"user_id":      userID,
+		"workspace_id": workspaceID,
+		"role":         role.Name,
+	})
+
+	return &permission, nil
+}
+
+// ListPermissions returns all permissions with preloaded relations.
+func (s *AdminService) ListPermissions() ([]models.Permission, error) {
+	var permissions []models.Permission
+	if err := s.db.Preload("User").Preload("Workspace").Preload("Role").Find(&permissions).Error; err != nil {
+		return nil, fmt.Errorf("fetch permissions: %w", err)
+	}
+	return permissions, nil
+}
+
+// RevokePermission revokes a permission by ID and removes RBAC access.
+func (s *AdminService) RevokePermission(permissionID string, adminUserID uuid.UUID) error {
+	var permission models.Permission
+	if err := s.db.Preload("User").Preload("Workspace").First(&permission, permissionID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return ErrNotFound
+		}
+		return err
+	}
+
+	if err := rbac.RevokeWorkspaceAccess(permission.UserID, permission.WorkspaceID); err != nil {
+		return fmt.Errorf("revoke RBAC permission: %w", err)
+	}
+
+	if err := s.db.Delete(&permission).Error; err != nil {
+		return fmt.Errorf("delete permission: %w", err)
+	}
+
+	audit.LogAction(s.db, adminUserID, audit.ActionRevokePermission, "permission:"+permissionID, map[string]any{
+		"user_id":      permission.UserID,
+		"workspace_id": permission.WorkspaceID,
+	})
+
+	return nil
+}
+
+// ListAuditLogs returns audit logs with optional filters.
+func (s *AdminService) ListAuditLogs(userIDFilter, actionFilter string) ([]models.AuditLog, error) {
+	query := s.db.Preload("User").Order("timestamp DESC").Limit(100)
+
+	if userIDFilter != "" {
+		query = query.Where("user_id = ?", userIDFilter)
+	}
+	if actionFilter != "" {
+		query = query.Where("action = ?", actionFilter)
+	}
+
+	var logs []models.AuditLog
+	if err := query.Find(&logs).Error; err != nil {
+		return nil, fmt.Errorf("fetch audit logs: %w", err)
+	}
+	return logs, nil
+}
+
+// GetDashboardStats returns admin dashboard statistics.
+func (s *AdminService) GetDashboardStats() (*DashboardStats, error) {
+	var result struct {
+		TotalBytes int64
+	}
+	if err := s.db.Model(&models.Workspace{}).
+		Select("COALESCE(SUM(size_bytes), 0) as total_bytes").
+		Scan(&result).Error; err != nil {
+		return nil, fmt.Errorf("fetch dashboard stats: %w", err)
+	}
+
+	return &DashboardStats{
+		TotalDiskUsageBytes:     result.TotalBytes,
+		TotalDiskUsageFormatted: utils.FormatBytes(result.TotalBytes),
+	}, nil
+}

--- a/internal/service/admin_test.go
+++ b/internal/service/admin_test.go
@@ -1,0 +1,316 @@
+package service
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/nebari-dev/nebi/internal/models"
+	"gorm.io/gorm"
+)
+
+func adminTestSetup(t *testing.T) (*AdminService, *WorkspaceService, *gorm.DB) {
+	t.Helper()
+	wsSvc, db := testSetup(t, false)
+	return NewAdminService(db), wsSvc, db
+}
+
+// --- ListUsers ---
+
+func TestAdminListUsers(t *testing.T) {
+	svc, _, db := adminTestSetup(t)
+	createTestUser(t, db, "alice")
+	createTestUser(t, db, "bob")
+
+	users, err := svc.ListUsers()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(users) != 2 {
+		t.Errorf("expected 2 users, got %d", len(users))
+	}
+}
+
+// --- CreateUser ---
+
+func TestAdminCreateUser(t *testing.T) {
+	svc, _, db := adminTestSetup(t)
+	adminID := createTestUser(t, db, "admin")
+
+	user, err := svc.CreateUser(CreateUserRequest{
+		Username: "newuser",
+		Email:    "new@test.com",
+		Password: "securepassword",
+	}, adminID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user.Username != "newuser" {
+		t.Errorf("expected username 'newuser', got %q", user.Username)
+	}
+	if user.PasswordHash == "" {
+		t.Error("expected password to be hashed")
+	}
+	if user.PasswordHash == "securepassword" {
+		t.Error("password should be hashed, not stored in plaintext")
+	}
+
+	// Verify audit log
+	var auditCount int64
+	db.Model(&models.AuditLog{}).Where("user_id = ? AND action = ?", adminID, "create_user").Count(&auditCount)
+	if auditCount != 1 {
+		t.Errorf("expected 1 audit log, got %d", auditCount)
+	}
+}
+
+func TestAdminCreateUser_WithAdmin(t *testing.T) {
+	svc, _, db := adminTestSetup(t)
+	adminID := createTestUser(t, db, "admin")
+
+	user, err := svc.CreateUser(CreateUserRequest{
+		Username: "newadmin",
+		Email:    "admin2@test.com",
+		Password: "password",
+		IsAdmin:  true,
+	}, adminID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the user got admin status via GetUser
+	result, err := svc.GetUser(user.ID)
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if !result.IsAdmin {
+		t.Error("expected user to be admin")
+	}
+}
+
+// --- GetUser ---
+
+func TestAdminGetUser_NotFound(t *testing.T) {
+	svc, _, _ := adminTestSetup(t)
+
+	_, err := svc.GetUser(uuid.New())
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// --- ToggleAdmin ---
+
+func TestAdminToggleAdmin(t *testing.T) {
+	svc, _, db := adminTestSetup(t)
+	adminID := createTestUser(t, db, "admin")
+	userID := createTestUser(t, db, "user")
+
+	// Make admin
+	result, err := svc.ToggleAdmin(userID, adminID)
+	if err != nil {
+		t.Fatalf("toggle on: %v", err)
+	}
+	if !result.IsAdmin {
+		t.Error("expected IsAdmin=true after toggle on")
+	}
+
+	// Revoke admin
+	result, err = svc.ToggleAdmin(userID, adminID)
+	if err != nil {
+		t.Fatalf("toggle off: %v", err)
+	}
+	if result.IsAdmin {
+		t.Error("expected IsAdmin=false after toggle off")
+	}
+}
+
+func TestAdminToggleAdmin_NotFound(t *testing.T) {
+	svc, _, db := adminTestSetup(t)
+	adminID := createTestUser(t, db, "admin")
+
+	_, err := svc.ToggleAdmin(uuid.New(), adminID)
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// --- DeleteUser ---
+
+func TestAdminDeleteUser(t *testing.T) {
+	svc, _, db := adminTestSetup(t)
+	adminID := createTestUser(t, db, "admin")
+	userID := createTestUser(t, db, "victim")
+
+	if err := svc.DeleteUser(userID, adminID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify deleted
+	var count int64
+	db.Model(&models.User{}).Where("id = ?", userID).Count(&count)
+	if count != 0 {
+		t.Error("expected user to be deleted")
+	}
+}
+
+func TestAdminDeleteUser_CannotDeleteSelf(t *testing.T) {
+	svc, _, db := adminTestSetup(t)
+	adminID := createTestUser(t, db, "admin")
+
+	err := svc.DeleteUser(adminID, adminID)
+	if err == nil {
+		t.Fatal("expected error for self-deletion")
+	}
+	var ve *ValidationError
+	if !isValidationError(err, &ve) {
+		t.Fatalf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestAdminDeleteUser_NotFound(t *testing.T) {
+	svc, _, db := adminTestSetup(t)
+	adminID := createTestUser(t, db, "admin")
+
+	err := svc.DeleteUser(uuid.New(), adminID)
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// --- ListRoles ---
+
+func TestAdminListRoles(t *testing.T) {
+	svc, _, db := adminTestSetup(t)
+	db.Create(&models.Role{Name: "viewer"})
+	db.Create(&models.Role{Name: "editor"})
+
+	roles, err := svc.ListRoles()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(roles) != 2 {
+		t.Errorf("expected 2 roles, got %d", len(roles))
+	}
+}
+
+// --- GrantPermission ---
+
+func TestAdminGrantPermission(t *testing.T) {
+	svc, wsSvc, db := adminTestSetup(t)
+	adminID := createTestUser(t, db, "admin")
+	userID := createTestUser(t, db, "user")
+	ws := createReadyWorkspace(t, wsSvc, db, "test-ws", adminID)
+	db.Create(&models.Role{Name: "editor"})
+
+	var role models.Role
+	db.Where("name = ?", "editor").First(&role)
+
+	perm, err := svc.GrantPermission(userID, ws.ID, role.ID, adminID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if perm.UserID != userID {
+		t.Errorf("expected user ID %s, got %s", userID, perm.UserID)
+	}
+}
+
+func TestAdminGrantPermission_UserNotFound(t *testing.T) {
+	svc, wsSvc, db := adminTestSetup(t)
+	adminID := createTestUser(t, db, "admin")
+	ws := createReadyWorkspace(t, wsSvc, db, "test-ws", adminID)
+
+	_, err := svc.GrantPermission(uuid.New(), ws.ID, 1, adminID)
+	if err == nil {
+		t.Fatal("expected error for non-existent user")
+	}
+}
+
+// --- RevokePermission ---
+
+func TestAdminRevokePermission(t *testing.T) {
+	svc, wsSvc, db := adminTestSetup(t)
+	adminID := createTestUser(t, db, "admin")
+	userID := createTestUser(t, db, "user")
+	ws := createReadyWorkspace(t, wsSvc, db, "test-ws", adminID)
+	db.Create(&models.Role{Name: "viewer"})
+
+	var role models.Role
+	db.Where("name = ?", "viewer").First(&role)
+
+	perm, _ := svc.GrantPermission(userID, ws.ID, role.ID, adminID)
+
+	err := svc.RevokePermission(fmt.Sprintf("%d", perm.ID), adminID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify deleted
+	var count int64
+	db.Model(&models.Permission{}).Where("id = ?", perm.ID).Count(&count)
+	if count != 0 {
+		t.Error("expected permission to be deleted")
+	}
+}
+
+func TestAdminRevokePermission_NotFound(t *testing.T) {
+	svc, _, db := adminTestSetup(t)
+	adminID := createTestUser(t, db, "admin")
+
+	err := svc.RevokePermission("99999", adminID)
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// --- ListAuditLogs ---
+
+func TestAdminListAuditLogs(t *testing.T) {
+	svc, _, db := adminTestSetup(t)
+	adminID := createTestUser(t, db, "admin")
+
+	// Create a user to generate audit log
+	svc.CreateUser(CreateUserRequest{
+		Username: "auditme",
+		Email:    "audit@test.com",
+		Password: "password",
+	}, adminID)
+
+	logs, err := svc.ListAuditLogs("", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(logs) == 0 {
+		t.Error("expected at least 1 audit log")
+	}
+}
+
+func TestAdminListAuditLogs_FilterByAction(t *testing.T) {
+	svc, _, db := adminTestSetup(t)
+	adminID := createTestUser(t, db, "admin")
+
+	svc.CreateUser(CreateUserRequest{
+		Username: "u1", Email: "u1@test.com", Password: "pass",
+	}, adminID)
+
+	logs, err := svc.ListAuditLogs("", "create_user")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Errorf("expected 1 filtered audit log, got %d", len(logs))
+	}
+}
+
+// --- GetDashboardStats ---
+
+func TestAdminGetDashboardStats(t *testing.T) {
+	svc, _, _ := adminTestSetup(t)
+
+	stats, err := svc.GetDashboardStats()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.TotalDiskUsageBytes != 0 {
+		t.Errorf("expected 0 bytes with no workspaces, got %d", stats.TotalDiskUsageBytes)
+	}
+}

--- a/internal/service/job.go
+++ b/internal/service/job.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/nebari-dev/nebi/internal/models"
+	"gorm.io/gorm"
+)
+
+// JobService contains business logic for job operations.
+type JobService struct {
+	db *gorm.DB
+}
+
+// NewJobService creates a new JobService.
+func NewJobService(db *gorm.DB) *JobService {
+	return &JobService{db: db}
+}
+
+// ListJobs returns all jobs for workspaces owned by the given user.
+func (s *JobService) ListJobs(userID uuid.UUID) ([]models.Job, error) {
+	var jobs []models.Job
+	err := s.db.
+		Select("jobs.*").
+		Joins("JOIN workspaces ON workspaces.id = jobs.workspace_id").
+		Where("workspaces.owner_id = ?", userID).
+		Order("jobs.created_at DESC").
+		Find(&jobs).Error
+
+	if err != nil {
+		return nil, fmt.Errorf("fetch jobs: %w", err)
+	}
+	return jobs, nil
+}
+
+// GetJob returns a single job by ID, verifying the user owns the workspace.
+func (s *JobService) GetJob(jobID string, userID uuid.UUID) (*models.Job, error) {
+	var job models.Job
+	err := s.db.
+		Select("jobs.*").
+		Joins("JOIN workspaces ON workspaces.id = jobs.workspace_id").
+		Where("jobs.id = ? AND workspaces.owner_id = ?", jobID, userID).
+		First(&job).Error
+
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("fetch job: %w", err)
+	}
+	return &job, nil
+}
+
+// GetJobForStreaming returns a job by ID with ownership check, for SSE streaming.
+// Returns the job regardless of status (caller decides what to do with completed jobs).
+func (s *JobService) GetJobForStreaming(jobID uuid.UUID, userID uuid.UUID) (*models.Job, error) {
+	var job models.Job
+	err := s.db.
+		Select("jobs.*").
+		Joins("JOIN workspaces ON workspaces.id = jobs.workspace_id").
+		Where("jobs.id = ? AND workspaces.owner_id = ?", jobID, userID).
+		First(&job).Error
+
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("fetch job: %w", err)
+	}
+	return &job, nil
+}

--- a/internal/service/job_test.go
+++ b/internal/service/job_test.go
@@ -1,0 +1,143 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/nebari-dev/nebi/internal/models"
+	"gorm.io/gorm"
+)
+
+func jobTestSetup(t *testing.T) (*JobService, *WorkspaceService, *gorm.DB) {
+	t.Helper()
+	wsSvc, db := testSetup(t, false)
+	return NewJobService(db), wsSvc, db
+}
+
+// --- ListJobs ---
+
+func TestJobListJobs_Empty(t *testing.T) {
+	svc, _, db := jobTestSetup(t)
+	userID := createTestUser(t, db, "alice")
+
+	jobs, err := svc.ListJobs(userID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Errorf("expected 0 jobs, got %d", len(jobs))
+	}
+}
+
+func TestJobListJobs_ReturnsOwnedOnly(t *testing.T) {
+	svc, wsSvc, db := jobTestSetup(t)
+	alice := createTestUser(t, db, "alice")
+	bob := createTestUser(t, db, "bob")
+
+	// Create workspaces for both users
+	wsAlice := createReadyWorkspace(t, wsSvc, db, "alice-ws", alice)
+	wsBob := createReadyWorkspace(t, wsSvc, db, "bob-ws", bob)
+
+	// Create jobs via service (install packages)
+	wsSvc.InstallPackages(context.Background(), wsAlice.ID.String(), []string{"numpy"}, alice)
+	wsSvc.InstallPackages(context.Background(), wsBob.ID.String(), []string{"pandas"}, bob)
+
+	// Alice should see her jobs (create + install = 2), not Bob's
+	aliceJobs, err := svc.ListJobs(alice)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	bobJobs, _ := svc.ListJobs(bob)
+
+	if len(aliceJobs) != 2 {
+		t.Errorf("expected 2 jobs for alice (create + install), got %d", len(aliceJobs))
+	}
+	if len(bobJobs) != 2 {
+		t.Errorf("expected 2 jobs for bob (create + install), got %d", len(bobJobs))
+	}
+	// All of Alice's jobs should be for her workspace
+	for _, j := range aliceJobs {
+		if j.WorkspaceID != wsAlice.ID {
+			t.Errorf("expected alice's workspace ID %s, got %s", wsAlice.ID, j.WorkspaceID)
+		}
+	}
+}
+
+// --- GetJob ---
+
+func TestJobGetJob(t *testing.T) {
+	svc, wsSvc, db := jobTestSetup(t)
+	alice := createTestUser(t, db, "alice")
+	ws := createReadyWorkspace(t, wsSvc, db, "test-ws", alice)
+
+	created, _ := wsSvc.InstallPackages(context.Background(), ws.ID.String(), []string{"numpy"}, alice)
+
+	job, err := svc.GetJob(created.ID.String(), alice)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if job.ID != created.ID {
+		t.Errorf("expected job ID %s, got %s", created.ID, job.ID)
+	}
+	if job.Type != models.JobTypeInstall {
+		t.Errorf("expected job type %q, got %q", models.JobTypeInstall, job.Type)
+	}
+}
+
+func TestJobGetJob_NotFound(t *testing.T) {
+	svc, _, db := jobTestSetup(t)
+	alice := createTestUser(t, db, "alice")
+
+	_, err := svc.GetJob(uuid.New().String(), alice)
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestJobGetJob_WrongOwner(t *testing.T) {
+	svc, wsSvc, db := jobTestSetup(t)
+	alice := createTestUser(t, db, "alice")
+	bob := createTestUser(t, db, "bob")
+	ws := createReadyWorkspace(t, wsSvc, db, "alice-ws", alice)
+
+	created, _ := wsSvc.InstallPackages(context.Background(), ws.ID.String(), []string{"numpy"}, alice)
+
+	// Bob should not be able to see Alice's job
+	_, err := svc.GetJob(created.ID.String(), bob)
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound for wrong owner, got %v", err)
+	}
+}
+
+// --- GetJobForStreaming ---
+
+func TestJobGetJobForStreaming(t *testing.T) {
+	svc, wsSvc, db := jobTestSetup(t)
+	alice := createTestUser(t, db, "alice")
+	ws := createReadyWorkspace(t, wsSvc, db, "test-ws", alice)
+
+	created, _ := wsSvc.InstallPackages(context.Background(), ws.ID.String(), []string{"numpy"}, alice)
+
+	job, err := svc.GetJobForStreaming(created.ID, alice)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if job.ID != created.ID {
+		t.Errorf("expected job ID %s, got %s", created.ID, job.ID)
+	}
+}
+
+func TestJobGetJobForStreaming_WrongOwner(t *testing.T) {
+	svc, wsSvc, db := jobTestSetup(t)
+	alice := createTestUser(t, db, "alice")
+	bob := createTestUser(t, db, "bob")
+	ws := createReadyWorkspace(t, wsSvc, db, "alice-ws", alice)
+
+	created, _ := wsSvc.InstallPackages(context.Background(), ws.ID.String(), []string{"numpy"}, alice)
+
+	_, err := svc.GetJobForStreaming(created.ID, bob)
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound for wrong owner, got %v", err)
+	}
+}

--- a/internal/service/registry.go
+++ b/internal/service/registry.go
@@ -1,0 +1,231 @@
+package service
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/google/uuid"
+	nebicrypto "github.com/nebari-dev/nebi/internal/crypto"
+	"github.com/nebari-dev/nebi/internal/models"
+	"gorm.io/gorm"
+)
+
+// RegistryService contains business logic for OCI registry operations.
+type RegistryService struct {
+	db     *gorm.DB
+	encKey []byte
+}
+
+// NewRegistryService creates a new RegistryService.
+func NewRegistryService(db *gorm.DB, encKey []byte) *RegistryService {
+	return &RegistryService{db: db, encKey: encKey}
+}
+
+// RegistryResult is the response type for registry operations.
+type RegistryResult struct {
+	ID          uuid.UUID `json:"id"`
+	Name        string    `json:"name"`
+	URL         string    `json:"url"`
+	Username    string    `json:"username"`
+	HasAPIToken bool      `json:"has_api_token"`
+	IsDefault   bool      `json:"is_default"`
+	Namespace   string    `json:"namespace"`
+	CreatedAt   string    `json:"created_at"`
+}
+
+// CreateRegistryRequest holds parameters for creating a registry.
+type CreateRegistryReq struct {
+	Name      string
+	URL       string
+	Username  string
+	Password  string
+	APIToken  string
+	IsDefault bool
+	Namespace string
+	CreatedBy uuid.UUID
+}
+
+// UpdateRegistryReq holds parameters for updating a registry.
+type UpdateRegistryReq struct {
+	Name      *string
+	URL       *string
+	Username  *string
+	Password  *string
+	APIToken  *string
+	IsDefault *bool
+	Namespace *string
+}
+
+// ListRegistries returns all registries with admin-level detail (includes username, token status).
+func (s *RegistryService) ListRegistries() ([]RegistryResult, error) {
+	var registries []models.OCIRegistry
+	if err := s.db.Find(&registries).Error; err != nil {
+		return nil, fmt.Errorf("fetch registries: %w", err)
+	}
+
+	result := make([]RegistryResult, len(registries))
+	for i, reg := range registries {
+		apiToken, err := nebicrypto.DecryptField(reg.APIToken, s.encKey)
+		if err != nil {
+			slog.Error("Failed to decrypt API token", "registry_id", reg.ID, "error", err)
+		}
+		result[i] = registryToResult(reg, reg.Username, apiToken != "")
+	}
+	return result, nil
+}
+
+// ListPublicRegistries returns registries with public-safe info (no credentials).
+func (s *RegistryService) ListPublicRegistries() ([]RegistryResult, error) {
+	var registries []models.OCIRegistry
+	if err := s.db.Find(&registries).Error; err != nil {
+		return nil, fmt.Errorf("fetch registries: %w", err)
+	}
+
+	result := make([]RegistryResult, len(registries))
+	for i, reg := range registries {
+		result[i] = registryToResult(reg, "", false)
+	}
+	return result, nil
+}
+
+// GetRegistry returns a single registry by ID with admin-level detail.
+func (s *RegistryService) GetRegistry(id string) (*RegistryResult, error) {
+	var registry models.OCIRegistry
+	if err := s.db.Where("id = ?", id).First(&registry).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	apiToken, err := nebicrypto.DecryptField(registry.APIToken, s.encKey)
+	if err != nil {
+		slog.Error("Failed to decrypt API token", "registry_id", registry.ID, "error", err)
+	}
+
+	r := registryToResult(registry, registry.Username, apiToken != "")
+	return &r, nil
+}
+
+// CreateRegistry creates a new registry with encrypted credentials.
+func (s *RegistryService) CreateRegistry(req CreateRegistryReq) (*RegistryResult, error) {
+	if req.IsDefault {
+		s.db.Model(&models.OCIRegistry{}).Where("is_default = ?", true).Update("is_default", false)
+	}
+
+	encPassword, err := nebicrypto.EncryptField(req.Password, s.encKey)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt credentials: %w", err)
+	}
+	encAPIToken, err := nebicrypto.EncryptField(req.APIToken, s.encKey)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt credentials: %w", err)
+	}
+
+	registry := models.OCIRegistry{
+		Name:      req.Name,
+		URL:       req.URL,
+		Username:  req.Username,
+		Password:  encPassword,
+		APIToken:  encAPIToken,
+		IsDefault: req.IsDefault,
+		Namespace: req.Namespace,
+		CreatedBy: req.CreatedBy,
+	}
+
+	if err := s.db.Create(&registry).Error; err != nil {
+		if strings.Contains(err.Error(), "UNIQUE") || strings.Contains(err.Error(), "duplicate") {
+			return nil, &ConflictError{Message: fmt.Sprintf("Registry with name '%s' already exists", req.Name)}
+		}
+		return nil, fmt.Errorf("create registry: %w", err)
+	}
+
+	r := registryToResult(registry, registry.Username, req.APIToken != "")
+	return &r, nil
+}
+
+// UpdateRegistry updates an existing registry.
+func (s *RegistryService) UpdateRegistry(id string, req UpdateRegistryReq) (*RegistryResult, error) {
+	var registry models.OCIRegistry
+	if err := s.db.Where("id = ?", id).First(&registry).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	if req.Name != nil {
+		registry.Name = *req.Name
+	}
+	if req.URL != nil {
+		registry.URL = *req.URL
+	}
+	if req.Username != nil {
+		registry.Username = *req.Username
+	}
+	if req.Password != nil {
+		enc, err := nebicrypto.EncryptField(*req.Password, s.encKey)
+		if err != nil {
+			return nil, fmt.Errorf("encrypt credentials: %w", err)
+		}
+		registry.Password = enc
+	}
+	if req.APIToken != nil {
+		enc, err := nebicrypto.EncryptField(*req.APIToken, s.encKey)
+		if err != nil {
+			return nil, fmt.Errorf("encrypt credentials: %w", err)
+		}
+		registry.APIToken = enc
+	}
+	if req.IsDefault != nil {
+		if *req.IsDefault {
+			s.db.Model(&models.OCIRegistry{}).Where("is_default = ?", true).Update("is_default", false)
+		}
+		registry.IsDefault = *req.IsDefault
+	}
+	if req.Namespace != nil {
+		registry.Namespace = *req.Namespace
+	}
+
+	if err := s.db.Save(&registry).Error; err != nil {
+		return nil, fmt.Errorf("update registry: %w", err)
+	}
+
+	apiToken, err := nebicrypto.DecryptField(registry.APIToken, s.encKey)
+	if err != nil {
+		slog.Error("Failed to decrypt API token", "registry_id", registry.ID, "error", err)
+	}
+
+	r := registryToResult(registry, registry.Username, apiToken != "")
+	return &r, nil
+}
+
+// DeleteRegistry deletes a registry by ID.
+func (s *RegistryService) DeleteRegistry(id string) error {
+	var registry models.OCIRegistry
+	if err := s.db.Where("id = ?", id).First(&registry).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return ErrNotFound
+		}
+		return err
+	}
+
+	if err := s.db.Delete(&registry).Error; err != nil {
+		return fmt.Errorf("delete registry: %w", err)
+	}
+	return nil
+}
+
+func registryToResult(reg models.OCIRegistry, username string, hasAPIToken bool) RegistryResult {
+	return RegistryResult{
+		ID:          reg.ID,
+		Name:        reg.Name,
+		URL:         reg.URL,
+		Username:    username,
+		HasAPIToken: hasAPIToken,
+		IsDefault:   reg.IsDefault,
+		Namespace:   reg.Namespace,
+		CreatedAt:   reg.CreatedAt.Format("2006-01-02 15:04:05"),
+	}
+}

--- a/internal/service/registry_test.go
+++ b/internal/service/registry_test.go
@@ -1,0 +1,202 @@
+package service
+
+import (
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+func registryTestSetup(t *testing.T) (*RegistryService, *gorm.DB) {
+	t.Helper()
+	_, db := testSetup(t, false)
+	// Use a test encryption key
+	encKey := []byte("test-encryption-key-32bytes!!!!!")
+	return NewRegistryService(db, encKey), db
+}
+
+// --- CreateRegistry ---
+
+func TestRegistryCreate(t *testing.T) {
+	svc, _ := registryTestSetup(t)
+
+	result, err := svc.CreateRegistry(CreateRegistryReq{
+		Name:     "test-registry",
+		URL:      "https://ghcr.io",
+		Username: "user",
+		Password: "pass",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Name != "test-registry" {
+		t.Errorf("expected name 'test-registry', got %q", result.Name)
+	}
+	if result.Username != "user" {
+		t.Errorf("expected username 'user', got %q", result.Username)
+	}
+}
+
+func TestRegistryCreate_DuplicateName(t *testing.T) {
+	svc, _ := registryTestSetup(t)
+
+	svc.CreateRegistry(CreateRegistryReq{Name: "dup", URL: "https://a.io"})
+
+	_, err := svc.CreateRegistry(CreateRegistryReq{Name: "dup", URL: "https://b.io"})
+	if err == nil {
+		t.Fatal("expected conflict error for duplicate name")
+	}
+	var ce *ConflictError
+	if !isConflictError(err, &ce) {
+		t.Fatalf("expected ConflictError, got %T: %v", err, err)
+	}
+}
+
+func TestRegistryCreate_SetsDefault(t *testing.T) {
+	svc, db := registryTestSetup(t)
+
+	svc.CreateRegistry(CreateRegistryReq{Name: "r1", URL: "https://a.io", IsDefault: true})
+	svc.CreateRegistry(CreateRegistryReq{Name: "r2", URL: "https://b.io", IsDefault: true})
+
+	// Only r2 should be default
+	registries, _ := svc.ListRegistries()
+	for _, r := range registries {
+		if r.Name == "r1" && r.IsDefault {
+			t.Error("r1 should not be default after r2 was set as default")
+		}
+		if r.Name == "r2" && !r.IsDefault {
+			t.Error("r2 should be default")
+		}
+	}
+	_ = db // used in setup
+}
+
+// --- ListRegistries ---
+
+func TestRegistryList(t *testing.T) {
+	svc, _ := registryTestSetup(t)
+
+	svc.CreateRegistry(CreateRegistryReq{Name: "r1", URL: "https://a.io"})
+	svc.CreateRegistry(CreateRegistryReq{Name: "r2", URL: "https://b.io"})
+
+	registries, err := svc.ListRegistries()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(registries) != 2 {
+		t.Errorf("expected 2 registries, got %d", len(registries))
+	}
+}
+
+// --- ListPublicRegistries ---
+
+func TestRegistryListPublic_HidesCredentials(t *testing.T) {
+	svc, _ := registryTestSetup(t)
+
+	svc.CreateRegistry(CreateRegistryReq{
+		Name:     "public-reg",
+		URL:      "https://ghcr.io",
+		Username: "secret-user",
+		Password: "secret-pass",
+		APIToken: "secret-token",
+	})
+
+	registries, err := svc.ListPublicRegistries()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(registries) != 1 {
+		t.Fatalf("expected 1 registry, got %d", len(registries))
+	}
+
+	if registries[0].Username != "" {
+		t.Errorf("expected empty username in public listing, got %q", registries[0].Username)
+	}
+	if registries[0].HasAPIToken {
+		t.Error("expected HasAPIToken=false in public listing")
+	}
+}
+
+// --- GetRegistry ---
+
+func TestRegistryGet(t *testing.T) {
+	svc, _ := registryTestSetup(t)
+
+	created, _ := svc.CreateRegistry(CreateRegistryReq{Name: "get-me", URL: "https://a.io"})
+
+	result, err := svc.GetRegistry(created.ID.String())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Name != "get-me" {
+		t.Errorf("expected name 'get-me', got %q", result.Name)
+	}
+}
+
+func TestRegistryGet_NotFound(t *testing.T) {
+	svc, _ := registryTestSetup(t)
+
+	_, err := svc.GetRegistry("nonexistent-id")
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// --- UpdateRegistry ---
+
+func TestRegistryUpdate(t *testing.T) {
+	svc, _ := registryTestSetup(t)
+
+	created, _ := svc.CreateRegistry(CreateRegistryReq{Name: "update-me", URL: "https://old.io"})
+
+	newName := "updated-name"
+	newURL := "https://new.io"
+	result, err := svc.UpdateRegistry(created.ID.String(), UpdateRegistryReq{
+		Name: &newName,
+		URL:  &newURL,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Name != "updated-name" {
+		t.Errorf("expected name 'updated-name', got %q", result.Name)
+	}
+	if result.URL != "https://new.io" {
+		t.Errorf("expected URL 'https://new.io', got %q", result.URL)
+	}
+}
+
+func TestRegistryUpdate_NotFound(t *testing.T) {
+	svc, _ := registryTestSetup(t)
+
+	newName := "nope"
+	_, err := svc.UpdateRegistry("nonexistent", UpdateRegistryReq{Name: &newName})
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// --- DeleteRegistry ---
+
+func TestRegistryDelete(t *testing.T) {
+	svc, _ := registryTestSetup(t)
+
+	created, _ := svc.CreateRegistry(CreateRegistryReq{Name: "del-me", URL: "https://a.io"})
+
+	if err := svc.DeleteRegistry(created.ID.String()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err := svc.GetRegistry(created.ID.String())
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestRegistryDelete_NotFound(t *testing.T) {
+	svc, _ := registryTestSetup(t)
+
+	err := svc.DeleteRegistry("nonexistent")
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/internal/swagger/docs.go
+++ b/internal/swagger/docs.go
@@ -74,7 +74,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.DashboardStatsResponse"
+                            "$ref": "#/definitions/service.DashboardStats"
                         }
                     }
                 }
@@ -178,9 +178,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Get list of all configured OCI registries (admin only)",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -194,7 +191,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/handlers.RegistryResponse"
+                                "$ref": "#/definitions/service.RegistryResult"
                             }
                         }
                     },
@@ -238,11 +235,17 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/handlers.RegistryResponse"
+                            "$ref": "#/definitions/service.RegistryResult"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/handlers.ErrorResponse"
                         }
@@ -264,9 +267,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Get details of a specific OCI registry (admin only)",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -287,7 +287,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.RegistryResponse"
+                            "$ref": "#/definitions/service.RegistryResult"
                         }
                     },
                     "404": {
@@ -337,7 +337,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.RegistryResponse"
+                            "$ref": "#/definitions/service.RegistryResult"
                         }
                     },
                     "400": {
@@ -361,12 +361,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Delete an OCI registry configuration (admin only)",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "admin"
                 ],
@@ -440,7 +434,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/handlers.UserWithAdminStatus"
+                                "$ref": "#/definitions/service.UserWithAdmin"
                             }
                         }
                     }
@@ -507,7 +501,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.UserWithAdminStatus"
+                            "$ref": "#/definitions/service.UserWithAdmin"
                         }
                     }
                 }
@@ -562,7 +556,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.UserWithAdminStatus"
+                            "$ref": "#/definitions/service.UserWithAdmin"
                         }
                     }
                 }
@@ -1022,9 +1016,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Get list of registries for users to select from (no credentials exposed)",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1038,7 +1029,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/handlers.RegistryResponse"
+                                "$ref": "#/definitions/service.RegistryResult"
                             }
                         }
                     }
@@ -2298,17 +2289,6 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.DashboardStatsResponse": {
-            "type": "object",
-            "properties": {
-                "total_disk_usage_bytes": {
-                    "type": "integer"
-                },
-                "total_disk_usage_formatted": {
-                    "type": "string"
-                }
-            }
-        },
         "handlers.ErrorResponse": {
             "type": "object",
             "properties": {
@@ -2436,35 +2416,6 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.RegistryResponse": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "has_api_token": {
-                    "type": "boolean"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_default": {
-                    "type": "boolean"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "namespace": {
-                    "type": "string"
-                },
-                "url": {
-                    "type": "string"
-                },
-                "username": {
-                    "type": "string"
-                }
-            }
-        },
         "handlers.RollbackRequest": {
             "type": "object",
             "required": [
@@ -2533,32 +2484,6 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "url": {
-                    "type": "string"
-                },
-                "username": {
-                    "type": "string"
-                }
-            }
-        },
-        "handlers.UserWithAdminStatus": {
-            "type": "object",
-            "properties": {
-                "avatar_url": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_admin": {
-                    "type": "boolean"
-                },
-                "updated_at": {
                     "type": "string"
                 },
                 "username": {
@@ -2919,6 +2844,17 @@ const docTemplate = `{
                 }
             }
         },
+        "service.DashboardStats": {
+            "type": "object",
+            "properties": {
+                "total_disk_usage_bytes": {
+                    "type": "integer"
+                },
+                "total_disk_usage_formatted": {
+                    "type": "string"
+                }
+            }
+        },
         "service.PublicationResult": {
             "type": "object",
             "properties": {
@@ -2973,6 +2909,61 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "service.RegistryResult": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "has_api_token": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_default": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "service.UserWithAdmin": {
+            "type": "object",
+            "properties": {
+                "avatar_url": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_admin": {
+                    "type": "boolean"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "username": {
                     "type": "string"
                 }
             }

--- a/internal/swagger/swagger.json
+++ b/internal/swagger/swagger.json
@@ -68,7 +68,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.DashboardStatsResponse"
+                            "$ref": "#/definitions/service.DashboardStats"
                         }
                     }
                 }
@@ -172,9 +172,6 @@
                     }
                 ],
                 "description": "Get list of all configured OCI registries (admin only)",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -188,7 +185,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/handlers.RegistryResponse"
+                                "$ref": "#/definitions/service.RegistryResult"
                             }
                         }
                     },
@@ -232,11 +229,17 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/handlers.RegistryResponse"
+                            "$ref": "#/definitions/service.RegistryResult"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/handlers.ErrorResponse"
                         }
@@ -258,9 +261,6 @@
                     }
                 ],
                 "description": "Get details of a specific OCI registry (admin only)",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -281,7 +281,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.RegistryResponse"
+                            "$ref": "#/definitions/service.RegistryResult"
                         }
                     },
                     "404": {
@@ -331,7 +331,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.RegistryResponse"
+                            "$ref": "#/definitions/service.RegistryResult"
                         }
                     },
                     "400": {
@@ -355,12 +355,6 @@
                     }
                 ],
                 "description": "Delete an OCI registry configuration (admin only)",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "admin"
                 ],
@@ -434,7 +428,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/handlers.UserWithAdminStatus"
+                                "$ref": "#/definitions/service.UserWithAdmin"
                             }
                         }
                     }
@@ -501,7 +495,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.UserWithAdminStatus"
+                            "$ref": "#/definitions/service.UserWithAdmin"
                         }
                     }
                 }
@@ -556,7 +550,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.UserWithAdminStatus"
+                            "$ref": "#/definitions/service.UserWithAdmin"
                         }
                     }
                 }
@@ -1016,9 +1010,6 @@
                     }
                 ],
                 "description": "Get list of registries for users to select from (no credentials exposed)",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -1032,7 +1023,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/handlers.RegistryResponse"
+                                "$ref": "#/definitions/service.RegistryResult"
                             }
                         }
                     }
@@ -2292,17 +2283,6 @@
                 }
             }
         },
-        "handlers.DashboardStatsResponse": {
-            "type": "object",
-            "properties": {
-                "total_disk_usage_bytes": {
-                    "type": "integer"
-                },
-                "total_disk_usage_formatted": {
-                    "type": "string"
-                }
-            }
-        },
         "handlers.ErrorResponse": {
             "type": "object",
             "properties": {
@@ -2430,35 +2410,6 @@
                 }
             }
         },
-        "handlers.RegistryResponse": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "has_api_token": {
-                    "type": "boolean"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_default": {
-                    "type": "boolean"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "namespace": {
-                    "type": "string"
-                },
-                "url": {
-                    "type": "string"
-                },
-                "username": {
-                    "type": "string"
-                }
-            }
-        },
         "handlers.RollbackRequest": {
             "type": "object",
             "required": [
@@ -2527,32 +2478,6 @@
                     "type": "string"
                 },
                 "url": {
-                    "type": "string"
-                },
-                "username": {
-                    "type": "string"
-                }
-            }
-        },
-        "handlers.UserWithAdminStatus": {
-            "type": "object",
-            "properties": {
-                "avatar_url": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_admin": {
-                    "type": "boolean"
-                },
-                "updated_at": {
                     "type": "string"
                 },
                 "username": {
@@ -2913,6 +2838,17 @@
                 }
             }
         },
+        "service.DashboardStats": {
+            "type": "object",
+            "properties": {
+                "total_disk_usage_bytes": {
+                    "type": "integer"
+                },
+                "total_disk_usage_formatted": {
+                    "type": "string"
+                }
+            }
+        },
         "service.PublicationResult": {
             "type": "object",
             "properties": {
@@ -2967,6 +2903,61 @@
                     "type": "string"
                 },
                 "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "service.RegistryResult": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "has_api_token": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_default": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "service.UserWithAdmin": {
+            "type": "object",
+            "properties": {
+                "avatar_url": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_admin": {
+                    "type": "boolean"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "username": {
                     "type": "string"
                 }
             }

--- a/internal/swagger/swagger.yaml
+++ b/internal/swagger/swagger.yaml
@@ -67,13 +67,6 @@ definitions:
     required:
     - name
     type: object
-  handlers.DashboardStatsResponse:
-    properties:
-      total_disk_usage_bytes:
-        type: integer
-      total_disk_usage_formatted:
-        type: string
-    type: object
   handlers.ErrorResponse:
     properties:
       error:
@@ -158,25 +151,6 @@ definitions:
       version_number:
         type: integer
     type: object
-  handlers.RegistryResponse:
-    properties:
-      created_at:
-        type: string
-      has_api_token:
-        type: boolean
-      id:
-        type: string
-      is_default:
-        type: boolean
-      name:
-        type: string
-      namespace:
-        type: string
-      url:
-        type: string
-      username:
-        type: string
-    type: object
   handlers.RollbackRequest:
     properties:
       version_number:
@@ -222,23 +196,6 @@ definitions:
       password:
         type: string
       url:
-        type: string
-      username:
-        type: string
-    type: object
-  handlers.UserWithAdminStatus:
-    properties:
-      avatar_url:
-        type: string
-      created_at:
-        type: string
-      email:
-        type: string
-      id:
-        type: string
-      is_admin:
-        type: boolean
-      updated_at:
         type: string
       username:
         type: string
@@ -489,6 +446,13 @@ definitions:
       username:
         type: string
     type: object
+  service.DashboardStats:
+    properties:
+      total_disk_usage_bytes:
+        type: integer
+      total_disk_usage_formatted:
+        type: string
+    type: object
   service.PublicationResult:
     properties:
       digest:
@@ -525,6 +489,42 @@ definitions:
       repository:
         type: string
       tag:
+        type: string
+    type: object
+  service.RegistryResult:
+    properties:
+      created_at:
+        type: string
+      has_api_token:
+        type: boolean
+      id:
+        type: string
+      is_default:
+        type: boolean
+      name:
+        type: string
+      namespace:
+        type: string
+      url:
+        type: string
+      username:
+        type: string
+    type: object
+  service.UserWithAdmin:
+    properties:
+      avatar_url:
+        type: string
+      created_at:
+        type: string
+      email:
+        type: string
+      id:
+        type: string
+      is_admin:
+        type: boolean
+      updated_at:
+        type: string
+      username:
         type: string
     type: object
 host: localhost:8460
@@ -567,7 +567,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.DashboardStatsResponse'
+            $ref: '#/definitions/service.DashboardStats'
       security:
       - BearerAuth: []
       summary: Get admin dashboard statistics
@@ -629,8 +629,6 @@ paths:
       - admin
   /admin/registries:
     get:
-      consumes:
-      - application/json
       description: Get list of all configured OCI registries (admin only)
       produces:
       - application/json
@@ -639,7 +637,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/handlers.RegistryResponse'
+              $ref: '#/definitions/service.RegistryResult'
             type: array
         "500":
           description: Internal Server Error
@@ -667,9 +665,13 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/handlers.RegistryResponse'
+            $ref: '#/definitions/service.RegistryResult'
         "400":
           description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/handlers.ErrorResponse'
         "500":
@@ -683,8 +685,6 @@ paths:
       - admin
   /admin/registries/{id}:
     delete:
-      consumes:
-      - application/json
       description: Delete an OCI registry configuration (admin only)
       parameters:
       - description: Registry ID
@@ -692,8 +692,6 @@ paths:
         name: id
         required: true
         type: string
-      produces:
-      - application/json
       responses:
         "204":
           description: No Content
@@ -707,8 +705,6 @@ paths:
       tags:
       - admin
     get:
-      consumes:
-      - application/json
       description: Get details of a specific OCI registry (admin only)
       parameters:
       - description: Registry ID
@@ -722,7 +718,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.RegistryResponse'
+            $ref: '#/definitions/service.RegistryResult'
         "404":
           description: Not Found
           schema:
@@ -754,7 +750,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.RegistryResponse'
+            $ref: '#/definitions/service.RegistryResult'
         "400":
           description: Bad Request
           schema:
@@ -793,7 +789,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/handlers.UserWithAdminStatus'
+              $ref: '#/definitions/service.UserWithAdmin'
             type: array
       security:
       - BearerAuth: []
@@ -849,7 +845,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.UserWithAdminStatus'
+            $ref: '#/definitions/service.UserWithAdmin'
       security:
       - BearerAuth: []
       summary: Get user by ID (admin only)
@@ -867,7 +863,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.UserWithAdminStatus'
+            $ref: '#/definitions/service.UserWithAdmin'
       security:
       - BearerAuth: []
       summary: Toggle admin status for a user
@@ -1168,8 +1164,6 @@ paths:
       - jobs
   /registries:
     get:
-      consumes:
-      - application/json
       description: Get list of registries for users to select from (no credentials
         exposed)
       produces:
@@ -1179,7 +1173,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/handlers.RegistryResponse'
+              $ref: '#/definitions/service.RegistryResult'
             type: array
       security:
       - BearerAuth: []


### PR DESCRIPTION
## Summary

- Extracts business logic from AdminHandler, RegistryHandler, and JobHandler into dedicated service structs (`AdminService`, `RegistryService`, `JobService`), completing the service layer migration started in #281
- All three handlers now delegate to services — no handler holds `*gorm.DB` or `encKey` directly
- AdminHandler's `c.MustGet("user")` panic risk replaced with safe `getAdminUserID` pattern
- 36 new service-level tests covering user CRUD, permission management, registry CRUD, credential hiding, job ownership isolation

### Handler changes

| Handler | Before | After |
|---|---|---|
| AdminHandler | `*gorm.DB` + direct RBAC + audit calls | `*AdminService` only |
| RegistryHandler | `*gorm.DB` + `encKey` + crypto calls | `*RegistryService` only |
| JobHandler | `*gorm.DB` + broker + valkey | `*JobService` + broker + valkey (SSE stays in handler) |

### Test count

Service tests: 60 -> 96 (36 new)