### PR TITLE
refactor: injectable RBAC, DB transactions, remove worker DB access

### DIFF
--- a/app.go
+++ b/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nebari-dev/nebi/internal/executor"
 	"github.com/nebari-dev/nebi/internal/models"
 	"github.com/nebari-dev/nebi/internal/queue"
+	"github.com/nebari-dev/nebi/internal/rbac"
 	"github.com/nebari-dev/nebi/internal/service"
 	"github.com/nebari-dev/nebi/internal/store"
 	"github.com/nebari-dev/nebi/internal/worker"
@@ -173,8 +174,9 @@ func (a *App) startEmbeddedServer(cfg *config.Config, database *gorm.DB) {
 	logToFile("startEmbeddedServer: executor initialized")
 
 	// Create service and worker (desktop app uses local mode, no encryption key needed)
-	svc := service.New(database, jobQueue, exec, true, nil)
-	w := worker.New(database, jobQueue, exec, svc, slog.Default(), nil)
+	svc := service.New(database, jobQueue, exec, true, nil, rbac.NewDefaultProvider())
+	jobSvc := service.NewJobService(database)
+	w := worker.New(jobQueue, exec, svc, jobSvc, slog.Default(), nil)
 	workerCtx, workerCancel := context.WithCancel(context.Background())
 	_ = workerCancel // Keep reference to avoid unused warning
 	logToFile("startEmbeddedServer: worker created")

--- a/internal/api/handlers/admin.go
+++ b/internal/api/handlers/admin.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"github.com/nebari-dev/nebi/internal/models"
 	"github.com/nebari-dev/nebi/internal/service"
 )
 
@@ -247,11 +246,5 @@ type GrantPermissionRequest struct {
 	RoleID      uint      `json:"role_id" binding:"required"`
 }
 
-// getAdminUserID extracts the admin user ID from context.
-func getAdminUserID(c *gin.Context) uuid.UUID {
-	user, exists := c.Get("user")
-	if !exists {
-		return uuid.Nil
-	}
-	return user.(*models.User).ID
-}
+// getAdminUserID reuses getUserID from helpers.go.
+var getAdminUserID = getUserID

--- a/internal/api/handlers/helpers.go
+++ b/internal/api/handlers/helpers.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/nebari-dev/nebi/internal/models"
+	"github.com/nebari-dev/nebi/internal/service"
+)
+
+// handleServiceError maps service-layer errors to HTTP status codes.
+func handleServiceError(c *gin.Context, err error) {
+	if errors.Is(err, service.ErrNotFound) {
+		c.JSON(http.StatusNotFound, ErrorResponse{Error: "Not found"})
+		return
+	}
+	var validationErr *service.ValidationError
+	if errors.As(err, &validationErr) {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: validationErr.Message})
+		return
+	}
+	var conflictErr *service.ConflictError
+	if errors.As(err, &conflictErr) {
+		c.JSON(http.StatusConflict, ErrorResponse{Error: conflictErr.Message})
+		return
+	}
+	var forbiddenErr *service.ForbiddenError
+	if errors.As(err, &forbiddenErr) {
+		c.JSON(http.StatusForbidden, ErrorResponse{Error: forbiddenErr.Message})
+		return
+	}
+	slog.Error("unhandled service error", "error", err)
+	c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Internal server error"})
+}
+
+// getUserID extracts the user ID from the Gin context.
+func getUserID(c *gin.Context) uuid.UUID {
+	user, exists := c.Get("user")
+	if !exists {
+		return uuid.Nil
+	}
+	return user.(*models.User).ID
+}

--- a/internal/api/handlers/workspace.go
+++ b/internal/api/handlers/workspace.go
@@ -1,14 +1,11 @@
 package handlers
 
 import (
-	"errors"
 	"fmt"
-	"log/slog"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"github.com/nebari-dev/nebi/internal/models"
 	"github.com/nebari-dev/nebi/internal/service"
 )
 
@@ -18,31 +15,6 @@ type WorkspaceHandler struct {
 
 func NewWorkspaceHandler(svc *service.WorkspaceService) *WorkspaceHandler {
 	return &WorkspaceHandler{svc: svc}
-}
-
-// handleServiceError maps service-layer errors to HTTP status codes.
-func handleServiceError(c *gin.Context, err error) {
-	if errors.Is(err, service.ErrNotFound) {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "Not found"})
-		return
-	}
-	var validationErr *service.ValidationError
-	if errors.As(err, &validationErr) {
-		c.JSON(http.StatusBadRequest, ErrorResponse{Error: validationErr.Message})
-		return
-	}
-	var conflictErr *service.ConflictError
-	if errors.As(err, &conflictErr) {
-		c.JSON(http.StatusConflict, ErrorResponse{Error: conflictErr.Message})
-		return
-	}
-	var forbiddenErr *service.ForbiddenError
-	if errors.As(err, &forbiddenErr) {
-		c.JSON(http.StatusForbidden, ErrorResponse{Error: forbiddenErr.Message})
-		return
-	}
-	slog.Error("unhandled service error", "error", err)
-	c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Internal server error"})
 }
 
 // ListWorkspaces godoc
@@ -653,11 +625,4 @@ type UpdatePublicationRequest struct {
 	IsPublic *bool `json:"is_public" binding:"required"`
 }
 
-// Helper function to get user ID from context
-func getUserID(c *gin.Context) uuid.UUID {
-	user, exists := c.Get("user")
-	if !exists {
-		return uuid.Nil
-	}
-	return user.(*models.User).ID
-}
+// getUserID is in helpers.go

