### PR TITLE
Default workspace view to remote when connected

### DIFF
--- a/frontend/src/store/viewModeStore.ts
+++ b/frontend/src/store/viewModeStore.ts
@@ -11,7 +11,7 @@ interface ViewModeState {
 export const useViewModeStore = create<ViewModeState>()(
   persist(
     (set) => ({
-      viewMode: 'local',
+      viewMode: 'remote',
       setViewMode: (mode) => set({ viewMode: mode }),
     }),
     { name: 'nebi-view-mode' }


### PR DESCRIPTION
## Summary
- Changes the default `viewMode` in `viewModeStore` from `'local'` to `'remote'` so that when nebi runs inside JupyterHub with `NEBI_REMOTE_URL` configured, users see the team server workspaces by default — matching what they see at the direct nebi URL.
- No behavior change for desktop users without a remote connection: `Workspaces.tsx` already falls back to showing local workspaces when `isRemoteConnected` is false, regardless of `viewMode`.
- Existing users with a persisted preference in localStorage are unaffected (zustand `persist` loads their saved choice).

## Test plan
- [x] Open nebi through the JupyterHub launcher and verify the workspace list matches the team server
- [x] Open nebi directly via the team server URL and verify workspaces display as before