### PR TITLE
refactor: eliminate last DB/RBAC globals, add queue tests

### DIFF
--- a/internal/api/handlers/registry_browse.go
+++ b/internal/api/handlers/registry_browse.go
@@ -6,23 +6,19 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	nebicrypto "github.com/nebari-dev/nebi/internal/crypto"
-	"github.com/nebari-dev/nebi/internal/models"
 	"github.com/nebari-dev/nebi/internal/oci"
 	"github.com/nebari-dev/nebi/internal/service"
-	"gorm.io/gorm"
 )
 
 // RegistryBrowseHandler handles browsing and importing from OCI registries
 type RegistryBrowseHandler struct {
-	db     *gorm.DB
-	svc    *service.WorkspaceService
-	encKey []byte
+	registrySvc *service.RegistryService
+	wsSvc       *service.WorkspaceService
 }
 
 // NewRegistryBrowseHandler creates a new registry browse handler
-func NewRegistryBrowseHandler(db *gorm.DB, svc *service.WorkspaceService, encKey []byte) *RegistryBrowseHandler {
-	return &RegistryBrowseHandler{db: db, svc: svc, encKey: encKey}
+func NewRegistryBrowseHandler(registrySvc *service.RegistryService, wsSvc *service.WorkspaceService) *RegistryBrowseHandler {
+	return &RegistryBrowseHandler{registrySvc: registrySvc, wsSvc: wsSvc}
 }
 
 // ImportRequest is the JSON body for the import endpoint
@@ -38,24 +34,19 @@ func (h *RegistryBrowseHandler) ListRepositories(c *gin.Context) {
 	registryID := c.Param("id")
 	search := c.Query("search")
 
-	var registry models.OCIRegistry
-	if err := h.db.Where("id = ?", registryID).First(&registry).Error; err != nil {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "Registry not found"})
-		return
-	}
-
-	password, err := nebicrypto.DecryptField(registry.Password, h.encKey)
+	regCreds, err := h.registrySvc.GetRegistryWithCredentials(registryID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to decrypt registry credentials"})
+		handleServiceError(c, err)
 		return
 	}
 
+	registry := regCreds.Registry
 	host, namespace := oci.ParseRegistryURL(registry.URL)
 
 	opts := oci.BrowseOptions{
 		RegistryHost: host,
 		Username:     registry.Username,
-		Password:     password,
+		Password:     regCreds.Password,
 	}
 
 	catalogFailed := false