--- a/internal/api/middleware/rbac.go
+++ b/internal/api/middleware/rbac.go
@@ -11,7 +11,7 @@ import (
 
 // RequireAdmin ensures the user is an admin.
 // When localMode is true the check is unconditionally skipped.
-func RequireAdmin(localMode bool) gin.HandlerFunc {
+func RequireAdmin(localMode bool, provider rbac.Provider) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if localMode {
 			c.Next()
@@ -26,7 +26,7 @@ func RequireAdmin(localMode bool) gin.HandlerFunc {
 		}
 
 		userID := user.(*models.User).ID
-		isAdmin, err := rbac.IsAdmin(userID)
+		isAdmin, err := provider.IsAdmin(userID)
 		if err != nil || !isAdmin {
 			c.JSON(http.StatusForbidden, gin.H{"error": "Admin access required"})
 			c.Abort()
@@ -39,7 +39,7 @@ func RequireAdmin(localMode bool) gin.HandlerFunc {
 
 // RequireWorkspaceAccess checks if user can access a workspace.
 // When localMode is true the check is unconditionally skipped.
-func RequireWorkspaceAccess(action string, localMode bool) gin.HandlerFunc {
+func RequireWorkspaceAccess(action string, localMode bool, provider rbac.Provider) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if localMode {
 			c.Next()
@@ -65,9 +65,9 @@ func RequireWorkspaceAccess(action string, localMode bool) gin.HandlerFunc {
 
 		var hasAccess bool
 		if action == "read" {
-			hasAccess, err = rbac.CanReadWorkspace(userID, wsID)
+			hasAccess, err = provider.CanReadWorkspace(userID, wsID)
 		} else if action == "write" {
-			hasAccess, err = rbac.CanWriteWorkspace(userID, wsID)
+			hasAccess, err = provider.CanWriteWorkspace(userID, wsID)
 		}
 
 		if err != nil || !hasAccess {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -27,11 +27,12 @@ import (
 
 // NewRouter creates and configures the Gin router
 func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Executor, logBroker *logstream.LogBroker, valkeyClient interface{}, logger *slog.Logger) *gin.Engine {
-	// Initialize RBAC enforcer
+	// Initialize RBAC enforcer and provider
 	if err := rbac.InitEnforcer(db, logger); err != nil {
 		logger.Error("Failed to initialize RBAC", "error", err)
 		panic(err)
 	}
+	rbacProvider := rbac.NewDefaultProvider()
 
 	// Set Gin mode
 	if cfg.Server.Mode == "production" {
@@ -172,8 +173,8 @@ func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Exe
 	}
 
 	// Initialize services and handlers
-	svc := service.New(db, q, exec, localMode, encKey)
-	adminSvc := service.NewAdminService(db)
+	svc := service.New(db, q, exec, localMode, encKey, rbacProvider)
+	adminSvc := service.NewAdminService(db, rbacProvider)
 	registrySvc := service.NewRegistryService(db, encKey)
 	jobSvc := service.NewJobService(db)
 
@@ -195,37 +196,37 @@ func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Exe
 		ws := protected.Group("/workspaces/:id")
 		{
 			// Read operations (require read permission)
-			ws.GET("", middleware.RequireWorkspaceAccess("read", localMode), wsHandler.GetWorkspace)
-			ws.GET("/packages", middleware.RequireWorkspaceAccess("read", localMode), wsHandler.ListPackages)
-			ws.GET("/pixi-toml", middleware.RequireWorkspaceAccess("read", localMode), wsHandler.GetPixiToml)
-			ws.GET("/collaborators", middleware.RequireWorkspaceAccess("read", localMode), wsHandler.ListCollaborators)
+			ws.GET("", middleware.RequireWorkspaceAccess("read", localMode, rbacProvider), wsHandler.GetWorkspace)
+			ws.GET("/packages", middleware.RequireWorkspaceAccess("read", localMode, rbacProvider), wsHandler.ListPackages)
+			ws.GET("/pixi-toml", middleware.RequireWorkspaceAccess("read", localMode, rbacProvider), wsHandler.GetPixiToml)
+			ws.GET("/collaborators", middleware.RequireWorkspaceAccess("read", localMode, rbacProvider), wsHandler.ListCollaborators)
 
 			// Version operations (read permission)
-			ws.GET("/versions", middleware.RequireWorkspaceAccess("read", localMode), wsHandler.ListVersions)
-			ws.GET("/versions/:version", middleware.RequireWorkspaceAccess("read", localMode), wsHandler.GetVersion)
-			ws.GET("/versions/:version/pixi-lock", middleware.RequireWorkspaceAccess("read", localMode), wsHandler.DownloadLockFile)
-			ws.GET("/versions/:version/pixi-toml", middleware.RequireWorkspaceAccess("read", localMode), wsHandler.DownloadManifestFile)
+			ws.GET("/versions", middleware.RequireWorkspaceAccess("read", localMode, rbacProvider), wsHandler.ListVersions)
+			ws.GET("/versions/:version", middleware.RequireWorkspaceAccess("read", localMode, rbacProvider), wsHandler.GetVersion)
+			ws.GET("/versions/:version/pixi-lock", middleware.RequireWorkspaceAccess("read", localMode, rbacProvider), wsHandler.DownloadLockFile)
+			ws.GET("/versions/:version/pixi-toml", middleware.RequireWorkspaceAccess("read", localMode, rbacProvider), wsHandler.DownloadManifestFile)
 
 			// Write operations (require write permission)
-			ws.PUT("/pixi-toml", middleware.RequireWorkspaceAccess("write", localMode), wsHandler.SavePixiToml)
-			ws.DELETE("", middleware.RequireWorkspaceAccess("write", localMode), wsHandler.DeleteWorkspace)
-			ws.POST("/packages", middleware.RequireWorkspaceAccess("write", localMode), wsHandler.InstallPackages)
-			ws.DELETE("/packages/:package", middleware.RequireWorkspaceAccess("write", localMode), wsHandler.RemovePackages)
-			ws.POST("/rollback", middleware.RequireWorkspaceAccess("write", localMode), wsHandler.RollbackToVersion)
+			ws.PUT("/pixi-toml", middleware.RequireWorkspaceAccess("write", localMode, rbacProvider), wsHandler.SavePixiToml)
+			ws.DELETE("", middleware.RequireWorkspaceAccess("write", localMode, rbacProvider), wsHandler.DeleteWorkspace)
+			ws.POST("/packages", middleware.RequireWorkspaceAccess("write", localMode, rbacProvider), wsHandler.InstallPackages)
+			ws.DELETE("/packages/:package", middleware.RequireWorkspaceAccess("write", localMode, rbacProvider), wsHandler.RemovePackages)
+			ws.POST("/rollback", middleware.RequireWorkspaceAccess("write", localMode, rbacProvider), wsHandler.RollbackToVersion)
 
 			// Sharing operations (owner only - checked in handler)
 			ws.POST("/share", wsHandler.ShareWorkspace)
 			ws.DELETE("/share/:user_id", wsHandler.UnshareWorkspace)
 
 			// Tags (read permission)
-			ws.GET("/tags", middleware.RequireWorkspaceAccess("read", localMode), wsHandler.ListTags)
+			ws.GET("/tags", middleware.RequireWorkspaceAccess("read", localMode, rbacProvider), wsHandler.ListTags)
 
 			// Push and publish operations (require write permission)
-			ws.POST("/push", middleware.RequireWorkspaceAccess("write", localMode), wsHandler.PushVersion)
-			ws.POST("/publish", middleware.RequireWorkspaceAccess("write", localMode), wsHandler.PublishWorkspace)
-			ws.GET("/publications", middleware.RequireWorkspaceAccess("read", localMode), wsHandler.ListPublications)
-			ws.PATCH("/publications/:pubId", middleware.RequireWorkspaceAccess("write", localMode), wsHandler.UpdatePublication)
-			ws.GET("/publish-defaults", middleware.RequireWorkspaceAccess("read", localMode), wsHandler.GetPublishDefaults)
+			ws.POST("/push", middleware.RequireWorkspaceAccess("write", localMode, rbacProvider), wsHandler.PushVersion)
+			ws.POST("/publish", middleware.RequireWorkspaceAccess("write", localMode, rbacProvider), wsHandler.PublishWorkspace)
+			ws.GET("/publications", middleware.RequireWorkspaceAccess("read", localMode, rbacProvider), wsHandler.ListPublications)
+			ws.PATCH("/publications/:pubId", middleware.RequireWorkspaceAccess("write", localMode, rbacProvider), wsHandler.UpdatePublication)
+			ws.GET("/publish-defaults", middleware.RequireWorkspaceAccess("read", localMode, rbacProvider), wsHandler.GetPublishDefaults)
 		}
 
 		// Job endpoints
@@ -250,7 +251,7 @@ func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Exe
 		// Admin endpoints (require admin role)
 		adminHandler := handlers.NewAdminHandler(adminSvc)
 		admin := protected.Group("/admin")
-		admin.Use(middleware.RequireAdmin(localMode))
+		admin.Use(middleware.RequireAdmin(localMode, rbacProvider))
 		{
 			// User management
 			admin.GET("/users", adminHandler.ListUsers)

--- a/internal/rbac/provider.go
+++ b/internal/rbac/provider.go
@@ -1,0 +1,46 @@
+package rbac
+
+import "github.com/google/uuid"
+
+// Provider abstracts RBAC operations so callers can use dependency injection
+// instead of the global enforcer. This enables per-test isolation and mocking.
+type Provider interface {
+	CanReadWorkspace(userID, wsID uuid.UUID) (bool, error)
+	CanWriteWorkspace(userID, wsID uuid.UUID) (bool, error)
+	IsAdmin(userID uuid.UUID) (bool, error)
+	GrantWorkspaceAccess(userID, wsID uuid.UUID, role string) error
+	RevokeWorkspaceAccess(userID, wsID uuid.UUID) error
+	MakeAdmin(userID uuid.UUID) error
+	RevokeAdmin(userID uuid.UUID) error
+	GetAllAdminUserIDs() (map[uuid.UUID]bool, error)
+}
+
+// DefaultProvider wraps the global Casbin enforcer as an rbac.Provider.
+type DefaultProvider struct{}
+
+func NewDefaultProvider() *DefaultProvider { return &DefaultProvider{} }
+
+func (DefaultProvider) CanReadWorkspace(userID, wsID uuid.UUID) (bool, error) {
+	return CanReadWorkspace(userID, wsID)
+}
+func (DefaultProvider) CanWriteWorkspace(userID, wsID uuid.UUID) (bool, error) {
+	return CanWriteWorkspace(userID, wsID)
+}
+func (DefaultProvider) IsAdmin(userID uuid.UUID) (bool, error) {
+	return IsAdmin(userID)
+}
+func (DefaultProvider) GrantWorkspaceAccess(userID, wsID uuid.UUID, role string) error {
+	return GrantWorkspaceAccess(userID, wsID, role)
+}
+func (DefaultProvider) RevokeWorkspaceAccess(userID, wsID uuid.UUID) error {
+	return RevokeWorkspaceAccess(userID, wsID)
+}
+func (DefaultProvider) MakeAdmin(userID uuid.UUID) error {
+	return MakeAdmin(userID)
+}
+func (DefaultProvider) RevokeAdmin(userID uuid.UUID) error {
+	return RevokeAdmin(userID)
+}
+func (DefaultProvider) GetAllAdminUserIDs() (map[uuid.UUID]bool, error) {
+	return GetAllAdminUserIDs()
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nebari-dev/nebi/internal/logger"
 	"github.com/nebari-dev/nebi/internal/logstream"
 	"github.com/nebari-dev/nebi/internal/queue"
+	"github.com/nebari-dev/nebi/internal/rbac"
 	"github.com/nebari-dev/nebi/internal/service"
 	"github.com/nebari-dev/nebi/internal/store"
 	"github.com/nebari-dev/nebi/internal/worker"
@@ -147,11 +148,12 @@ func Run(ctx context.Context, cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to derive encryption key: %w", err)
 	}
-	workerSvc := service.New(database, jobQueue, exec, appCfg.IsLocalMode(), workerEncKey)
+	workerSvc := service.New(database, jobQueue, exec, appCfg.IsLocalMode(), workerEncKey, rbac.NewDefaultProvider())
+	workerJobSvc := service.NewJobService(database)
 
 	// Initialize and start worker if needed
 	if runWorker {
-		w = worker.New(database, jobQueue, exec, workerSvc, slog.Default(), valkeyClient)
+		w = worker.New(jobQueue, exec, workerSvc, workerJobSvc, slog.Default(), valkeyClient)
 		workerCtx, cancel := context.WithCancel(ctx)
 		workerCancel = cancel
 

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -14,12 +14,13 @@ import (
 
 // AdminService contains business logic for admin operations.
 type AdminService struct {
-	db *gorm.DB
+	db   *gorm.DB
+	rbac rbac.Provider
 }
 
 // NewAdminService creates a new AdminService.
-func NewAdminService(db *gorm.DB) *AdminService {
-	return &AdminService{db: db}
+func NewAdminService(db *gorm.DB, rbacProvider rbac.Provider) *AdminService {
+	return &AdminService{db: db, rbac: rbacProvider}
 }
 
 // UserWithAdmin wraps a user with their admin status.
@@ -49,7 +50,7 @@ func (s *AdminService) ListUsers() ([]UserWithAdmin, error) {
 		return nil, fmt.Errorf("fetch users: %w", err)
 	}
 
-	adminUserIDs, err := rbac.GetAllAdminUserIDs()
+	adminUserIDs, err := s.rbac.GetAllAdminUserIDs()
 	if err != nil {
 		return nil, fmt.Errorf("check admin status: %w", err)
 	}
@@ -82,7 +83,7 @@ func (s *AdminService) CreateUser(req CreateUserRequest, adminUserID uuid.UUID) 
 	}
 
 	if req.IsAdmin {
-		if err := rbac.MakeAdmin(user.ID); err != nil {
+		if err := s.rbac.MakeAdmin(user.ID); err != nil {
 			return nil, fmt.Errorf("grant admin: %w", err)
 		}
 	}
@@ -106,7 +107,7 @@ func (s *AdminService) GetUser(userID uuid.UUID) (*UserWithAdmin, error) {
 		return nil, err
 	}
 
-	isAdmin, _ := rbac.IsAdmin(user.ID)
+	isAdmin, _ := s.rbac.IsAdmin(user.ID)
 	return &UserWithAdmin{User: user, IsAdmin: isAdmin}, nil
 }
 
@@ -120,15 +121,15 @@ func (s *AdminService) ToggleAdmin(userID uuid.UUID, adminUserID uuid.UUID) (*Us
 		return nil, err
 	}
 
-	isAdmin, _ := rbac.IsAdmin(user.ID)
+	isAdmin, _ := s.rbac.IsAdmin(user.ID)
 
 	if isAdmin {
-		if err := rbac.RevokeAdmin(user.ID); err != nil {
+		if err := s.rbac.RevokeAdmin(user.ID); err != nil {
 			return nil, fmt.Errorf("revoke admin: %w", err)
 		}
 		audit.LogAction(s.db, adminUserID, audit.ActionRevokeAdmin, "user:"+user.ID.String(), nil)
 	} else {
-		if err := rbac.MakeAdmin(user.ID); err != nil {
+		if err := s.rbac.MakeAdmin(user.ID); err != nil {
 			return nil, fmt.Errorf("make admin: %w", err)
 		}
 		audit.LogAction(s.db, adminUserID, audit.ActionMakeAdmin, "user:"+user.ID.String(), nil)
@@ -197,24 +198,32 @@ func (s *AdminService) GrantPermission(userID, workspaceID uuid.UUID, roleID uin
 		return nil, err
 	}
 
-	permission := models.Permission{
-		UserID:      userID,
-		WorkspaceID: workspaceID,
-		RoleID:      roleID,
-	}
-	if err := s.db.Create(&permission).Error; err != nil {
-		return nil, fmt.Errorf("create permission: %w", err)
+	var permission models.Permission
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		permission = models.Permission{
+			UserID:      userID,
+			WorkspaceID: workspaceID,
+			RoleID:      roleID,
+		}
+		if err := tx.Create(&permission).Error; err != nil {
+			return fmt.Errorf("create permission: %w", err)
+		}
+
+		audit.LogAction(tx, adminUserID, audit.ActionGrantPermission, fmt.Sprintf("permission:%d", permission.ID), map[string]any{
+			"user_id":      userID,
+			"workspace_id": workspaceID,
+			"role":         role.Name,
+		})
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	if err := rbac.GrantWorkspaceAccess(user.ID, ws.ID, role.Name); err != nil {
+	if err := s.rbac.GrantWorkspaceAccess(user.ID, ws.ID, role.Name); err != nil {
 		return nil, fmt.Errorf("grant RBAC permission: %w", err)
 	}
-
-	audit.LogAction(s.db, adminUserID, audit.ActionGrantPermission, fmt.Sprintf("permission:%d", permission.ID), map[string]any{
-		"user_id":      userID,
-		"workspace_id": workspaceID,
-		"role":         role.Name,
-	})
 
 	return &permission, nil
 }
@@ -231,25 +240,32 @@ func (s *AdminService) ListPermissions() ([]models.Permission, error) {
 // RevokePermission revokes a permission by ID and removes RBAC access.
 func (s *AdminService) RevokePermission(permissionID string, adminUserID uuid.UUID) error {
 	var permission models.Permission
-	if err := s.db.Preload("User").Preload("Workspace").First(&permission, permissionID).Error; err != nil {
+	if err := s.db.Preload("User").Preload("Workspace").First(&permission, "id = ?", permissionID).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return ErrNotFound
 		}
 		return err
 	}
 
-	if err := rbac.RevokeWorkspaceAccess(permission.UserID, permission.WorkspaceID); err != nil {
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Delete(&permission).Error; err != nil {
+			return fmt.Errorf("delete permission: %w", err)
+		}
+
+		audit.LogAction(tx, adminUserID, audit.ActionRevokePermission, "permission:"+permissionID, map[string]any{
+			"user_id":      permission.UserID,
+			"workspace_id": permission.WorkspaceID,
+		})
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := s.rbac.RevokeWorkspaceAccess(permission.UserID, permission.WorkspaceID); err != nil {
 		return fmt.Errorf("revoke RBAC permission: %w", err)
 	}
-
-	if err := s.db.Delete(&permission).Error; err != nil {
-		return fmt.Errorf("delete permission: %w", err)
-	}
-
-	audit.LogAction(s.db, adminUserID, audit.ActionRevokePermission, "permission:"+permissionID, map[string]any{
-		"user_id":      permission.UserID,
-		"workspace_id": permission.WorkspaceID,
-	})
 
 	return nil
 }

--- a/internal/service/admin_test.go
+++ b/internal/service/admin_test.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/nebari-dev/nebi/internal/models"
+	"github.com/nebari-dev/nebi/internal/rbac"
 	"gorm.io/gorm"
 )
 
 func adminTestSetup(t *testing.T) (*AdminService, *WorkspaceService, *gorm.DB) {
 	t.Helper()
 	wsSvc, db := testSetup(t, false)
-	return NewAdminService(db), wsSvc, db
+	return NewAdminService(db, rbac.NewDefaultProvider()), wsSvc, db
 }
 
 // --- ListUsers ---

--- a/internal/service/job.go
+++ b/internal/service/job.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/nebari-dev/nebi/internal/models"
@@ -69,4 +70,65 @@ func (s *JobService) GetJobForStreaming(jobID uuid.UUID, userID uuid.UUID) (*mod
 		return nil, fmt.Errorf("fetch job: %w", err)
 	}
 	return &job, nil
+}
+
+// --- Worker-facing methods ---
+
+// MarkRunning sets a job's status to running with a start timestamp.
+func (s *JobService) MarkRunning(job *models.Job) {
+	job.Status = models.JobStatusRunning
+	now := time.Now()
+	job.StartedAt = &now
+	s.db.Save(job)
+}
+
+// MarkCompleted sets a job's status to completed with final logs.
+func (s *JobService) MarkCompleted(job *models.Job, logs string) {
+	completedAt := time.Now()
+	job.CompletedAt = &completedAt
+	job.Status = models.JobStatusCompleted
+	job.Logs = logs
+	s.db.Save(job)
+}
+
+// MarkFailed sets a job's status to failed with error and final logs.
+func (s *JobService) MarkFailed(job *models.Job, logs string, errMsg string) {
+	completedAt := time.Now()
+	job.CompletedAt = &completedAt
+	job.Status = models.JobStatusFailed
+	job.Error = errMsg
+	job.Logs = logs
+	s.db.Save(job)
+}
+
+// MarkPanicked sets a job as failed after a panic recovery.
+func (s *JobService) MarkPanicked(job *models.Job, panicMsg string) {
+	completedAt := time.Now()
+	job.CompletedAt = &completedAt
+	job.Status = models.JobStatusFailed
+	job.Error = panicMsg
+	s.db.Save(job)
+}
+
+// FlushLogs persists the current log content for a job.
+func (s *JobService) FlushLogs(jobID uuid.UUID, logs string) error {
+	return s.db.Model(&models.Job{}).Where("id = ?", jobID).Update("logs", logs).Error
+}
+
+// LoadWorkspace loads a workspace by ID.
+func (s *JobService) LoadWorkspace(workspaceID uuid.UUID) (*models.Workspace, error) {
+	var ws models.Workspace
+	if err := s.db.First(&ws, workspaceID).Error; err != nil {
+		return nil, fmt.Errorf("load workspace: %w", err)
+	}
+	return &ws, nil
+}
+
+// LoadVersion loads a workspace version by ID.
+func (s *JobService) LoadVersion(versionID uuid.UUID) (*models.WorkspaceVersion, error) {
+	var version models.WorkspaceVersion
+	if err := s.db.First(&version, versionID).Error; err != nil {
+		return nil, fmt.Errorf("load version: %w", err)
+	}
+	return &version, nil
 }

--- a/internal/service/workspace.go
+++ b/internal/service/workspace.go
@@ -21,13 +21,14 @@ type WorkspaceService struct {
 	db       *gorm.DB
 	queue    queue.Queue
 	executor executor.Executor
+	rbac     rbac.Provider
 	isLocal  bool
 	encKey   []byte
 }
 
 // New creates a new WorkspaceService.
-func New(db *gorm.DB, q queue.Queue, exec executor.Executor, isLocal bool, encKey []byte) *WorkspaceService {
-	return &WorkspaceService{db: db, queue: q, executor: exec, isLocal: isLocal, encKey: encKey}
+func New(db *gorm.DB, q queue.Queue, exec executor.Executor, isLocal bool, encKey []byte, rbacProvider rbac.Provider) *WorkspaceService {
+	return &WorkspaceService{db: db, queue: q, executor: exec, isLocal: isLocal, encKey: encKey, rbac: rbacProvider}
 }
 
 // List returns workspaces visible to the given user.
@@ -109,39 +110,46 @@ func (s *WorkspaceService) Create(ctx context.Context, req CreateRequest, userID
 		Path:           req.Path,
 	}
 
-	if err := s.db.Create(&ws).Error; err != nil {
-		return nil, fmt.Errorf("create workspace: %w", err)
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&ws).Error; err != nil {
+			return fmt.Errorf("create workspace: %w", err)
+		}
+
+		// Queue creation job
+		metadata := map[string]interface{}{}
+		if req.PixiToml != "" {
+			metadata["pixi_toml"] = req.PixiToml
+		}
+
+		job := &models.Job{
+			Type:        models.JobTypeCreate,
+			WorkspaceID: ws.ID,
+			Status:      models.JobStatusPending,
+			Metadata:    metadata,
+		}
+		if err := tx.Create(job).Error; err != nil {
+			return fmt.Errorf("create job: %w", err)
+		}
+		if err := s.queue.Enqueue(ctx, job); err != nil {
+			return fmt.Errorf("enqueue job: %w", err)
+		}
+
+		audit.LogAction(tx, userID, audit.ActionCreateWorkspace, fmt.Sprintf("ws:%s", ws.ID.String()), map[string]interface{}{
+			"name":            ws.Name,
+			"package_manager": ws.PackageManager,
+		})
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	// Queue creation job
-	metadata := map[string]interface{}{}
-	if req.PixiToml != "" {
-		metadata["pixi_toml"] = req.PixiToml
-	}
-
-	job := &models.Job{
-		Type:        models.JobTypeCreate,
-		WorkspaceID: ws.ID,
-		Status:      models.JobStatusPending,
-		Metadata:    metadata,
-	}
-	if err := s.db.Create(job).Error; err != nil {
-		return nil, fmt.Errorf("create job: %w", err)
-	}
-	if err := s.queue.Enqueue(ctx, job); err != nil {
-		return nil, fmt.Errorf("enqueue job: %w", err)
-	}
-
-	// Grant owner access
-	if err := rbac.GrantWorkspaceAccess(userID, ws.ID, "owner"); err != nil {
+	// RBAC grant happens outside the transaction because Casbin uses its own
+	// DB connection, which would deadlock SQLite inside a transaction.
+	if err := s.rbac.GrantWorkspaceAccess(userID, ws.ID, "owner"); err != nil {
 		return nil, fmt.Errorf("grant owner access: %w", err)
 	}
-
-	// Audit
-	audit.LogAction(s.db, userID, audit.ActionCreateWorkspace, fmt.Sprintf("ws:%s", ws.ID.String()), map[string]interface{}{
-		"name":            ws.Name,
-		"package_manager": ws.PackageManager,
-	})
 
 	return &ws, nil
 }

--- a/internal/service/workspace_permissions.go
+++ b/internal/service/workspace_permissions.go
@@ -6,7 +6,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/nebari-dev/nebi/internal/audit"
 	"github.com/nebari-dev/nebi/internal/models"
-	"github.com/nebari-dev/nebi/internal/rbac"
 	"gorm.io/gorm"
 )
 
@@ -48,25 +47,32 @@ func (s *WorkspaceService) ShareWorkspace(wsID string, ownerID uuid.UUID, target
 		return nil, fmt.Errorf("role not found: %w", err)
 	}
 
-	// Create permission record
-	permission := models.Permission{
-		UserID:      targetUserID,
-		WorkspaceID: wsUUID,
-		RoleID:      roleRecord.ID,
-	}
-	if err := s.db.Create(&permission).Error; err != nil {
-		return nil, fmt.Errorf("create permission: %w", err)
+	var permission models.Permission
+	err = s.db.Transaction(func(tx *gorm.DB) error {
+		permission = models.Permission{
+			UserID:      targetUserID,
+			WorkspaceID: wsUUID,
+			RoleID:      roleRecord.ID,
+		}
+		if err := tx.Create(&permission).Error; err != nil {
+			return fmt.Errorf("create permission: %w", err)
+		}
+
+		audit.LogAction(tx, ownerID, audit.ActionGrantPermission, fmt.Sprintf("ws:%s", wsUUID.String()), map[string]interface{}{
+			"target_user_id": targetUserID,
+			"role":           role,
+		})
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	// Grant in RBAC
-	if err := rbac.GrantWorkspaceAccess(targetUserID, wsUUID, role); err != nil {
+	// RBAC outside transaction — Casbin uses its own DB connection
+	if err := s.rbac.GrantWorkspaceAccess(targetUserID, wsUUID, role); err != nil {
 		return nil, fmt.Errorf("grant RBAC permission: %w", err)
 	}
-
-	audit.LogAction(s.db, ownerID, audit.ActionGrantPermission, fmt.Sprintf("ws:%s", wsUUID.String()), map[string]interface{}{
-		"target_user_id": targetUserID,
-		"role":           role,
-	})
 
 	return &permission, nil
 }
@@ -105,19 +111,25 @@ func (s *WorkspaceService) UnshareWorkspace(wsID string, ownerID uuid.UUID, targ
 		return err
 	}
 
-	// Revoke from RBAC
-	if err := rbac.RevokeWorkspaceAccess(targetUUID, wsUUID); err != nil {
+	err = s.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Delete(&permission).Error; err != nil {
+			return fmt.Errorf("delete permission: %w", err)
+		}
+
+		audit.LogAction(tx, ownerID, audit.ActionRevokePermission, fmt.Sprintf("ws:%s", wsUUID.String()), map[string]interface{}{
+			"target_user_id": targetUUID,
+		})
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// RBAC outside transaction — Casbin uses its own DB connection
+	if err := s.rbac.RevokeWorkspaceAccess(targetUUID, wsUUID); err != nil {
 		return fmt.Errorf("revoke RBAC permission: %w", err)
 	}
-
-	// Delete permission record
-	if err := s.db.Delete(&permission).Error; err != nil {
-		return fmt.Errorf("delete permission: %w", err)
-	}
-
-	audit.LogAction(s.db, ownerID, audit.ActionRevokePermission, fmt.Sprintf("ws:%s", wsUUID.String()), map[string]interface{}{
-		"target_user_id": targetUUID,
-	})
 
 	return nil
 }

--- a/internal/service/workspace_test.go
+++ b/internal/service/workspace_test.go
@@ -64,7 +64,7 @@ func testSetup(t *testing.T, isLocal bool) (*WorkspaceService, *gorm.DB) {
 		t.Fatalf("new executor: %v", err)
 	}
 
-	svc := New(db, q, exec, isLocal, nil)
+	svc := New(db, q, exec, isLocal, nil, rbac.NewDefaultProvider())
 	return svc, db
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -19,15 +19,14 @@ import (
 	"github.com/nebari-dev/nebi/internal/queue"
 	"github.com/nebari-dev/nebi/internal/service"
 	"github.com/valkey-io/valkey-go"
-	"gorm.io/gorm"
 )
 
 // Worker processes jobs from the queue
 type Worker struct {
-	db           *gorm.DB
 	queue        queue.Queue
 	executor     executor.Executor
 	svc          *service.WorkspaceService
+	jobSvc       *service.JobService
 	logger       *slog.Logger
 	broker       *logstream.LogBroker
 	valkeyClient valkey.Client // For distributed log streaming (optional, can be nil for local mode)
@@ -37,13 +36,13 @@ type Worker struct {
 }
 
 // New creates a new worker instance
-func New(db *gorm.DB, q queue.Queue, exec executor.Executor, svc *service.WorkspaceService, logger *slog.Logger, valkeyClient valkey.Client) *Worker {
+func New(q queue.Queue, exec executor.Executor, svc *service.WorkspaceService, jobSvc *service.JobService, logger *slog.Logger, valkeyClient valkey.Client) *Worker {
 	maxWorkers := 10 // Allow up to 10 concurrent jobs
 	return &Worker{
-		db:           db,
 		queue:        q,
 		executor:     exec,
 		svc:          svc,
+		jobSvc:       jobSvc,
 		logger:       logger,
 		broker:       logstream.NewBroker(),
 		valkeyClient: valkeyClient,
@@ -111,22 +110,14 @@ func (w *Worker) processJob(ctx context.Context, job *models.Job) {
 	defer func() {
 		if r := recover(); r != nil {
 			w.logger.Error("Panic recovered in processJob", "job_id", job.ID, "panic", r)
-			// Update job as failed
-			completedAt := time.Now()
-			job.CompletedAt = &completedAt
-			job.Status = models.JobStatusFailed
-			job.Error = fmt.Sprintf("Job panicked: %v", r)
-			w.db.Save(job)
+			w.jobSvc.MarkPanicked(job, fmt.Sprintf("Job panicked: %v", r))
 		}
 	}()
 
 	w.logger.Info("Processing job", "job_id", job.ID, "type", job.Type)
 
 	// Update job status to running
-	job.Status = models.JobStatusRunning
-	now := time.Now()
-	job.StartedAt = &now
-	w.db.Save(job)
+	w.jobSvc.MarkRunning(job)
 
 	// Create thread-safe log buffer
 	var logBuf bytes.Buffer
@@ -169,38 +160,28 @@ func (w *Worker) processJob(ctx context.Context, job *models.Job) {
 	logMutex.Unlock()
 
 	// Update job status
-	completedAt := time.Now()
-	job.CompletedAt = &completedAt
-	job.Logs = finalLogs
-
 	if err != nil {
 		w.logger.Error("Job failed", "job_id", job.ID, "error", err)
-		job.Status = models.JobStatusFailed
-		job.Error = err.Error()
+		w.jobSvc.MarkFailed(job, finalLogs, err.Error())
 		// Publish error to subscribers
 		errorMsg := fmt.Sprintf("\n[ERROR] Job failed: %v\n", err)
 		w.broker.Publish(job.ID, errorMsg)
-		// Also publish to Valkey if available
 		if w.valkeyClient != nil {
 			valkeyWriter := logstream.NewValkeyLogWriter(w.valkeyClient, job.ID.String())
 			valkeyWriter.Publish(errorMsg)
 		}
 	} else {
 		w.logger.Info("Job completed", "job_id", job.ID)
-		job.Status = models.JobStatusCompleted
+		w.jobSvc.MarkCompleted(job, finalLogs)
 		// Publish completion to subscribers
 		completionMsg := "\n[COMPLETED] Job finished successfully\n"
 		w.broker.Publish(job.ID, completionMsg)
-		// Also publish to Valkey if available
 		if w.valkeyClient != nil {
 			valkeyWriter := logstream.NewValkeyLogWriter(w.valkeyClient, job.ID.String())
 			valkeyWriter.Publish(completionMsg)
-			// Set TTL on Valkey log channel for cleanup (1 hour)
 			valkeyWriter.SetTTL(3600)
 		}
 	}
-
-	w.db.Save(job)
 }
 
 // flushLogsToDatabase periodically saves accumulated logs to the database
@@ -217,7 +198,7 @@ func (w *Worker) flushLogsToDatabase(jobID uuid.UUID, logBuf *bytes.Buffer, logM
 			logMutex.Unlock()
 
 			// Save to database
-			if err := w.db.Model(&models.Job{}).Where("id = ?", jobID).Update("logs", currentLogs).Error; err != nil {
+			if err := w.jobSvc.FlushLogs(jobID, currentLogs); err != nil {
 				w.logger.Error("Failed to flush logs to database", "job_id", jobID, "error", err)
 			}
 
@@ -227,7 +208,7 @@ func (w *Worker) flushLogsToDatabase(jobID uuid.UUID, logBuf *bytes.Buffer, logM
 			finalLogs := logBuf.String()
 			logMutex.Unlock()
 
-			if err := w.db.Model(&models.Job{}).Where("id = ?", jobID).Update("logs", finalLogs).Error; err != nil {
+			if err := w.jobSvc.FlushLogs(jobID, finalLogs); err != nil {
 				w.logger.Error("Failed final log flush", "job_id", jobID, "error", err)
 			}
 			return
@@ -249,9 +230,9 @@ func (w *threadSafeWriter) Write(p []byte) (n int, err error) {
 
 func (w *Worker) executeJob(ctx context.Context, job *models.Job, logWriter io.Writer) error {
 	// Load workspace
-	var ws models.Workspace
-	if err := w.db.First(&ws, job.WorkspaceID).Error; err != nil {
-		return fmt.Errorf("failed to load workspace: %w", err)
+	ws, err := w.jobSvc.LoadWorkspace(job.WorkspaceID)
+	if err != nil {
+		return err
 	}
 
 	// Extract user ID from job metadata (if present)
@@ -274,26 +255,26 @@ func (w *Worker) executeJob(ctx context.Context, job *models.Job, logWriter io.W
 			pixiToml, _ = pixiTomlInterface.(string)
 		}
 
-		if err := w.executor.CreateWorkspace(ctx, &ws, logWriter, pixiToml); err != nil {
+		if err := w.executor.CreateWorkspace(ctx, ws, logWriter, pixiToml); err != nil {
 			w.svc.SetWorkspaceStatus(ws.ID, models.WsStatusFailed)
 			return err
 		}
 
 		// Persist the resolved path so the CLI can find the workspace on disk
 		if ws.Path == "" {
-			w.svc.SetWorkspacePath(ws.ID, w.executor.GetWorkspacePath(&ws))
+			w.svc.SetWorkspacePath(ws.ID, w.executor.GetWorkspacePath(ws))
 		}
 
 		// List installed packages and save to database
-		if err := w.svc.SyncPackagesFromWorkspace(ctx, &ws); err != nil {
+		if err := w.svc.SyncPackagesFromWorkspace(ctx, ws); err != nil {
 			w.logger.Error("Failed to sync packages", "error", err)
 		}
 
-		w.svc.UpdateWorkspaceSize(&ws)
+		w.svc.UpdateWorkspaceSize(ws)
 		w.svc.SetWorkspaceStatus(ws.ID, models.WsStatusReady)
 
 		// Create version snapshot
-		if err := w.svc.CreateVersionSnapshot(ctx, &ws, job.ID, userID, "Initial workspace creation"); err != nil {
+		if err := w.svc.CreateVersionSnapshot(ctx, ws, job.ID, userID, "Initial workspace creation"); err != nil {
 			w.logger.Error("Failed to create version snapshot", "error", err)
 		}
 
@@ -303,14 +284,14 @@ func (w *Worker) executeJob(ctx context.Context, job *models.Job, logWriter io.W
 			return fmt.Errorf("packages not found in job metadata")
 		}
 
-		if err := w.executor.InstallPackages(ctx, &ws, packages, logWriter); err != nil {
+		if err := w.executor.InstallPackages(ctx, ws, packages, logWriter); err != nil {
 			return err
 		}
 
 		w.svc.SaveInstalledPackages(ws.ID, packages)
-		w.svc.UpdateWorkspaceSize(&ws)
+		w.svc.UpdateWorkspaceSize(ws)
 
-		if err := w.svc.CreateVersionSnapshot(ctx, &ws, job.ID, userID, fmt.Sprintf("Installed packages: %v", packages)); err != nil {
+		if err := w.svc.CreateVersionSnapshot(ctx, ws, job.ID, userID, fmt.Sprintf("Installed packages: %v", packages)); err != nil {
 			w.logger.Error("Failed to create version snapshot", "error", err)
 		}
 
@@ -320,21 +301,21 @@ func (w *Worker) executeJob(ctx context.Context, job *models.Job, logWriter io.W
 			return fmt.Errorf("packages not found in job metadata")
 		}
 
-		if err := w.executor.RemovePackages(ctx, &ws, packages, logWriter); err != nil {
+		if err := w.executor.RemovePackages(ctx, ws, packages, logWriter); err != nil {
 			return err
 		}
 
 		w.svc.DeletePackagesByName(ws.ID, packages)
-		w.svc.UpdateWorkspaceSize(&ws)
+		w.svc.UpdateWorkspaceSize(ws)
 
-		if err := w.svc.CreateVersionSnapshot(ctx, &ws, job.ID, userID, fmt.Sprintf("Removed packages: %v", packages)); err != nil {
+		if err := w.svc.CreateVersionSnapshot(ctx, ws, job.ID, userID, fmt.Sprintf("Removed packages: %v", packages)); err != nil {
 			w.logger.Error("Failed to create version snapshot", "error", err)
 		}
 
 	case models.JobTypeDelete:
 		w.svc.SetWorkspaceStatus(ws.ID, models.WsStatusDeleting)
 
-		if err := w.executor.DeleteWorkspace(ctx, &ws, logWriter); err != nil {
+		if err := w.executor.DeleteWorkspace(ctx, ws, logWriter); err != nil {
 			return err
 		}
 
@@ -353,9 +334,9 @@ func (w *Worker) executeJob(ctx context.Context, job *models.Job, logWriter io.W
 		}
 
 		// Fetch version
-		var version models.WorkspaceVersion
-		if err := w.db.First(&version, versionID).Error; err != nil {
-			return fmt.Errorf("failed to load version: %w", err)
+		version, err := w.jobSvc.LoadVersion(versionID)
+		if err != nil {
+			return err
 		}
 
 		if version.WorkspaceID != ws.ID {
@@ -364,17 +345,17 @@ func (w *Worker) executeJob(ctx context.Context, job *models.Job, logWriter io.W
 
 		fmt.Fprintf(logWriter, "Rolling back to version %d\n", version.VersionNumber)
 
-		if err := w.executeRollback(ctx, &ws, &version, logWriter); err != nil {
+		if err := w.executeRollback(ctx, ws, version, logWriter); err != nil {
 			return err
 		}
 
-		if err := w.svc.SyncPackagesFromWorkspace(ctx, &ws); err != nil {
+		if err := w.svc.SyncPackagesFromWorkspace(ctx, ws); err != nil {
 			w.logger.Error("Failed to sync packages after rollback", "error", err)
 		}
 
-		w.svc.UpdateWorkspaceSize(&ws)
+		w.svc.UpdateWorkspaceSize(ws)
 
-		if err := w.svc.CreateVersionSnapshot(ctx, &ws, job.ID, userID, fmt.Sprintf("Rolled back to version %d", version.VersionNumber)); err != nil {
+		if err := w.svc.CreateVersionSnapshot(ctx, ws, job.ID, userID, fmt.Sprintf("Rolled back to version %d", version.VersionNumber)); err != nil {
 			w.logger.Error("Failed to create version snapshot after rollback", "error", err)
 		}
 


### PR DESCRIPTION
## Summary

Four architectural improvements completing the codebase architecture initiative:

- **Injectable RBAC** — new `rbac.Provider` interface (8 methods) with `DefaultProvider` wrapping Casbin. Services and middleware accept it via constructor instead of calling globals. Enables per-test RBAC mocking.
- **Transaction boundaries** — workspace Create, Share/Unshare, admin Grant/Revoke wrap DB writes + audit in `db.Transaction`. RBAC stays outside (Casbin has its own connection). DB records are now atomic.
- **Worker drops `*gorm.DB`** — all job lifecycle methods (MarkRunning/Completed/Failed, FlushLogs, LoadWorkspace/Version) moved to JobService. Worker no longer holds a DB connection.
- **Handler consolidation** — `handleServiceError` and `getUserID` moved to shared `helpers.go`. Removed duplicates from workspace.go and admin.go.

Also fixes the `First(permissionID)` raw-string GORM arg flagged in #283 security review.

### Dependency changes

| Component | Before | After |
|---|---|---|
| WorkspaceService | `db, queue, executor, isLocal, encKey` | + `rbac.Provider` |
| AdminService | `db` | + `rbac.Provider` |
| Middleware | calls `rbac.IsAdmin()` global | accepts `rbac.Provider` |
| Worker | `db, queue, executor, svc` | `queue, executor, svc, jobSvc` (no DB) |

All 96 service tests pass.