### PR TITLE
feat(server): add explicit host bind support for nebi serve

### DIFF
--- a/cmd/nebi/serve.go
+++ b/cmd/nebi/serve.go
@@ -9,6 +9,7 @@ import (
 )
 
 var (
+	serveHost string
 	servePort int
 	serveMode string
 )
@@ -31,8 +32,10 @@ Examples:
   nebi serve --mode server      # Run API server only
   nebi serve --mode worker      # Run worker only
   nebi serve --port 8080        # Override port
+  nebi serve --host 127.0.0.1   # Bind only to loopback
 
 Environment variables:
+  NEBI_SERVER_HOST         Bind host/IP (e.g. 127.0.0.1). If unset, bind all interfaces.
   NEBI_SERVER_PORT         Server port (default: 8460)
   NEBI_DATABASE_DRIVER     Database driver: sqlite, postgres
   NEBI_DATABASE_DSN        Database connection string
@@ -44,12 +47,14 @@ Environment variables:
 }
 
 func init() {
+	serveCmd.Flags().StringVar(&serveHost, "host", "", "Bind host/IP (overrides config), e.g. 127.0.0.1. Empty keeps all-interface bind")
 	serveCmd.Flags().IntVarP(&servePort, "port", "p", 0, "Port to run server on (overrides config)")
 	serveCmd.Flags().StringVarP(&serveMode, "mode", "m", "both", "Run mode: server, worker, or both")
 }
 
 func runServe(cmd *cobra.Command, args []string) {
 	cfg := server.Config{
+		Host:    serveHost,
 		Port:    servePort,
 		Mode:    serveMode,
 		Version: Version,

--- a/docs/docs/server-setup.md
+++ b/docs/docs/server-setup.md
@@ -31,11 +31,21 @@ Start the server:
 nebi serve
 ```
 
-By default the server starts on [localhost:8460](http://localhost:8460). To use a different port, use the `--port` flag:
+By default (`--host` unset), Nebi binds all interfaces on port `8460`.
+
+To use a different port:
 
 ```bash
 nebi serve --port 9000
 ```
+
+To explicitly bind a host/interface, use `--host` (or `NEBI_SERVER_HOST`):
+
+```bash
+nebi serve --host 127.0.0.1 --port 8460
+```
+
+For local-only usage (desktop/IPC scenarios), always set `--host 127.0.0.1` (or `NEBI_SERVER_HOST=127.0.0.1`).
 
 Once the server is running, authenticate from any client machine with [`nebi login`](./cli-team.md#connect-to-a-server).
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,7 +25,9 @@ func (c *Config) IsLocalMode() bool {
 }
 
 // ServerConfig holds HTTP server configuration
+// Host may be empty to allow "all interfaces" bind behavior.
 type ServerConfig struct {
+	Host     string `mapstructure:"host"` // Bind host/IP (e.g. "127.0.0.1", "0.0.0.0")
 	Port     int    `mapstructure:"port"`
 	Mode     string `mapstructure:"mode"`      // "development" or "production"
 	BasePath string `mapstructure:"base_path"` // URL path prefix (e.g. "/nebi")
@@ -83,6 +85,7 @@ func Load() (*Config, error) {
 
 	// Set defaults for local development
 	v.SetDefault("mode", "team")
+	v.SetDefault("server.host", "")
 	v.SetDefault("server.port", 8460)
 	v.SetDefault("server.mode", "development")
 	v.SetDefault("server.base_path", "")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,9 +5,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -31,6 +34,7 @@ import (
 
 // Config holds the server configuration options.
 type Config struct {
+	Host    string // Bind host/IP (empty = config/default behavior)
 	Port    int    // Port to run the server on (0 = use config default)
 	Mode    string // Run mode: server, worker, or both
 	Version string // Version string to report
@@ -53,7 +57,10 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
-	// Override port from CLI flag if provided
+	// Override host/port from CLI flags if provided
+	if strings.TrimSpace(cfg.Host) != "" {
+		appCfg.Server.Host = strings.TrimSpace(cfg.Host)
+	}
 	if cfg.Port != 0 {
 		appCfg.Server.Port = cfg.Port
 	}
@@ -179,7 +186,7 @@ func Run(ctx context.Context, cfg Config) error {
 		var valkeyClientInterface interface{} = valkeyClient
 		router := api.NewRouter(appCfg, database, jobQueue, exec, broker, valkeyClientInterface, slog.Default())
 
-		addr := fmt.Sprintf(":%d", appCfg.Server.Port)
+		addr := listenAddress(appCfg.Server.Host, appCfg.Server.Port)
 		srv = &http.Server{
 			Addr:    addr,
 			Handler: router,
@@ -192,10 +199,7 @@ func Run(ctx context.Context, cfg Config) error {
 			}
 		}()
 
-		url := fmt.Sprintf("http://localhost:%d", appCfg.Server.Port)
-		if appCfg.Server.BasePath != "" {
-			url += appCfg.Server.BasePath
-		}
+		url := serverURL(appCfg.Server.Host, appCfg.Server.Port, appCfg.Server.BasePath)
 		fmt.Printf("\n  \033[32m✔\033[0m Server running at \033[1;36m%s\033[0m\n\n", url)
 	}
 
@@ -222,6 +226,30 @@ func Run(ctx context.Context, cfg Config) error {
 
 	slog.Info("Nebi exited")
 	return nil
+}
+
+func listenAddress(host string, port int) string {
+	if strings.TrimSpace(host) == "" {
+		return fmt.Sprintf(":%d", port)
+	}
+	return net.JoinHostPort(strings.TrimSpace(host), strconv.Itoa(port))
+}
+
+func displayHost(host string) string {
+	trimmed := strings.TrimSpace(host)
+	if trimmed == "" || trimmed == "0.0.0.0" || trimmed == "::" {
+		return "localhost"
+	}
+	return trimmed
+}
+
+func serverURL(host string, port int, basePath string) string {
+	hostPort := net.JoinHostPort(displayHost(host), strconv.Itoa(port))
+	url := "http://" + hostPort
+	if basePath != "" {
+		url += basePath
+	}
+	return url
 }
 
 // RunWithSignalHandling starts the server and handles OS signals for graceful shutdown.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,74 @@
+package server
+
+import "testing"
+
+func TestListenAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		port int
+		want string
+	}{
+		{name: "empty host uses all interfaces", host: "", port: 8460, want: ":8460"},
+		{name: "whitespace host uses all interfaces", host: "   ", port: 9000, want: ":9000"},
+		{name: "ipv4 host", host: "127.0.0.1", port: 8460, want: "127.0.0.1:8460"},
+		{name: "ipv6 host", host: "::1", port: 8460, want: "[::1]:8460"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := listenAddress(tt.host, tt.port)
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestDisplayHost(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{name: "empty host", host: "", want: "localhost"},
+		{name: "whitespace host", host: "  ", want: "localhost"},
+		{name: "all interfaces ipv4", host: "0.0.0.0", want: "localhost"},
+		{name: "all interfaces ipv6", host: "::", want: "localhost"},
+		{name: "loopback ipv4", host: "127.0.0.1", want: "127.0.0.1"},
+		{name: "loopback ipv6", host: "::1", want: "::1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := displayHost(tt.host)
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestServerURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		port     int
+		basePath string
+		want     string
+	}{
+		{name: "empty host defaults to localhost display", host: "", port: 8460, want: "http://localhost:8460"},
+		{name: "ipv4 host", host: "127.0.0.1", port: 8460, want: "http://127.0.0.1:8460"},
+		{name: "ipv6 host is bracketed", host: "::1", port: 8460, want: "http://[::1]:8460"},
+		{name: "all interfaces display localhost", host: "0.0.0.0", port: 9000, basePath: "/api/v1", want: "http://localhost:9000/api/v1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := serverURL(tt.host, tt.port, tt.basePath)
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add `--host` support to `nebi serve` and plumb it into `server.Config`
- add `server.host` config support (`NEBI_SERVER_HOST`)
- bind HTTP server to `host:port` when host is provided (preserve existing behavior when empty)

## Why
Applications that embed Nebi as a subprocess need to enforce loopback-only binding (`127.0.0.1`) for local IPC security.