@@ -65,14 +56,12 @@ func (h *RegistryBrowseHandler) ListRepositories(c *gin.Context) {
 
 		// Try Quay.io API fallback if the host is quay.io
 		if strings.Contains(host, "quay.io") {
-			// Derive namespace from URL path or registry namespace
 			ns := namespace
 			if ns == "" && registry.Namespace != "" {
 				ns = registry.Namespace
 			}
 			if ns != "" {
-				apiToken, _ := nebicrypto.DecryptField(registry.APIToken, h.encKey)
-				quayRepos, quayErr := oci.ListRepositoriesViaQuayAPI(c.Request.Context(), host, ns, apiToken)
+				quayRepos, quayErr := oci.ListRepositoriesViaQuayAPI(c.Request.Context(), host, ns, regCreds.APIToken)
 				if quayErr == nil && len(quayRepos) > 0 {
 					repos = quayRepos
 					catalogFailed = false
@@ -91,15 +80,15 @@ func (h *RegistryBrowseHandler) ListRepositories(c *gin.Context) {
 	}
 
 	// Always merge in known publications from the DB
-	knownRepos := h.fallbackRepositories(registry.ID.String(), "")
+	knownRepoNames := h.registrySvc.FallbackRepositories(registryID)
 	seen := make(map[string]bool)
 	for _, r := range repos {
 		seen[r.Name] = true
 	}
-	for _, r := range knownRepos {
-		if !seen[r.Name] {
-			repos = append(repos, r)
-			seen[r.Name] = true
+	for _, name := range knownRepoNames {
+		if !seen[name] {
+			repos = append(repos, oci.RepositoryInfo{Name: name})
+			seen[name] = true
 		}
 	}
 
@@ -124,31 +113,6 @@ func (h *RegistryBrowseHandler) ListRepositories(c *gin.Context) {
 	})
 }
 
-// fallbackRepositories returns distinct repositories from publication records
-func (h *RegistryBrowseHandler) fallbackRepositories(registryID, search string) []oci.RepositoryInfo {
-	var repositories []string
-	query := h.db.Model(&models.Publication{}).
-		Where("registry_id = ?", registryID).
-		Distinct("repository").
-		Pluck("repository", &repositories)
-
-	if query.Error != nil {
-		return []oci.RepositoryInfo{}
-	}
-
-	var result []oci.RepositoryInfo
-	for _, repo := range repositories {
-		if search == "" || strings.Contains(strings.ToLower(repo), strings.ToLower(search)) {
-			result = append(result, oci.RepositoryInfo{Name: repo})
-		}
-	}
-
-	if result == nil {
-		result = []oci.RepositoryInfo{}
-	}
-	return result
-}
-
 // ListTags lists tags for a repository in a registry
 func (h *RegistryBrowseHandler) ListTags(c *gin.Context) {
 	registryID := c.Param("id")
@@ -159,29 +123,23 @@ func (h *RegistryBrowseHandler) ListTags(c *gin.Context) {
 		return
 	}
 
-	var registry models.OCIRegistry
-	if err := h.db.Where("id = ?", registryID).First(&registry).Error; err != nil {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "Registry not found"})
-		return
-	}
-
-	password, err := nebicrypto.DecryptField(registry.Password, h.encKey)
+	regCreds, err := h.registrySvc.GetRegistryWithCredentials(registryID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to decrypt registry credentials"})
+		handleServiceError(c, err)
 		return
 	}
 
-	host, _ := oci.ParseRegistryURL(registry.URL)
+	host, _ := oci.ParseRegistryURL(regCreds.Registry.URL)
 	repoRef := fmt.Sprintf("%s/%s", host, repoName)
 	opts := oci.BrowseOptions{
 		RegistryHost: host,
-		Username:     registry.Username,
-		Password:     password,
+		Username:     regCreds.Registry.Username,
+		Password:     regCreds.Password,
 	}
 
 	tags, err := oci.ListTags(c.Request.Context(), repoRef, opts)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: fmt.Sprintf("Failed to list tags: %v", err)})
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to list tags"})
 		return
 	}
 
@@ -203,33 +161,27 @@ func (h *RegistryBrowseHandler) ImportEnvironment(c *gin.Context) {
 		return
 	}
 
-	var registry models.OCIRegistry
-	if err := h.db.Where("id = ?", registryID).First(&registry).Error; err != nil {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "Registry not found"})
-		return
-	}
-
-	password, err := nebicrypto.DecryptField(registry.Password, h.encKey)
+	regCreds, err := h.registrySvc.GetRegistryWithCredentials(registryID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to decrypt registry credentials"})
+		handleServiceError(c, err)
 		return
 	}
 
-	host, _ := oci.ParseRegistryURL(registry.URL)
+	host, _ := oci.ParseRegistryURL(regCreds.Registry.URL)
 	repoRef := fmt.Sprintf("%s/%s", host, req.Repository)
 	opts := oci.BrowseOptions{
 		RegistryHost: host,
-		Username:     registry.Username,
-		Password:     password,
+		Username:     regCreds.Registry.Username,
+		Password:     regCreds.Password,
 	}
 
 	result, err := oci.PullEnvironment(c.Request.Context(), repoRef, req.Tag, opts)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: fmt.Sprintf("Failed to pull environment: %v", err)})
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to pull environment"})
 		return
 	}
 
