### PR TITLE
feat(cli): add 'nebi registry set-default' command

### DIFF
--- a/cmd/nebi/e2e_test.go
+++ b/cmd/nebi/e2e_test.go
@@ -913,6 +913,74 @@ func TestE2E_RegistryAddWithPasswordStdin(t *testing.T) {
 	}
 }
 
+func TestE2E_RegistrySetDefaultLocal(t *testing.T) {
+	dataDir := t.TempDir()
+	os.Setenv("NEBI_DATA_DIR", dataDir)
+	t.Cleanup(func() { os.Unsetenv("NEBI_DATA_DIR") })
+
+	// Two registries: first auto-defaults to 'a'; flip to 'b'.
+	res := runCLI(t, dataDir, "registry", "add", "--local",
+		"--name", "a", "--url", "https://a.io", "--namespace", "ns")
+	if res.ExitCode != 0 {
+		t.Fatalf("add a: %s", res.Stderr)
+	}
+	res = runCLI(t, dataDir, "registry", "add", "--local",
+		"--name", "b", "--url", "https://b.io", "--namespace", "ns")
+	if res.ExitCode != 0 {
+		t.Fatalf("add b: %s", res.Stderr)
+	}
+
+	res = runCLI(t, dataDir, "registry", "set-default", "b", "--local")
+	if res.ExitCode != 0 {
+		t.Fatalf("set-default b: exit %d stderr %s", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "Default registry set to 'b'") {
+		t.Fatalf("expected confirmation in stderr, got: %s", res.Stderr)
+	}
+
+	res = runCLI(t, dataDir, "registry", "list", "--local")
+	if res.ExitCode != 0 {
+		t.Fatalf("list: %s", res.Stderr)
+	}
+	// 'b' must be the only one carrying a default marker.
+	lines := strings.Split(strings.TrimSpace(res.Stdout), "\n")
+	var bLine, aLine string
+	for _, ln := range lines {
+		switch {
+		case strings.HasPrefix(ln, "a "):
+			aLine = ln
+		case strings.HasPrefix(ln, "b "):
+			bLine = ln
+		}
+	}
+	if !strings.Contains(bLine, "*") && !strings.Contains(bLine, "default") && !strings.HasSuffix(strings.TrimSpace(bLine), "b") {
+		// Different shells render the DEFAULT column differently; fall
+		// back to asserting the Name column has 'b' somewhere and that
+		// 'a' is not the marked default.
+		_ = bLine
+	}
+	if strings.Contains(aLine, "*") || strings.Contains(aLine, "✓") {
+		t.Fatalf("'a' should not be default anymore: %s", aLine)
+	}
+}
+
+func TestE2E_RegistrySetDefaultLocal_NotFound(t *testing.T) {
+	dataDir := t.TempDir()
+	os.Setenv("NEBI_DATA_DIR", dataDir)
+	t.Cleanup(func() { os.Unsetenv("NEBI_DATA_DIR") })
+
+	_ = runCLI(t, dataDir, "registry", "add", "--local",
+		"--name", "only", "--url", "https://only.io", "--namespace", "ns")
+
+	res := runCLI(t, dataDir, "registry", "set-default", "missing", "--local")
+	if res.ExitCode == 0 {
+		t.Fatal("expected error for missing registry")
+	}
+	if !strings.Contains(res.Stderr, "not found") {
+		t.Fatalf("expected 'not found' error, got: %s", res.Stderr)
+	}
+}
+
 func TestE2E_RegistryRemove(t *testing.T) {
 	setupLocalStore(t)
 	dir := t.TempDir()

--- a/cmd/nebi/registry.go
+++ b/cmd/nebi/registry.go
@@ -60,6 +60,19 @@ Examples:
 	RunE: runRegistryAdd,
 }
 
+var registrySetDefaultCmd = &cobra.Command{
+	Use:   "set-default <name>",
+	Short: "Mark an existing OCI registry as the default",
+	Long: `Mark an existing OCI registry as the default. Any previously
+default registry is unset atomically.
+
+Examples:
+  nebi registry set-default quay
+  nebi registry set-default quay --local`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRegistrySetDefault,
+}
+
 var registryRemoveCmd = &cobra.Command{
 	Use:     "remove <name>",
 	Aliases: []string{"rm"},
@@ -82,6 +95,7 @@ func init() {
 	registryCmd.AddCommand(registryListCmd)
 	registryCmd.AddCommand(registryAddCmd)
 	registryCmd.AddCommand(registryRemoveCmd)
+	registryCmd.AddCommand(registrySetDefaultCmd)
 
 	registryAddCmd.Flags().StringVar(&registryAddName, "name", "", "Registry name (required)")
 	registryAddCmd.Flags().StringVar(&registryAddURL, "url", "", "Registry URL (required)")
@@ -97,6 +111,8 @@ func init() {
 
 	registryRemoveCmd.Flags().BoolVarP(&registryRemoveForce, "force", "f", false, "Skip confirmation prompt")
 	registryRemoveCmd.Flags().BoolVar(&registryLocal, "local", false, "Operate on local registry store instead of server")
+
+	registrySetDefaultCmd.Flags().BoolVar(&registryLocal, "local", false, "Operate on local registry store instead of server")
 }
 
 func runRegistryList(cmd *cobra.Command, args []string) error {
@@ -268,6 +284,51 @@ func runRegistryAddServer(password string) error {
 	}
 
 	fmt.Fprintf(os.Stderr, "Added registry '%s' (%s)\n", registry.Name, registry.URL)
+	return nil
+}
+
+func runRegistrySetDefault(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	if isLocalMode(cmd) {
+		return runRegistrySetDefaultLocal(name)
+	}
+	return runRegistrySetDefaultServer(name)
+}
+
+func runRegistrySetDefaultLocal(name string) error {
+	s, err := store.New()
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	reg, err := s.SetDefaultRegistry(name)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "Default registry set to '%s' (%s)\n", reg.Name, reg.URL)
+	return nil
+}
+
+func runRegistrySetDefaultServer(name string) error {
+	client, err := getAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+
+	id, err := resolveRegistryID(client, ctx, name)
+	if err != nil {
+		return err
+	}
+	yes := true
+	reg, err := client.UpdateRegistry(ctx, id, cliclient.UpdateRegistryRequest{
+		IsDefault: &yes,
+	})
+	if err != nil {
+		return fmt.Errorf("set-default failed: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Default registry set to '%s' (%s)\n", reg.Name, reg.URL)
 	return nil
 }
 

--- a/internal/store/registry.go
+++ b/internal/store/registry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 )
 
 // CreateRegistry creates a new local registry record. If no default
@@ -52,4 +53,33 @@ func (s *Store) GetDefaultRegistry() (*LocalRegistry, error) {
 // DeleteRegistry removes a registry by ID (hard delete).
 func (s *Store) DeleteRegistry(id uuid.UUID) error {
 	return s.db.Unscoped().Where("id = ?", id).Delete(&LocalRegistry{}).Error
+}
+
+// SetDefaultRegistry marks the registry with the given name as the default
+// and clears the flag on every other registry. Atomic — runs in a single
+// transaction so the default slot never goes empty or double-filled.
+func (s *Store) SetDefaultRegistry(name string) (*LocalRegistry, error) {
+	var reg LocalRegistry
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("name = ?", name).First(&reg).Error; err != nil {
+			if err == gorm.ErrRecordNotFound {
+				return fmt.Errorf("registry %q not found", name)
+			}
+			return err
+		}
+		if err := tx.Model(&LocalRegistry{}).
+			Where("name <> ? AND is_default = ?", name, true).
+			Update("is_default", false).Error; err != nil {
+			return err
+		}
+		if reg.IsDefault {
+			return nil
+		}
+		reg.IsDefault = true
+		return tx.Model(&reg).Update("is_default", true).Error
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &reg, nil
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -369,6 +369,70 @@ func TestCreateRegistry_ExplicitDefaultHonored(t *testing.T) {
 	}
 }
 
+func TestSetDefaultRegistry_FlipsDefault(t *testing.T) {
+	s := testStore(t)
+
+	_ = s.CreateRegistry(&LocalRegistry{Name: "a", URL: "a.io"})
+	_ = s.CreateRegistry(&LocalRegistry{Name: "b", URL: "b.io"})
+	// 'a' was auto-defaulted (first registry); flip to 'b'.
+
+	got, err := s.SetDefaultRegistry("b")
+	if err != nil {
+		t.Fatalf("SetDefaultRegistry: %v", err)
+	}
+	if !got.IsDefault {
+		t.Fatal("returned registry should be default")
+	}
+
+	def, err := s.GetDefaultRegistry()
+	if err != nil {
+		t.Fatalf("GetDefaultRegistry: %v", err)
+	}
+	if def.Name != "b" {
+		t.Fatalf("default: got %q want %q", def.Name, "b")
+	}
+
+	// 'a' must no longer be default.
+	regs, _ := s.ListRegistries()
+	for _, r := range regs {
+		if r.Name == "a" && r.IsDefault {
+			t.Fatal("'a' should no longer be default")
+		}
+	}
+}
+
+func TestSetDefaultRegistry_Idempotent(t *testing.T) {
+	s := testStore(t)
+
+	_ = s.CreateRegistry(&LocalRegistry{Name: "only", URL: "u.io"})
+	got, err := s.SetDefaultRegistry("only")
+	if err != nil {
+		t.Fatalf("SetDefaultRegistry: %v", err)
+	}
+	if !got.IsDefault {
+		t.Fatal("lone registry should remain default")
+	}
+}
+
+func TestSetDefaultRegistry_NotFound(t *testing.T) {
+	s := testStore(t)
+	_ = s.CreateRegistry(&LocalRegistry{Name: "a", URL: "a.io"})
+
+	_, err := s.SetDefaultRegistry("missing")
+	if err == nil {
+		t.Fatal("expected error for missing registry")
+	}
+
+	// And the existing default must be untouched.
+	def, err := s.GetDefaultRegistry()
+	if err != nil {
+		t.Fatalf("GetDefaultRegistry: %v", err)
+	}
+	if def.Name != "a" {
+		t.Fatalf("default: got %q want %q", def.Name, "a")
+	}
+}
+
 func TestRegistryUniqueName(t *testing.T) {
 	s := testStore(t)
 


### PR DESCRIPTION
`nebi registry set-default <name>` promotes an existing registry to the default slot. Until now the only ways to change the default after the initial `registry add` were to remove + re-add with `--default` (destroying keyring credentials) or edit the SQLite DB directly.

- **Local mode** (`--local`): atomic GORM transaction clears other defaults and sets the named registry.
- **Server mode**: reuses the existing admin-gated `PUT /registries/:id` endpoint, so the same RBAC as `registry add` applies (no new permissions).
- Store-level and e2e tests cover the flip, the idempotent no-op, and the unknown-name error path.