### PR TITLE
fix(cli): align local registry remove message with e2e test

### DIFF
--- a/cmd/nebi/registry.go
+++ b/cmd/nebi/registry.go
@@ -370,7 +370,7 @@ func runRegistryRemoveLocal(name string) error {
 	cs := store.NewCredentialStore(s.DataDir())
 	cs.DeletePassword(name) // Ignore error — credential may not exist
 
-	fmt.Fprintf(os.Stderr, "Removed local registry '%s'\n", name)
+	fmt.Fprintf(os.Stderr, "Removed registry '%s'\n", name)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- `TestE2E_RegistryRemove` fails on main: it asserts stderr contains `Removed registry`, but local-mode `registry remove` prints `Removed local registry 'X'` — which does not contain that substring.
- Drop the word `local` so the local- and server-mode messages match. The `(local)` store is an internal distinction; users don't need to see it here, and the prompt already says `Remove local registry '%s'? [y/N]` before deletion.

Failing run: https://github.com/nebari-dev/nebi/actions/runs/24778626703/job/72519017682