-	ws, err := h.svc.Create(c.Request.Context(), service.CreateRequest{
+	ws, err := h.wsSvc.Create(c.Request.Context(), service.CreateRequest{
 		Name:           req.Name,
 		PackageManager: "pixi",
 		PixiToml:       result.PixiToml,

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -60,7 +60,7 @@ func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Exe
 	var authenticator auth.Authenticator
 	var oidcAuth *auth.OIDCAuthenticator
 	// Session check endpoint needs a BasicAuthenticator for JWT generation.
-	sessionBasicAuth := auth.NewBasicAuthenticator(db, cfg.Auth.JWTSecret)
+	sessionBasicAuth := auth.NewBasicAuthenticator(db, cfg.Auth.JWTSecret, rbacProvider)
 
 	if localMode {
 		localAuth, err := auth.NewLocalAuthenticator(db)
@@ -72,7 +72,7 @@ func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Exe
 		logger.Info("Running in local mode — authentication bypassed", "user", auth.LocalUsername())
 	} else {
 		if cfg.Auth.Type == "basic" {
-			basicAuth := auth.NewBasicAuthenticator(db, cfg.Auth.JWTSecret)
+			basicAuth := auth.NewBasicAuthenticator(db, cfg.Auth.JWTSecret, rbacProvider)
 			basicAuth.SetProxyAdminGroups(cfg.Auth.ProxyAdminGroups)
 			authenticator = basicAuth
 		}
@@ -87,13 +87,13 @@ func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Exe
 			}
 			var err error
 			// Use context.Background() for initialization
-			oidcAuth, err = auth.NewOIDCAuthenticator(nil, oidcCfg, db, cfg.Auth.JWTSecret)
+			oidcAuth, err = auth.NewOIDCAuthenticator(nil, oidcCfg, db, cfg.Auth.JWTSecret, rbacProvider)
 			if err != nil {
 				logger.Error("Failed to initialize OIDC authenticator, will retry in background", "error", err)
 				// Retry in background — the OIDC provider (e.g. Keycloak) may not
 				// be ready yet at startup. Once it becomes reachable, wire the
 				// verifier into the authenticators so proxy auth starts working.
-				go retryOIDCInit(oidcCfg, db, cfg.Auth.JWTSecret, sessionBasicAuth, authenticator, logger)
+				go retryOIDCInit(oidcCfg, db, cfg.Auth.JWTSecret, rbacProvider, sessionBasicAuth, authenticator, logger)
 			} else {
 				logger.Info("OIDC authentication enabled", "issuer", cfg.Auth.OIDCIssuerURL)
 			}
@@ -243,7 +243,7 @@ func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Exe
 		protected.GET("/registries", registryHandler.ListPublicRegistries)
 
 		// Registry browse & import endpoints (for all authenticated users)
-		browseHandler := handlers.NewRegistryBrowseHandler(db, svc, encKey)
+		browseHandler := handlers.NewRegistryBrowseHandler(registrySvc, svc)
 		protected.GET("/registries/:id/repositories", browseHandler.ListRepositories)
 		protected.GET("/registries/:id/tags", browseHandler.ListTags)
 		protected.POST("/registries/:id/import", browseHandler.ImportEnvironment)
@@ -417,11 +417,11 @@ func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Exe
 // succeeds. This handles the case where the OIDC provider (e.g. Keycloak) is
 // not yet ready when Nebi starts. Once discovery succeeds, the ID token
 // verifier is wired into the authenticators so proxy auth starts working.
-func retryOIDCInit(cfg auth.OIDCConfig, db *gorm.DB, jwtSecret string,
+func retryOIDCInit(cfg auth.OIDCConfig, db *gorm.DB, jwtSecret string, rbacProvider rbac.Provider,
 	sessionAuth *auth.BasicAuthenticator, mainAuth auth.Authenticator, logger *slog.Logger) {
 	for {
 		time.Sleep(10 * time.Second)
-		oa, err := auth.NewOIDCAuthenticator(nil, cfg, db, jwtSecret)
+		oa, err := auth.NewOIDCAuthenticator(nil, cfg, db, jwtSecret, rbacProvider)
 		if err != nil {
 			logger.Warn("OIDC initialization retry failed, will try again", "error", err)
 			continue

--- a/internal/auth/basic.go
+++ b/internal/auth/basic.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/nebari-dev/nebi/internal/models"
+	"github.com/nebari-dev/nebi/internal/rbac"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 )
@@ -31,13 +32,15 @@ type BasicAuthenticator struct {
 	jwtSecret        []byte
 	proxyAdminGroups []string
 	idTokenVerifier  *oidc.IDTokenVerifier
+	rbac             rbac.Provider
 }
 
 // NewBasicAuthenticator creates a new basic authenticator
-func NewBasicAuthenticator(db *gorm.DB, jwtSecret string) *BasicAuthenticator {
+func NewBasicAuthenticator(db *gorm.DB, jwtSecret string, rbacProvider rbac.Provider) *BasicAuthenticator {
 	return &BasicAuthenticator{
 		db:        db,
 		jwtSecret: []byte(jwtSecret),
+		rbac:      rbacProvider,
 	}
 }
 
@@ -198,7 +201,7 @@ func (a *BasicAuthenticator) Middleware() gin.HandlerFunc {
 		}
 
 		// Sync admin role from proxy groups on every request
-		syncRolesFromGroups(user.ID, proxyClaims.Groups, a.proxyAdminGroups)
+		syncRolesFromGroups(user.ID, proxyClaims.Groups, a.proxyAdminGroups, a.rbac)
 
 		c.Set(UserContextKey, user)
 		c.Next()
@@ -238,7 +241,7 @@ func (a *BasicAuthenticator) SessionFromProxy(r *http.Request, adminGroups strin
 		return nil, fmt.Errorf("failed to find/create proxy user: %w", err)
 	}
 
-	syncRolesFromGroups(user.ID, proxyClaims.Groups, parseAdminGroups(adminGroups))
+	syncRolesFromGroups(user.ID, proxyClaims.Groups, parseAdminGroups(adminGroups), a.rbac)
 
 	token, err := a.generateToken(user)
 	if err != nil {
@@ -288,7 +291,7 @@ func (a *BasicAuthenticator) ExchangeIDToken(rawIDToken string, adminGroups stri
 		return nil, fmt.Errorf("failed to find/create user: %w", err)
 	}
 
-	syncRolesFromGroups(user.ID, claims.Groups, parseAdminGroups(adminGroups))
+	syncRolesFromGroups(user.ID, claims.Groups, parseAdminGroups(adminGroups), a.rbac)
 
 	token, err := a.generateToken(user)
 	if err != nil {

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -9,6 +9,7 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/google/uuid"
 	"github.com/nebari-dev/nebi/internal/models"
+	"github.com/nebari-dev/nebi/internal/rbac"
 	"golang.org/x/oauth2"
 	"gorm.io/gorm"
 )
@@ -33,7 +34,7 @@ type OIDCConfig struct {
 }
 
 // NewOIDCAuthenticator creates a new OIDC authenticator
-func NewOIDCAuthenticator(ctx context.Context, cfg OIDCConfig, db *gorm.DB, jwtSecret string) (*OIDCAuthenticator, error) {
+func NewOIDCAuthenticator(ctx context.Context, cfg OIDCConfig, db *gorm.DB, jwtSecret string, rbacProvider rbac.Provider) (*OIDCAuthenticator, error) {
 	// Use background context if none provided
 	if ctx == nil {
 		ctx = context.Background()
@@ -66,7 +67,7 @@ func NewOIDCAuthenticator(ctx context.Context, cfg OIDCConfig, db *gorm.DB, jwtS
 	})
 
 	// Create basic authenticator for JWT generation
-	basicAuth := NewBasicAuthenticator(db, jwtSecret)
+	basicAuth := NewBasicAuthenticator(db, jwtSecret, rbacProvider)
 
 	return &OIDCAuthenticator{
 		provider:  provider,

--- a/internal/auth/proxy.go
+++ b/internal/auth/proxy.go
@@ -108,7 +108,7 @@ func findOrCreateProxyUser(db *gorm.DB, claims *ProxyTokenClaims) (*models.User,
 
 // syncRolesFromGroups grants or revokes Nebi admin based on whether the
 // user belongs to any of the configured admin groups.
-func syncRolesFromGroups(userID uuid.UUID, groups []string, adminGroups []string) {
+func syncRolesFromGroups(userID uuid.UUID, groups []string, adminGroups []string, rbacProvider rbac.Provider) {
 	adminGroupSet := make(map[string]bool, len(adminGroups))
 	for _, g := range adminGroups {
 		g = strings.TrimSpace(g)
@@ -127,20 +127,20 @@ func syncRolesFromGroups(userID uuid.UUID, groups []string, adminGroups []string
 		}
 	}
 
-	isAdmin, err := rbac.IsAdmin(userID)
+	isAdmin, err := rbacProvider.IsAdmin(userID)
 	if err != nil {
 		slog.Warn("Failed to check admin status during proxy sync", "user_id", userID, "error", err)
 		return
 	}
 
 	if shouldBeAdmin && !isAdmin {
-		if err := rbac.MakeAdmin(userID); err != nil {
+		if err := rbacProvider.MakeAdmin(userID); err != nil {
 			slog.Warn("Failed to grant admin from proxy groups", "user_id", userID, "error", err)
 		} else {
 			slog.Info("Granted admin via proxy group membership", "user_id", userID)
 		}
 	} else if !shouldBeAdmin && isAdmin {
-		if err := rbac.RevokeAdmin(userID); err != nil {
+		if err := rbacProvider.RevokeAdmin(userID); err != nil {
 			slog.Warn("Failed to revoke admin from proxy groups", "user_id", userID, "error", err)
 		} else {
 			slog.Info("Revoked admin via proxy group membership", "user_id", userID)

--- a/internal/db/admin.go
+++ b/internal/db/admin.go
@@ -13,7 +13,7 @@ import (
 
 // CreateDefaultAdmin creates a default admin user if ADMIN_USERNAME and ADMIN_PASSWORD are set
 // and no users exist in the database
-func CreateDefaultAdmin(db *gorm.DB) error {
+func CreateDefaultAdmin(db *gorm.DB, rbacProvider rbac.Provider) error {
 	username := os.Getenv("ADMIN_USERNAME")
 	password := os.Getenv("ADMIN_PASSWORD")
 	email := os.Getenv("ADMIN_EMAIL")
@@ -58,13 +58,8 @@ func CreateDefaultAdmin(db *gorm.DB) error {
 		return fmt.Errorf("failed to create admin user: %w", err)
 	}
 
-	// Initialize RBAC enforcer if not already done
-	if err := rbac.InitEnforcer(db, slog.Default()); err != nil {
-		return fmt.Errorf("failed to initialize RBAC: %w", err)
-	}
-
 	// Grant admin role in RBAC
-	if err := rbac.MakeAdmin(user.ID); err != nil {
+	if err := rbacProvider.MakeAdmin(user.ID); err != nil {
 		return fmt.Errorf("failed to grant admin role: %w", err)
 	}
 

--- a/internal/queue/memory_test.go
+++ b/internal/queue/memory_test.go
@@ -1,0 +1,242 @@
+package queue
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nebari-dev/nebi/internal/models"
+)
+
+func newTestJob() *models.Job {
+	return &models.Job{
+		ID:          uuid.New(),
+		WorkspaceID: uuid.New(),
+		Type:        models.JobTypeCreate,
+		Status:      models.JobStatusPending,
+	}
+}
+
+func TestMemoryQueue_EnqueueDequeue(t *testing.T) {
+	q := NewMemoryQueue(10)
+	defer q.Close()
+
+	job := newTestJob()
+
+	if err := q.Enqueue(context.Background(), job); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	got, err := q.Dequeue(context.Background())
+	if err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if got.ID != job.ID {
+		t.Errorf("expected job ID %s, got %s", job.ID, got.ID)
+	}
+}
+
+func TestMemoryQueue_EnqueueRequiresID(t *testing.T) {
+	q := NewMemoryQueue(10)
+	defer q.Close()
+
+	job := &models.Job{} // no ID
+
+	err := q.Enqueue(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected error for job without ID")
+	}
+}
+
+func TestMemoryQueue_DequeueBlocksUntilJob(t *testing.T) {
+	q := NewMemoryQueue(10)
+	defer q.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	// Dequeue on empty queue should block until context expires
+	_, err := q.Dequeue(ctx)
+	if err != context.DeadlineExceeded {
+		t.Errorf("expected DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestMemoryQueue_FIFO(t *testing.T) {
+	q := NewMemoryQueue(10)
+	defer q.Close()
+
+	job1 := newTestJob()
+	job2 := newTestJob()
+	job3 := newTestJob()
+
+	q.Enqueue(context.Background(), job1)
+	q.Enqueue(context.Background(), job2)
+	q.Enqueue(context.Background(), job3)
+
+	got1, _ := q.Dequeue(context.Background())
+	got2, _ := q.Dequeue(context.Background())
+	got3, _ := q.Dequeue(context.Background())
+
+	if got1.ID != job1.ID || got2.ID != job2.ID || got3.ID != job3.ID {
+		t.Errorf("expected FIFO order: %s,%s,%s got %s,%s,%s",
+			job1.ID, job2.ID, job3.ID, got1.ID, got2.ID, got3.ID)
+	}
+}
+
+func TestMemoryQueue_GetStatus(t *testing.T) {
+	q := NewMemoryQueue(10)
+	defer q.Close()
+
+	job := newTestJob()
+	q.Enqueue(context.Background(), job)
+
+	got, err := q.GetStatus(context.Background(), job.ID)
+	if err != nil {
+		t.Fatalf("get status: %v", err)
+	}
+	if got.Status != models.JobStatusPending {
+		t.Errorf("expected status pending, got %s", got.Status)
+	}
+}
+
+func TestMemoryQueue_GetStatus_NotFound(t *testing.T) {
+	q := NewMemoryQueue(10)
+	defer q.Close()
+
+	_, err := q.GetStatus(context.Background(), uuid.New())
+	if err != ErrJobNotFound {
+		t.Errorf("expected ErrJobNotFound, got %v", err)
+	}
+}
+
+func TestMemoryQueue_UpdateStatus(t *testing.T) {
+	q := NewMemoryQueue(10)
+	defer q.Close()
+
+	job := newTestJob()
+	q.Enqueue(context.Background(), job)
+
+	err := q.UpdateStatus(context.Background(), job.ID, models.JobStatusRunning, "starting...")
+	if err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+
+	got, _ := q.GetStatus(context.Background(), job.ID)
+	if got.Status != models.JobStatusRunning {
+		t.Errorf("expected running, got %s", got.Status)
+	}
+	if got.Logs != "starting..." {
+		t.Errorf("expected logs 'starting...', got %q", got.Logs)
+	}
+}
+
+func TestMemoryQueue_UpdateStatus_AppendLogs(t *testing.T) {
+	q := NewMemoryQueue(10)
+	defer q.Close()
+
+	job := newTestJob()
+	q.Enqueue(context.Background(), job)
+
+	q.UpdateStatus(context.Background(), job.ID, models.JobStatusRunning, "line1")
+	q.UpdateStatus(context.Background(), job.ID, models.JobStatusRunning, "line2")
+
+	got, _ := q.GetStatus(context.Background(), job.ID)
+	if got.Logs != "line1\nline2" {
+		t.Errorf("expected appended logs, got %q", got.Logs)
+	}
+}
+
+func TestMemoryQueue_Complete(t *testing.T) {
+	q := NewMemoryQueue(10)
+	defer q.Close()
+
+	job := newTestJob()
+	q.Enqueue(context.Background(), job)
+
+	err := q.Complete(context.Background(), job.ID, "done")
+	if err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	got, _ := q.GetStatus(context.Background(), job.ID)
+	if got.Status != models.JobStatusCompleted {
+		t.Errorf("expected completed, got %s", got.Status)
+	}
+	if got.CompletedAt == nil {
+		t.Error("expected CompletedAt to be set")
+	}
+}
+
+func TestMemoryQueue_Fail(t *testing.T) {
+	q := NewMemoryQueue(10)
+	defer q.Close()
+
+	job := newTestJob()
+	q.Enqueue(context.Background(), job)
+
+	err := q.Fail(context.Background(), job.ID, "something broke", "error logs")
+	if err != nil {
+		t.Fatalf("fail: %v", err)
+	}
+
+	got, _ := q.GetStatus(context.Background(), job.ID)
+	if got.Status != models.JobStatusFailed {
+		t.Errorf("expected failed, got %s", got.Status)
+	}
+	if got.Error != "something broke" {
+		t.Errorf("expected error message, got %q", got.Error)
+	}
+	if got.CompletedAt == nil {
+		t.Error("expected CompletedAt to be set")
+	}
+}
+
+func TestMemoryQueue_Complete_NotFound(t *testing.T) {
+	q := NewMemoryQueue(10)
+	defer q.Close()
+
+	err := q.Complete(context.Background(), uuid.New(), "")
+	if err != ErrJobNotFound {
+		t.Errorf("expected ErrJobNotFound, got %v", err)
+	}
+}
+
+func TestMemoryQueue_Fail_NotFound(t *testing.T) {
+	q := NewMemoryQueue(10)
+	defer q.Close()
+
+	err := q.Fail(context.Background(), uuid.New(), "err", "")
+	if err != ErrJobNotFound {
+		t.Errorf("expected ErrJobNotFound, got %v", err)
+	}
+}
+
+func TestMemoryQueue_DefaultBufferSize(t *testing.T) {
+	q := NewMemoryQueue(0) // should default to 100
+	defer q.Close()
+
+	// Should work — buffer size was corrected to 100
+	job := newTestJob()
+	if err := q.Enqueue(context.Background(), job); err != nil {
+		t.Fatalf("enqueue with default buffer: %v", err)
+	}
+}
+
+func TestMemoryQueue_EnqueueStoresCopy(t *testing.T) {
+	q := NewMemoryQueue(10)
+	defer q.Close()
+
+	job := newTestJob()
+	q.Enqueue(context.Background(), job)
+
+	// Mutate the original
+	job.Status = models.JobStatusRunning
+
+	// The stored copy should still be pending
+	got, _ := q.GetStatus(context.Background(), job.ID)
+	if got.Status != models.JobStatusPending {
+		t.Error("expected stored copy to be independent of original pointer")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -96,7 +96,11 @@ func Run(ctx context.Context, cfg Config) error {
 
 	// Create default admin user if configured (team mode only)
 	if !appCfg.IsLocalMode() {
-		if err := db.CreateDefaultAdmin(database); err != nil {
+		// Initialize RBAC early so CreateDefaultAdmin can grant admin role
+		if err := rbac.InitEnforcer(database, slog.Default()); err != nil {
+			return fmt.Errorf("failed to initialize RBAC: %w", err)
+		}
+		if err := db.CreateDefaultAdmin(database, rbac.NewDefaultProvider()); err != nil {
 			return fmt.Errorf("failed to create default admin user: %w", err)
 		}
 	}

--- a/internal/service/registry.go
+++ b/internal/service/registry.go
@@ -217,6 +217,47 @@ func (s *RegistryService) DeleteRegistry(id string) error {
 	return nil
 }
 
+// RegistryWithCredentials holds a registry and its decrypted credentials for OCI operations.
+type RegistryWithCredentials struct {
+	Registry models.OCIRegistry
+	Password string
+	APIToken string
+}
+
+// GetRegistryWithCredentials returns a registry with decrypted credentials for OCI operations.
+func (s *RegistryService) GetRegistryWithCredentials(id string) (*RegistryWithCredentials, error) {
+	var registry models.OCIRegistry
+	if err := s.db.Where("id = ?", id).First(&registry).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	password, err := nebicrypto.DecryptField(registry.Password, s.encKey)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt registry credentials: %w", err)
+	}
+
+	apiToken, _ := nebicrypto.DecryptField(registry.APIToken, s.encKey)
+
+	return &RegistryWithCredentials{
+		Registry: registry,
+		Password: password,
+		APIToken: apiToken,
+	}, nil
+}
+
+// FallbackRepositories returns distinct repository names from publication records for a registry.
+func (s *RegistryService) FallbackRepositories(registryID string) []string {
+	var repositories []string
+	s.db.Model(&models.Publication{}).
+		Where("registry_id = ?", registryID).
+		Distinct("repository").
+		Pluck("repository", &repositories)
+	return repositories
+}
+
 func registryToResult(reg models.OCIRegistry, username string, hasAPIToken bool) RegistryResult {
 	return RegistryResult{
 		ID:          reg.ID,


### PR DESCRIPTION
## Summary

- **RegistryBrowseHandler drops `*gorm.DB`** — last handler holding a direct DB connection. New `RegistryService.GetRegistryWithCredentials()` and `FallbackRepositories()` methods replace inline queries. Also fixes OCI error info leakage in ListTags.
- **auth/proxy and db/admin use injected `rbac.Provider`** — `syncRolesFromGroups`, `BasicAuthenticator`, `OIDCAuthenticator`, and `CreateDefaultAdmin` all accept `rbac.Provider` instead of calling global functions. Zero `rbac.*` global calls remain in business logic.
- **14 new MemoryQueue tests** — enqueue/dequeue, FIFO ordering, blocking, status lifecycle, error cases, copy isolation.

### After this PR

- No handler holds `*gorm.DB`
- No service or handler calls global `rbac.*` functions
- Test count: 96 service + 14 queue = 110 total (was 21 before this initiative)

### Re: repository layer

A full repository abstraction (GORM behind interfaces) would be a 50+ file change across all services. The ROI is low given that SQLite in-memory tests already run the full suite in ~7 seconds. If test speed or DB-swappability becomes a real need, it can be done incrementally per-service.