### PR TITLE
feat(api): publish/import full OCI bundles in local mode

### DIFF
--- a/cmd/nebi/bundle_api_e2e_test.go
+++ b/cmd/nebi/bundle_api_e2e_test.go
@@ -1,0 +1,287 @@
+//go:build e2e
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/nebari-dev/nebi/internal/cliclient"
+	"github.com/nebari-dev/nebi/internal/oci"
+	"github.com/nebari-dev/nebi/internal/server"
+)
+
+// TestE2E_BundlePublishImportViaAPI_LocalMode verifies that importing a bundle
+// via the Nebi HTTP API in local mode correctly extracts all asset layers to
+// the workspace directory on disk. It:
+//
+//  1. Starts a fresh Nebi server in local mode (independent of the shared TestMain server).
+//  2. Seeds an in-memory OCI registry with a bundle containing pixi.toml,
+//     pixi.lock, and notebook.ipynb using oci.Publish directly.
+//  3. Creates the registry in Nebi via POST /admin/registries.
+//  4. Imports via POST /registries/:id/import.
+//  5. Polls GET /workspaces/:id until status == "ready".
+//  6. Asserts notebook.ipynb and pixi.lock exist on disk with correct content.
+func TestE2E_BundlePublishImportViaAPI_LocalMode(t *testing.T) {
+	// Snapshot and restore env vars that overlap with the global TestMain setup.
+	// We need to override them for this test's private server without poisoning
+	// the shared server that TestMain already started on a different port.
+	envVars := []string{
+		"NEBI_MODE",
+		"NEBI_DATABASE_DSN",
+		"NEBI_STORAGE_WORKSPACES_DIR",
+		"NEBI_SERVER_PORT",
+		"NEBI_PACKAGE_MANAGER_PIXI_PATH",
+	}
+	saved := make(map[string]string, len(envVars))
+	for _, k := range envVars {
+		saved[k] = os.Getenv(k)
+	}
+	t.Cleanup(func() {
+		for k, v := range saved {
+			if v == "" {
+				os.Unsetenv(k)
+			} else {
+				os.Setenv(k, v)
+			}
+		}
+	})
+
+	// ---- Temp directories ----
+	dbDir := t.TempDir()
+	dbPath := filepath.Join(dbDir, "bundle-api-e2e.db")
+	wsDir := t.TempDir()
+
+	// ---- Port allocation ----
+	port, err := findFreePort()
+	if err != nil {
+		t.Fatalf("find free port: %v", err)
+	}
+
+	// ---- Set env vars for local-mode server ----
+	os.Setenv("NEBI_MODE", "local")
+	os.Setenv("NEBI_DATABASE_DSN", dbPath)
+	os.Setenv("NEBI_STORAGE_WORKSPACES_DIR", wsDir)
+	os.Setenv("NEBI_SERVER_PORT", fmt.Sprintf("%d", port))
+	// Point pixi to a no-op binary so "pixi install" succeeds without
+	// actually installing any packages. The workspace only needs files on
+	// disk for this test to pass. Use /usr/bin/true (macOS) with /bin/true
+	// as a fallback for Linux.
+	noopBinary := "/usr/bin/true"
+	if _, err := os.Stat(noopBinary); err != nil {
+		noopBinary = "/bin/true"
+	}
+	os.Setenv("NEBI_PACKAGE_MANAGER_PIXI_PATH", noopBinary)
+
+	serverURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	// ---- Start local-mode server ----
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- server.Run(ctx, server.Config{
+			Port:    port,
+			Mode:    "both",
+			Version: "e2e-bundle-api-test",
+		})
+	}()
+
+	waitForHealth(serverURL+"/api/v1/health", serverErr, io.Discard)
+
+	// ---- Login ----
+	unauthClient := cliclient.NewWithoutAuth(serverURL)
+	loginResp, err := unauthClient.Login(ctx, "admin", "adminpass")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	token := loginResp.Token
+
+	// ---- In-memory OCI registry ----
+	ociSrv := httptest.NewServer(registry.New())
+	t.Cleanup(ociSrv.Close)
+	ociURL, _ := url.Parse(ociSrv.URL)
+	ociHost := ociURL.Host
+
+	// ---- Seed the OCI registry via oci.Publish ----
+	const (
+		repoName     = "notebook-env"
+		bundleTag    = "v1"
+		ociNS        = "demo"
+		notebookBody = `{"cells":[],"metadata":{},"nbformat":4,"nbformat_minor":5}`
+		pixiTomlBody = "[project]\nname = \"notebook-env\"\nchannels = [\"conda-forge\"]\nplatforms = [\"linux-64\"]\n"
+		pixiLockBody = "version: 6\n# seeded-by-test\n"
+	)
+
+	srcDir := t.TempDir()
+	writeFile := func(rel, body string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(filepath.Join(srcDir, rel)), 0o755); err != nil {
+			t.Fatalf("mkdir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(filepath.Join(srcDir, rel), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	writeFile("pixi.toml", pixiTomlBody)
+	writeFile("pixi.lock", pixiLockBody)
+	writeFile("notebook.ipynb", notebookBody)
+
+	reg := oci.Registry{Host: ociHost, Namespace: ociNS, PlainHTTP: true}
+	if _, err := oci.Publish(ctx, srcDir, reg, repoName, bundleTag); err != nil {
+		t.Fatalf("seed oci.Publish: %v", err)
+	}
+
+	// ---- Create registry in Nebi via POST /admin/registries ----
+	registryID := createRegistryViaAPI(t, serverURL, token, map[string]interface{}{
+		"name":       "bundle-api-e2e-reg",
+		"url":        "http://" + ociHost,
+		"namespace":  ociNS,
+		"is_default": true,
+	})
+
+	// ---- Import via POST /registries/:id/import ----
+	wsID := importViaAPI(t, serverURL, token, registryID, map[string]interface{}{
+		"repository": repoName,
+		"tag":        bundleTag,
+		"name":       "notebook-imported",
+	})
+
+	// ---- Poll workspace until ready (or fail after 30s) ----
+	pollWorkspaceReady(t, serverURL, token, wsID, 30*time.Second)
+
+	// ---- Derive workspace directory path ----
+	// LocalExecutor.GetWorkspacePath: {wsDir}/{normalized-name}-{uuid}
+	// normalized("notebook-imported") → "notebook-imported"
+	wsPath := filepath.Join(wsDir, fmt.Sprintf("notebook-imported-%s", wsID))
+
+	// ---- Assertions ----
+	assertFileContent(t, wsPath, "notebook.ipynb", notebookBody)
+	assertFileContent(t, wsPath, "pixi.lock", pixiLockBody)
+	assertFileContains(t, wsPath, "pixi.toml", "notebook-env")
+}
+
+// createRegistryViaAPI POSTs to /admin/registries and returns the created registry ID.
+func createRegistryViaAPI(t *testing.T, serverURL, token string, body map[string]interface{}) string {
+	t.Helper()
+	b, _ := json.Marshal(body)
+	req, _ := http.NewRequest(http.MethodPost, serverURL+"/api/v1/admin/registries", bytes.NewReader(b))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /admin/registries: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("POST /admin/registries: status %d, body: %s", resp.StatusCode, raw)
+	}
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("decode registry response: %v (body: %s)", err, raw)
+	}
+	if result.ID == "" {
+		t.Fatalf("registry response missing id: %s", raw)
+	}
+	return result.ID
+}
+
+// importViaAPI POSTs to /registries/:id/import and returns the created workspace ID.
+func importViaAPI(t *testing.T, serverURL, token, registryID string, body map[string]interface{}) string {
+	t.Helper()
+	b, _ := json.Marshal(body)
+	url := fmt.Sprintf("%s/api/v1/registries/%s/import", serverURL, registryID)
+	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /registries/%s/import: %v", registryID, err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("POST /registries/%s/import: status %d, body: %s", registryID, resp.StatusCode, raw)
+	}
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("decode import response: %v (body: %s)", err, raw)
+	}
+	if result.ID == "" {
+		t.Fatalf("import response missing id: %s", raw)
+	}
+	return result.ID
+}
+
+// pollWorkspaceReady polls GET /workspaces/:id until status == "ready" or times out.
+func pollWorkspaceReady(t *testing.T, serverURL, token, wsID string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	url := fmt.Sprintf("%s/api/v1/workspaces/%s", serverURL, wsID)
+	for time.Now().Before(deadline) {
+		req, _ := http.NewRequest(http.MethodGet, url, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			time.Sleep(250 * time.Millisecond)
+			continue
+		}
+		raw, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		var ws struct {
+			Status string `json:"status"`
+		}
+		if err := json.Unmarshal(raw, &ws); err != nil {
+			t.Fatalf("decode workspace response: %v (body: %s)", err, raw)
+		}
+		switch ws.Status {
+		case "ready":
+			return
+		case "failed":
+			t.Fatalf("workspace %s entered 'failed' state", wsID)
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("workspace %s did not become ready within %s", wsID, timeout)
+}
+
+// assertFileContent reads rel inside wsDir and checks it equals want exactly.
+func assertFileContent(t *testing.T, wsDir, rel, want string) {
+	t.Helper()
+	got, err := os.ReadFile(filepath.Join(wsDir, rel))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	if string(got) != want {
+		t.Fatalf("content mismatch for %s:\n got: %q\nwant: %q", rel, got, want)
+	}
+}
+
+// assertFileContains reads rel inside wsDir and checks it contains substr.
+func assertFileContains(t *testing.T, wsDir, rel, substr string) {
+	t.Helper()
+	got, err := os.ReadFile(filepath.Join(wsDir, rel))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	if !bytes.Contains(got, []byte(substr)) {
+		t.Fatalf("%s does not contain %q:\n%s", rel, substr, got)
+	}
+}

--- a/cmd/nebi/bundle_api_e2e_test.go
+++ b/cmd/nebi/bundle_api_e2e_test.go
@@ -22,21 +22,21 @@ import (
 	"github.com/nebari-dev/nebi/internal/server"
 )
 
-// TestE2E_BundlePublishImportViaAPI_LocalMode verifies that importing a bundle
-// via the Nebi HTTP API in local mode correctly extracts all asset layers to
-// the workspace directory on disk. It:
-//
-//  1. Starts a fresh Nebi server in local mode (independent of the shared TestMain server).
-//  2. Seeds an in-memory OCI registry with a bundle containing pixi.toml,
-//     pixi.lock, and notebook.ipynb using oci.Publish directly.
-//  3. Creates the registry in Nebi via POST /admin/registries.
-//  4. Imports via POST /registries/:id/import.
-//  5. Polls GET /workspaces/:id until status == "ready".
-//  6. Asserts notebook.ipynb and pixi.lock exist on disk with correct content.
-func TestE2E_BundlePublishImportViaAPI_LocalMode(t *testing.T) {
-	// Snapshot and restore env vars that overlap with the global TestMain setup.
-	// We need to override them for this test's private server without poisoning
-	// the shared server that TestMain already started on a different port.
+// localModeEnv holds everything a local-mode HTTP test needs.
+type localModeEnv struct {
+	serverURL string
+	token     string
+	ctx       context.Context
+	wsDir     string
+	ociHost   string
+}
+
+// startLocalModeServer spins up a private Nebi server in NEBI_MODE=local
+// (independent of the shared TestMain team-mode server) plus an in-memory
+// OCI registry. Env vars are snapshotted/restored via t.Cleanup so the
+// shared server is unaffected.
+func startLocalModeServer(t *testing.T) *localModeEnv {
+	t.Helper()
 	envVars := []string{
 		"NEBI_MODE",
 		"NEBI_DATABASE_DSN",
@@ -58,26 +58,19 @@ func TestE2E_BundlePublishImportViaAPI_LocalMode(t *testing.T) {
 		}
 	})
 
-	// ---- Temp directories ----
 	dbDir := t.TempDir()
 	dbPath := filepath.Join(dbDir, "bundle-api-e2e.db")
 	wsDir := t.TempDir()
 
-	// ---- Port allocation ----
 	port, err := findFreePort()
 	if err != nil {
 		t.Fatalf("find free port: %v", err)
 	}
 
-	// ---- Set env vars for local-mode server ----
 	os.Setenv("NEBI_MODE", "local")
 	os.Setenv("NEBI_DATABASE_DSN", dbPath)
 	os.Setenv("NEBI_STORAGE_WORKSPACES_DIR", wsDir)
 	os.Setenv("NEBI_SERVER_PORT", fmt.Sprintf("%d", port))
-	// Point pixi to a no-op binary so "pixi install" succeeds without
-	// actually installing any packages. The workspace only needs files on
-	// disk for this test to pass. Use /usr/bin/true (macOS) with /bin/true
-	// as a fallback for Linux.
 	noopBinary := "/usr/bin/true"
 	if _, err := os.Stat(noopBinary); err != nil {
 		noopBinary = "/bin/true"
@@ -85,11 +78,8 @@ func TestE2E_BundlePublishImportViaAPI_LocalMode(t *testing.T) {
 	os.Setenv("NEBI_PACKAGE_MANAGER_PIXI_PATH", noopBinary)
 
 	serverURL := fmt.Sprintf("http://127.0.0.1:%d", port)
-
-	// ---- Start local-mode server ----
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-
 	serverErr := make(chan error, 1)
 	go func() {
 		serverErr <- server.Run(ctx, server.Config{
@@ -98,22 +88,37 @@ func TestE2E_BundlePublishImportViaAPI_LocalMode(t *testing.T) {
 			Version: "e2e-bundle-api-test",
 		})
 	}()
-
 	waitForHealth(serverURL+"/api/v1/health", serverErr, io.Discard)
 
-	// ---- Login ----
 	unauthClient := cliclient.NewWithoutAuth(serverURL)
 	loginResp, err := unauthClient.Login(ctx, "admin", "adminpass")
 	if err != nil {
 		t.Fatalf("login: %v", err)
 	}
-	token := loginResp.Token
 
-	// ---- In-memory OCI registry ----
 	ociSrv := httptest.NewServer(registry.New())
 	t.Cleanup(ociSrv.Close)
 	ociURL, _ := url.Parse(ociSrv.URL)
-	ociHost := ociURL.Host
+
+	return &localModeEnv{
+		serverURL: serverURL,
+		token:     loginResp.Token,
+		ctx:       ctx,
+		wsDir:     wsDir,
+		ociHost:   ociURL.Host,
+	}
+}
+
+// TestE2E_BundlePublishImportViaAPI_LocalMode verifies that importing a bundle
+// via the Nebi HTTP API in local mode correctly extracts all asset layers to
+// the workspace directory on disk.
+func TestE2E_BundlePublishImportViaAPI_LocalMode(t *testing.T) {
+	env := startLocalModeServer(t)
+	serverURL := env.serverURL
+	token := env.token
+	ctx := env.ctx
+	wsDir := env.wsDir
+	ociHost := env.ociHost
 
 	// ---- Seed the OCI registry via oci.Publish ----
 	const (
@@ -171,6 +176,118 @@ func TestE2E_BundlePublishImportViaAPI_LocalMode(t *testing.T) {
 	assertFileContent(t, wsPath, "notebook.ipynb", notebookBody)
 	assertFileContent(t, wsPath, "pixi.lock", pixiLockBody)
 	assertFileContains(t, wsPath, "pixi.toml", "notebook-env")
+}
+
+// TestE2E_BundlePublishViaAPI_LocalMode verifies that publishing a workspace
+// via POST /workspaces/:id/publish in local mode uploads the full bundle —
+// pixi.toml, pixi.lock, AND every asset file — to the registry.
+func TestE2E_BundlePublishViaAPI_LocalMode(t *testing.T) {
+	env := startLocalModeServer(t)
+
+	// ---- Create + populate a workspace ----
+	const (
+		notebookBody = `{"cells":[],"metadata":{},"nbformat":4,"nbformat_minor":5}`
+		pixiTomlBody = "[project]\nname = \"publish-test\"\nchannels = [\"conda-forge\"]\nplatforms = [\"linux-64\"]\n"
+		pixiLockBody = "version: 6\n# server-published\n"
+	)
+	wsID := createWorkspaceViaAPI(t, env.serverURL, env.token, "publish-test", pixiTomlBody)
+	pollWorkspaceReady(t, env.serverURL, env.token, wsID, 30*time.Second)
+
+	// Drop a real lockfile + asset on disk where the server expects them
+	// (the worker only wrote pixi.toml; we add the rest by hand to
+	// simulate what the user would have done via push or the editor).
+	wsPath := filepath.Join(env.wsDir, fmt.Sprintf("publish-test-%s", wsID))
+	if err := os.WriteFile(filepath.Join(wsPath, "pixi.lock"), []byte(pixiLockBody), 0o644); err != nil {
+		t.Fatalf("seed pixi.lock: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(wsPath, "notebook.ipynb"), []byte(notebookBody), 0o644); err != nil {
+		t.Fatalf("seed notebook: %v", err)
+	}
+
+	// ---- Register the OCI destination ----
+	registryID := createRegistryViaAPI(t, env.serverURL, env.token, map[string]interface{}{
+		"name":       "publish-target-reg",
+		"url":        "http://" + env.ociHost,
+		"namespace":  "demo",
+		"is_default": true,
+	})
+
+	// ---- Publish via POST /workspaces/:id/publish ----
+	publishViaAPI(t, env.serverURL, env.token, wsID, map[string]interface{}{
+		"registry_id": registryID,
+		"repository":  "publish-test-repo",
+		"tag":         "v1",
+	})
+
+	// ---- Pull back via oci.PullBundle and verify the asset layer is present ----
+	repoRef := fmt.Sprintf("%s/demo/publish-test-repo", env.ociHost)
+	pull, err := oci.PullBundle(env.ctx, repoRef, "v1", oci.PullOptions{PlainHTTP: true})
+	if err != nil {
+		t.Fatalf("PullBundle: %v", err)
+	}
+	if len(pull.Assets) != 1 || pull.Assets[0].Path != "notebook.ipynb" {
+		t.Fatalf("expected one asset notebook.ipynb in published bundle, got %+v", pull.Assets)
+	}
+	if !contains(pull.PixiToml, "publish-test") {
+		t.Errorf("published pixi.toml missing project name; got %q", pull.PixiToml)
+	}
+	if !contains(pull.PixiLock, "server-published") {
+		t.Errorf("published pixi.lock did not round-trip; got %q", pull.PixiLock)
+	}
+}
+
+func contains(s, sub string) bool { return bytes.Contains([]byte(s), []byte(sub)) }
+
+// createWorkspaceViaAPI POSTs to /workspaces and returns the created workspace ID.
+func createWorkspaceViaAPI(t *testing.T, serverURL, token, name, pixiToml string) string {
+	t.Helper()
+	body := map[string]interface{}{
+		"name":            name,
+		"package_manager": "pixi",
+		"pixi_toml":       pixiToml,
+	}
+	b, _ := json.Marshal(body)
+	req, _ := http.NewRequest(http.MethodPost, serverURL+"/api/v1/workspaces", bytes.NewReader(b))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /workspaces: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /workspaces: status %d, body: %s", resp.StatusCode, raw)
+	}
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("decode workspace response: %v (body: %s)", err, raw)
+	}
+	if result.ID == "" {
+		t.Fatalf("workspace response missing id: %s", raw)
+	}
+	return result.ID
+}
+
+// publishViaAPI POSTs to /workspaces/:id/publish and asserts a 2xx response.
+func publishViaAPI(t *testing.T, serverURL, token, wsID string, body map[string]interface{}) {
+	t.Helper()
+	b, _ := json.Marshal(body)
+	url := fmt.Sprintf("%s/api/v1/workspaces/%s/publish", serverURL, wsID)
+	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /workspaces/%s/publish: %v", wsID, err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		t.Fatalf("POST /workspaces/%s/publish: status %d, body: %s", wsID, resp.StatusCode, raw)
+	}
 }
 
 // createRegistryViaAPI POSTs to /admin/registries and returns the created registry ID.

--- a/cmd/nebi/bundle_e2e_test.go
+++ b/cmd/nebi/bundle_e2e_test.go
@@ -37,8 +37,7 @@ var publishedRefRE = regexp.MustCompile(`Published (\S+) \(digest:`)
 func TestE2E_LocalBundlePublishImport(t *testing.T) {
 	// Isolate the local store for this test.
 	dataDir := t.TempDir()
-	os.Setenv("NEBI_DATA_DIR", dataDir)
-	t.Cleanup(func() { os.Unsetenv("NEBI_DATA_DIR") })
+	t.Setenv("NEBI_DATA_DIR", dataDir)
 
 	regHost := startE2ERegistry(t)
 	regURL := "http://" + regHost
@@ -153,8 +152,7 @@ func TestE2E_LocalBundlePublishImport(t *testing.T) {
 // with assets refuses to overwrite a non-empty destination.
 func TestE2E_LocalBundleRejectsNonEmptyDest(t *testing.T) {
 	dataDir := t.TempDir()
-	os.Setenv("NEBI_DATA_DIR", dataDir)
-	t.Cleanup(func() { os.Unsetenv("NEBI_DATA_DIR") })
+	t.Setenv("NEBI_DATA_DIR", dataDir)
 
 	regHost := startE2ERegistry(t)
 	regURL := "http://" + regHost

--- a/cmd/nebi/publish.go
+++ b/cmd/nebi/publish.go
@@ -2,10 +2,7 @@ package main
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 
@@ -199,7 +196,7 @@ func runPublishLocal(args []string) error {
 	// pixi.lock are untouched. Preview walks the workspace with the
 	// same rules Publish will use, so both always agree on the asset
 	// set.
-	assetRefs, err := previewBundleForHash(ws.Path)
+	assetRefs, err := oci.PreviewAssetRefs(ws.Path)
 	if err != nil {
 		return fmt.Errorf("preview bundle for tag hash: %w", err)
 	}
@@ -251,47 +248,6 @@ func runPublishLocal(args []string) error {
 
 	fmt.Fprintf(os.Stderr, "Published %s:%s (digest: %s)\n", fullRepo, tag, digest)
 	return nil
-}
-
-// previewBundleForHash walks the workspace with the same filters
-// publishBundle will apply and returns each asset as a (path, digest)
-// pair suitable for contenthash.HashBundle. The "digest" is the SHA-256
-// of the file bytes — not the OCI blob digest — but that is fine: the
-// tag only needs to change when the bundle changes, and both sides
-// derive the hash the same way from file contents.
-func previewBundleForHash(workspaceDir string) ([]contenthash.AssetRef, error) {
-	assets, err := oci.Preview(context.Background(), workspaceDir)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]contenthash.AssetRef, 0, len(assets))
-	for _, a := range assets {
-		// Skip core files — HashBundle already folds pixi.toml and
-		// pixi.lock in via its first two arguments, so counting them
-		// again here would just decorate the hash with no extra signal.
-		if a.RelPath == "pixi.toml" || a.RelPath == "pixi.lock" {
-			continue
-		}
-		sum, err := fileSHA256(a.AbsPath)
-		if err != nil {
-			return nil, fmt.Errorf("hash %s: %w", a.RelPath, err)
-		}
-		out = append(out, contenthash.AssetRef{Path: a.RelPath, Digest: "sha256:" + sum})
-	}
-	return out, nil
-}
-
-func fileSHA256(path string) (string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // resolveRegistryID resolves a registry name/ID or finds the default registry.

--- a/internal/api/handlers/registry_browse.go
+++ b/internal/api/handlers/registry_browse.go
@@ -161,30 +161,10 @@ func (h *RegistryBrowseHandler) ImportEnvironment(c *gin.Context) {
 		return
 	}
 
-	regCreds, err := h.registrySvc.GetRegistryWithCredentials(registryID)
-	if err != nil {
-		handleServiceError(c, err)
-		return
-	}
-
-	host, _ := oci.ParseRegistryURL(regCreds.Registry.URL)
-	repoRef := fmt.Sprintf("%s/%s", host, req.Repository)
-	opts := oci.BrowseOptions{
-		RegistryHost: host,
-		Username:     regCreds.Registry.Username,
-		Password:     regCreds.Password,
-	}
-
-	result, err := oci.PullEnvironment(c.Request.Context(), repoRef, req.Tag, opts)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to pull environment"})
-		return
-	}
-
-	ws, err := h.wsSvc.Create(c.Request.Context(), service.CreateRequest{
-		Name:           req.Name,
-		PackageManager: "pixi",
-		PixiToml:       result.PixiToml,
+	ws, err := h.wsSvc.ImportFromRegistry(c.Request.Context(), registryID, service.ImportFromRegistryRequest{
+		Repository: req.Repository,
+		Tag:        req.Tag,
+		Name:       req.Name,
 	}, userID)
 	if err != nil {
 		handleServiceError(c, err)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -27,10 +27,17 @@ import (
 
 // NewRouter creates and configures the Gin router
 func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Executor, logBroker *logstream.LogBroker, valkeyClient interface{}, logger *slog.Logger) *gin.Engine {
-	// Initialize RBAC enforcer and provider
-	if err := rbac.InitEnforcer(db, logger); err != nil {
-		logger.Error("Failed to initialize RBAC", "error", err)
-		panic(err)
+	// Initialize RBAC enforcer and provider.
+	// In local mode the admin and workspace RBAC checks are unconditionally
+	// skipped (see RequireAdmin / RequireWorkspaceAccess middleware), so
+	// there is no need to re-initialise the global casbin enforcer — and
+	// doing so would clobber the enforcer that was already set up by a
+	// concurrently-running team-mode server (relevant in tests).
+	if !cfg.IsLocalMode() {
+		if err := rbac.InitEnforcer(db, logger); err != nil {
+			logger.Error("Failed to initialize RBAC", "error", err)
+			panic(err)
+		}
 	}
 	rbacProvider := rbac.NewDefaultProvider()
 

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -42,6 +42,7 @@ const (
 	ActionRemovePackage    = "remove_package"
 	ActionSolveWorkspace   = "solve_workspace"
 	ActionPublishWorkspace = "publish_workspace"
+	ActionImportWorkspace  = "import_workspace"
 	ActionPush             = "push"
 	ActionReassignTag      = "reassign_tag"
 	ActionLogin            = "login"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -128,6 +128,30 @@ func Load() (*Config, error) {
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
 
+	// viper's AutomaticEnv + Unmarshal does not propagate env vars into
+	// nested structs without explicit BindEnv. Bind each nested key so that
+	// e.g. NEBI_PACKAGE_MANAGER_PIXI_PATH overrides the pixi_path field.
+	_ = v.BindEnv("package_manager.default_type", "NEBI_PACKAGE_MANAGER_DEFAULT_TYPE")
+	_ = v.BindEnv("package_manager.pixi_path", "NEBI_PACKAGE_MANAGER_PIXI_PATH")
+	_ = v.BindEnv("package_manager.uv_path", "NEBI_PACKAGE_MANAGER_UV_PATH")
+	_ = v.BindEnv("storage.workspaces_dir", "NEBI_STORAGE_WORKSPACES_DIR")
+	_ = v.BindEnv("server.host", "NEBI_SERVER_HOST")
+	_ = v.BindEnv("server.port", "NEBI_SERVER_PORT")
+	_ = v.BindEnv("server.mode", "NEBI_SERVER_MODE")
+	_ = v.BindEnv("server.base_path", "NEBI_SERVER_BASE_PATH")
+	_ = v.BindEnv("database.driver", "NEBI_DATABASE_DRIVER")
+	_ = v.BindEnv("database.dsn", "NEBI_DATABASE_DSN")
+	_ = v.BindEnv("auth.type", "NEBI_AUTH_TYPE")
+	_ = v.BindEnv("auth.jwt_secret", "NEBI_AUTH_JWT_SECRET")
+	_ = v.BindEnv("auth.oidc_issuer_url", "NEBI_AUTH_OIDC_ISSUER_URL")
+	_ = v.BindEnv("auth.oidc_client_id", "NEBI_AUTH_OIDC_CLIENT_ID")
+	_ = v.BindEnv("auth.oidc_client_secret", "NEBI_AUTH_OIDC_CLIENT_SECRET")
+	_ = v.BindEnv("auth.oidc_redirect_url", "NEBI_AUTH_OIDC_REDIRECT_URL")
+	_ = v.BindEnv("queue.type", "NEBI_QUEUE_TYPE")
+	_ = v.BindEnv("queue.valkey_addr", "NEBI_QUEUE_VALKEY_ADDR")
+	_ = v.BindEnv("log.format", "NEBI_LOG_FORMAT")
+	_ = v.BindEnv("log.level", "NEBI_LOG_LEVEL")
+
 	var cfg Config
 	if err := v.Unmarshal(&cfg); err != nil {
 		return nil, fmt.Errorf("error unmarshaling config: %w", err)

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -7,23 +7,23 @@ import (
 	"github.com/nebari-dev/nebi/internal/models"
 )
 
+// CreateWorkspaceOptions tunes CreateWorkspace. PixiToml seeds a newly
+// created workspace with a pinned manifest. SeedDir seeds a newly
+// created workspace from a pre-populated directory (used for bundle
+// imports); when non-empty, PixiToml is ignored because the seed's
+// pixi.toml is authoritative. SeedDir is removed after a successful
+// create to keep staging from leaking.
+type CreateWorkspaceOptions struct {
+	PixiToml string
+	SeedDir  string
+}
+
 // Executor interface for running workspace operations
 type Executor interface {
-	// CreateWorkspace creates a new workspace with optional pixi.toml content
-	CreateWorkspace(ctx context.Context, ws *models.Workspace, logWriter io.Writer, pixiToml ...string) error
-
-	// InstallPackages installs packages in a workspace
+	CreateWorkspace(ctx context.Context, ws *models.Workspace, logWriter io.Writer, opts CreateWorkspaceOptions) error
 	InstallPackages(ctx context.Context, ws *models.Workspace, packages []string, logWriter io.Writer) error
-
-	// RemovePackages removes packages from a workspace
 	RemovePackages(ctx context.Context, ws *models.Workspace, packages []string, logWriter io.Writer) error
-
-	// DeleteWorkspace removes a workspace
 	DeleteWorkspace(ctx context.Context, ws *models.Workspace, logWriter io.Writer) error
-
-	// SolveEnvironment runs pixi install to solve and install the current pixi.toml
 	SolveEnvironment(ctx context.Context, ws *models.Workspace, logWriter io.Writer) error
-
-	// GetWorkspacePath returns the filesystem path for a workspace
 	GetWorkspacePath(ws *models.Workspace) string
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -26,4 +26,8 @@ type Executor interface {
 	DeleteWorkspace(ctx context.Context, ws *models.Workspace, logWriter io.Writer) error
 	SolveEnvironment(ctx context.Context, ws *models.Workspace, logWriter io.Writer) error
 	GetWorkspacePath(ws *models.Workspace) string
+	// StagingRoot returns a directory under the executor's storage root
+	// suitable for one-off staging (e.g. bundle import pre-extraction).
+	// The directory is ensured to exist.
+	StagingRoot() string
 }

--- a/internal/executor/local.go
+++ b/internal/executor/local.go
@@ -62,6 +62,13 @@ func normalizeEnvName(name string) string {
 	return name
 }
 
+// StagingRoot returns {baseDir}/.import-staging, creating it if missing.
+func (e *LocalExecutor) StagingRoot() string {
+	root := filepath.Join(e.baseDir, ".import-staging")
+	_ = os.MkdirAll(root, 0o755)
+	return root
+}
+
 // GetWorkspacePath returns the filesystem path for a workspace
 // For source=="local" workspaces with a path set, returns that path directly.
 // Otherwise: {baseDir}/{normalized-name}-{uuid}

--- a/internal/executor/local.go
+++ b/internal/executor/local.go
@@ -75,18 +75,15 @@ func (e *LocalExecutor) GetWorkspacePath(ws *models.Workspace) string {
 }
 
 // CreateWorkspace creates a new workspace on the local filesystem
-func (e *LocalExecutor) CreateWorkspace(ctx context.Context, ws *models.Workspace, logWriter io.Writer, pixiToml ...string) error {
+func (e *LocalExecutor) CreateWorkspace(ctx context.Context, ws *models.Workspace, logWriter io.Writer, opts CreateWorkspaceOptions) error {
 	envPath := e.GetWorkspacePath(ws)
-
 	fmt.Fprintf(logWriter, "Creating environment at: %s\n", envPath)
 
-	// Create package manager instance
 	pmType := ws.PackageManager
 	if pmType == "" {
 		pmType = e.config.PackageManager.DefaultType
 	}
 
-	// Use custom path if configured
 	var pm pkgmgr.PackageManager
 	var err error
 	if pmType == "pixi" && e.config.PackageManager.PixiPath != "" {
@@ -96,66 +93,122 @@ func (e *LocalExecutor) CreateWorkspace(ctx context.Context, ws *models.Workspac
 	} else {
 		pm, err = pkgmgr.New(pmType)
 	}
-
 	if err != nil {
 		return fmt.Errorf("failed to create package manager: %w", err)
 	}
-
 	fmt.Fprintf(logWriter, "Using package manager: %s\n", pm.Name())
 
-	// Check if custom pixi.toml content is provided
-	if len(pixiToml) > 0 && pixiToml[0] != "" {
-		// Create environment directory
-		if err := os.MkdirAll(envPath, 0755); err != nil {
-			return fmt.Errorf("failed to create environment directory: %w", err)
+	switch {
+	case opts.SeedDir != "":
+		if err := os.MkdirAll(envPath, 0o755); err != nil {
+			return fmt.Errorf("create env dir: %w", err)
+		}
+		fmt.Fprintf(logWriter, "Seeding workspace from %s\n", opts.SeedDir)
+		if err := seedWorkspaceFromDir(opts.SeedDir, envPath); err != nil {
+			return fmt.Errorf("seed workspace: %w", err)
+		}
+		if err := os.RemoveAll(opts.SeedDir); err != nil {
+			fmt.Fprintf(logWriter, "Warning: staging cleanup failed: %v\n", err)
+		}
+		if err := runPixiInstall(ctx, pm, envPath, logWriter); err != nil {
+			return err
 		}
 
-		// Write custom pixi.toml content
+	case opts.PixiToml != "":
+		if err := os.MkdirAll(envPath, 0o755); err != nil {
+			return fmt.Errorf("create env dir: %w", err)
+		}
 		pixiTomlPath := filepath.Join(envPath, "pixi.toml")
 		fmt.Fprintf(logWriter, "Writing custom pixi.toml content\n")
-		if err := os.WriteFile(pixiTomlPath, []byte(pixiToml[0]), 0644); err != nil {
+		if err := os.WriteFile(pixiTomlPath, []byte(opts.PixiToml), 0o644); err != nil {
 			return fmt.Errorf("failed to write pixi.toml: %w", err)
 		}
-		fmt.Fprintf(logWriter, "Custom pixi.toml written successfully\n")
-
-		// Run pixi install to create the actual environment
-		// This will read the pixi.toml and create the .pixi directory with the conda environment
-		fmt.Fprintf(logWriter, "Installing environment from pixi.toml\n")
-
-		// Get pixi binary path from package manager
-		pixiBinary := "pixi" // Default fallback
-		if pixiMgr, ok := pm.(*pixi.PixiManager); ok {
-			pixiBinary = pixiMgr.BinaryPath()
+		if err := runPixiInstall(ctx, pm, envPath, logWriter); err != nil {
+			return err
 		}
 
-		installCmd := exec.CommandContext(ctx, pixiBinary, "install", "-v")
-		installCmd.Dir = envPath
-		installCmd.Stdout = logWriter
-		installCmd.Stderr = logWriter
-
-		fmt.Fprintf(logWriter, "Running: pixi install -v\n")
-		if err := installCmd.Run(); err != nil {
-			return fmt.Errorf("failed to install pixi environment: %w", err)
-		}
-		fmt.Fprintf(logWriter, "Pixi environment installed successfully\n")
-	} else {
-		// Initialize environment with default configuration
-		// Note: For pixi, the Name parameter is used as the project name in pixi.toml
-		// The environment is created in EnvPath directory itself
-		opts := pkgmgr.InitOptions{
+	default:
+		initOpts := pkgmgr.InitOptions{
 			EnvPath:   envPath,
 			Name:      ws.Name,
-			Channels:  []string{"conda-forge"}, // Default channel for pixi
+			Channels:  []string{"conda-forge"},
 			LogWriter: logWriter,
 		}
-
-		if err := pm.Init(ctx, opts); err != nil {
+		if err := pm.Init(ctx, initOpts); err != nil {
 			return fmt.Errorf("failed to initialize environment: %w", err)
 		}
 	}
 
 	fmt.Fprintf(logWriter, "Environment created successfully\n")
 	return nil
+}
+
+// runPixiInstall runs `pixi install -v` in envPath. Extracted so the
+// pixi.toml-only and seed-dir branches share the install step.
+func runPixiInstall(ctx context.Context, pm pkgmgr.PackageManager, envPath string, logWriter io.Writer) error {
+	pixiBinary := "pixi"
+	if pixiMgr, ok := pm.(*pixi.PixiManager); ok {
+		pixiBinary = pixiMgr.BinaryPath()
+	}
+	installCmd := exec.CommandContext(ctx, pixiBinary, "install", "-v")
+	installCmd.Dir = envPath
+	installCmd.Stdout = logWriter
+	installCmd.Stderr = logWriter
+	fmt.Fprintf(logWriter, "Running: %s install -v\n", pixiBinary)
+	if err := installCmd.Run(); err != nil {
+		return fmt.Errorf("failed to install pixi environment: %w", err)
+	}
+	fmt.Fprintf(logWriter, "Pixi environment installed successfully\n")
+	return nil
+}
+
+// seedWorkspaceFromDir recursively moves every entry under srcDir into
+// dstDir, preserving relative paths. Rejects any cleaned relative path
+// that escapes dstDir as defense-in-depth. Uses os.Rename when possible;
+// falls back to copy when the rename fails (cross-filesystem, etc.).
+func seedWorkspaceFromDir(srcDir, dstDir string) error {
+	return filepath.WalkDir(srcDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == srcDir {
+			return nil
+		}
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		cleaned := filepath.Clean(rel)
+		if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) || filepath.IsAbs(cleaned) {
+			return fmt.Errorf("unsafe seed path %q", rel)
+		}
+		dst := filepath.Join(dstDir, cleaned)
+
+		if d.IsDir() {
+			return os.MkdirAll(dst, 0o755)
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return err
+		}
+		if err := os.Rename(path, dst); err == nil {
+			return nil
+		}
+		// Fallback: copy bytes.
+		in, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer in.Close()
+		out, err := os.Create(dst)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(out, in); err != nil {
+			out.Close()
+			return err
+		}
+		return out.Close()
+	})
 }
 
 // InstallPackages installs packages in a workspace

--- a/internal/executor/local.go
+++ b/internal/executor/local.go
@@ -107,15 +107,20 @@ func (e *LocalExecutor) CreateWorkspace(ctx context.Context, ws *models.Workspac
 
 	switch {
 	case opts.SeedDir != "":
+		// Always clean up the staging dir, even on partial failure (e.g. a
+		// mid-walk error in seedWorkspaceFromDir leaves files behind).
+		// Owned by this branch end-to-end.
+		defer func() {
+			if rmErr := os.RemoveAll(opts.SeedDir); rmErr != nil {
+				fmt.Fprintf(logWriter, "Warning: staging cleanup failed: %v\n", rmErr)
+			}
+		}()
 		if err := os.MkdirAll(envPath, 0o755); err != nil {
 			return fmt.Errorf("create env dir: %w", err)
 		}
 		fmt.Fprintf(logWriter, "Seeding workspace from %s\n", opts.SeedDir)
 		if err := seedWorkspaceFromDir(opts.SeedDir, envPath); err != nil {
 			return fmt.Errorf("seed workspace: %w", err)
-		}
-		if err := os.RemoveAll(opts.SeedDir); err != nil {
-			fmt.Fprintf(logWriter, "Warning: staging cleanup failed: %v\n", err)
 		}
 		if err := runPixiInstall(ctx, pm, envPath, logWriter); err != nil {
 			return err

--- a/internal/executor/local_test.go
+++ b/internal/executor/local_test.go
@@ -237,6 +237,58 @@ func TestLocalExecutor_CreateWorkspace_SeedDirPopulatesWorkspace(t *testing.T) {
 	}
 }
 
+// TestLocalExecutor_CreateWorkspace_SeedDirCleanedOnInstallFailure proves
+// the staging dir is removed even when pixi install errors out — otherwise
+// long-lived servers leak staging dirs on every failed import.
+func TestLocalExecutor_CreateWorkspace_SeedDirCleanedOnInstallFailure(t *testing.T) {
+	// Stub pixi: succeeds on `--version` (NewWithPath gate) but fails
+	// on every other invocation (i.e. `install`).
+	pixiBin := writeStubBinary(t, `#!/bin/sh
+case "$1" in
+  --version) echo "stub pixi 0.0.0"; exit 0 ;;
+  *) exit 1 ;;
+esac
+`)
+
+	cfg := &config.Config{
+		Storage: config.StorageConfig{WorkspacesDir: t.TempDir()},
+		PackageManager: config.PackageManagerConfig{
+			DefaultType: "pixi",
+			PixiPath:    pixiBin,
+		},
+	}
+	exec, err := NewLocalExecutor(cfg)
+	if err != nil {
+		t.Fatalf("NewLocalExecutor: %v", err)
+	}
+
+	stagingDir := t.TempDir()
+	writeSeedFile(t, stagingDir, "pixi.toml", "[project]\nname = \"x\"\n")
+	writeSeedFile(t, stagingDir, "pixi.lock", "version: 6\n")
+
+	ws := &models.Workspace{ID: uuid.New(), Name: "fail-seed", PackageManager: "pixi"}
+	var log bytes.Buffer
+	err = exec.CreateWorkspace(context.Background(), ws, &log, CreateWorkspaceOptions{SeedDir: stagingDir})
+	if err == nil {
+		t.Fatalf("expected pixi install failure, got nil; log: %s", log.String())
+	}
+
+	if _, err := os.Stat(stagingDir); !os.IsNotExist(err) {
+		t.Errorf("staging dir leaked after install failure: stat err=%v\nlog: %s", err, log.String())
+	}
+}
+
+// writeStubBinary writes an executable shell script to a temp file and
+// returns its path. Used to stub the pixi binary in tests.
+func writeStubBinary(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "stub")
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
 func writeSeedFile(t *testing.T, root, rel, body string) {
 	t.Helper()
 	full := filepath.Join(root, rel)

--- a/internal/executor/local_test.go
+++ b/internal/executor/local_test.go
@@ -182,6 +182,72 @@ func TestDeleteWorkspace_ManagedDirAlreadyGone(t *testing.T) {
 	}
 }
 
+func TestLocalExecutor_CreateWorkspace_SeedDirPopulatesWorkspace(t *testing.T) {
+	cfg := &config.Config{
+		Storage: config.StorageConfig{WorkspacesDir: t.TempDir()},
+		PackageManager: config.PackageManagerConfig{
+			DefaultType: "pixi",
+			PixiPath:    "/usr/bin/true", // no-op pixi install
+		},
+	}
+	exec, err := NewLocalExecutor(cfg)
+	if err != nil {
+		t.Fatalf("NewLocalExecutor: %v", err)
+	}
+
+	// Pre-stage an import directory with pixi + asset.
+	stagingDir := t.TempDir()
+	writeSeedFile(t, stagingDir, "pixi.toml", "[project]\nname = \"seed\"\n")
+	writeSeedFile(t, stagingDir, "pixi.lock", "version: 6\n")
+	writeSeedFile(t, stagingDir, "data/sample.csv", "a,b\n1,2\n")
+
+	ws := &models.Workspace{
+		ID:             uuid.New(),
+		Name:           "seeded",
+		PackageManager: "pixi",
+	}
+
+	var log bytes.Buffer
+	err = exec.CreateWorkspace(context.Background(), ws, &log, CreateWorkspaceOptions{
+		SeedDir: stagingDir,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v\nlog: %s", err, log.String())
+	}
+
+	envPath := exec.GetWorkspacePath(ws)
+	for rel, want := range map[string]string{
+		"pixi.toml":       "[project]\nname = \"seed\"\n",
+		"pixi.lock":       "version: 6\n",
+		"data/sample.csv": "a,b\n1,2\n",
+	} {
+		got, err := os.ReadFile(filepath.Join(envPath, rel))
+		if err != nil {
+			t.Errorf("missing seeded file %s: %v", rel, err)
+			continue
+		}
+		if string(got) != want {
+			t.Errorf("seeded %s body mismatch:\ngot  %q\nwant %q", rel, got, want)
+		}
+	}
+
+	// Staging dir should be gone after successful seed.
+	if _, err := os.Stat(stagingDir); !os.IsNotExist(err) {
+		t.Errorf("staging dir still exists after CreateWorkspace")
+	}
+}
+
+func writeSeedFile(t *testing.T, root, rel, body string) {
+	t.Helper()
+	full := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestNormalizeEnvName(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/internal/oci/browser.go
+++ b/internal/oci/browser.go
@@ -640,11 +640,23 @@ func ChangeRepositoryVisibility(ctx context.Context, host, repoPath, apiToken st
 }
 
 // fetchLayerBytes returns the full raw bytes for a layer descriptor.
+// The body is bounded to desc.Size+1 so a registry that omits
+// Content-Length and serves an oversized stream cannot exhaust RAM —
+// the size cap in resolveBundleManifest only sees the manifest's
+// declared sizes, not the actual transport bytes.
 func fetchLayerBytes(ctx context.Context, repo *remote.Repository, desc ocispec.Descriptor) ([]byte, error) {
 	reader, err := repo.Fetch(ctx, desc)
 	if err != nil {
 		return nil, err
 	}
 	defer reader.Close()
-	return io.ReadAll(reader)
+	limited := io.LimitReader(reader, desc.Size+1)
+	buf, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(buf)) > desc.Size {
+		return nil, fmt.Errorf("layer body exceeds declared size %d", desc.Size)
+	}
+	return buf, nil
 }

--- a/internal/oci/browser.go
+++ b/internal/oci/browser.go
@@ -53,6 +53,12 @@ type PullOptions struct {
 	// PlainHTTP talks to the registry over HTTP. Test/local registries
 	// only.
 	PlainHTTP bool
+	// MaxBundleBytes caps the total size of all classified layers in the
+	// manifest (sum of pixi.toml + pixi.lock + every asset). Enforced
+	// before the first byte is fetched, so an attacker-controlled
+	// registry cannot exhaust disk by streaming a multi-GB asset blob.
+	// Zero or negative = no cap.
+	MaxBundleBytes int64
 }
 
 // AssetBlob names a single asset layer in a bundle. It is a listing
@@ -369,6 +375,16 @@ func resolveBundleManifest(
 		return nil, cm, err
 	}
 	cm.manifestDesc = desc
+	if opts.MaxBundleBytes > 0 {
+		var total int64
+		total += cm.pixiToml.Size + cm.pixiLock.Size
+		for _, a := range cm.assets {
+			total += a.Size
+		}
+		if total > opts.MaxBundleBytes {
+			return nil, cm, fmt.Errorf("bundle size %d bytes exceeds cap %d bytes", total, opts.MaxBundleBytes)
+		}
+	}
 	return repo, cm, nil
 }
 

--- a/internal/oci/bundle_integration_test.go
+++ b/internal/oci/bundle_integration_test.go
@@ -182,6 +182,40 @@ func TestPullBundle_ListsAssetsWithoutFetchingBytes(t *testing.T) {
 	}
 }
 
+// TestPullBundle_RejectsOversizedBundle proves MaxBundleBytes is
+// enforced before any blob is fetched, so a registry serving a runaway
+// asset cannot exhaust disk through the import path.
+func TestPullBundle_RejectsOversizedBundle(t *testing.T) {
+	host := startTestRegistry(t)
+	src := t.TempDir()
+	writeFile(t, src, "pixi.toml", "[workspace]\nname = \"big\"\n")
+	writeFile(t, src, "pixi.lock", "version: 6\n")
+	writeFile(t, src, "asset.bin", strings.Repeat("Q", 8192))
+
+	res, err := Publish(context.Background(), src, testRegistry(host, "demo"), "big", "v1")
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	_, err = PullBundle(context.Background(), res.Repository, "v1", PullOptions{
+		PlainHTTP:      true,
+		MaxBundleBytes: 4096, // less than the asset alone
+	})
+	if err == nil {
+		t.Fatalf("expected size-cap rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds cap") {
+		t.Fatalf("expected cap error, got: %v", err)
+	}
+
+	// Same call without cap should succeed.
+	if _, err := PullBundle(context.Background(), res.Repository, "v1", PullOptions{
+		PlainHTTP: true,
+	}); err != nil {
+		t.Fatalf("pull without cap: %v", err)
+	}
+}
+
 func TestPublishBundle_ManyAssetsParallel(t *testing.T) {
 	host := startTestRegistry(t)
 	src := t.TempDir()

--- a/internal/oci/bundle_integration_test.go
+++ b/internal/oci/bundle_integration_test.go
@@ -3,6 +3,7 @@ package oci
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -179,6 +180,92 @@ func TestPullBundle_ListsAssetsWithoutFetchingBytes(t *testing.T) {
 	}
 	if pull.Assets[0].Path != "big.bin" {
 		t.Fatalf("unexpected asset path %q", pull.Assets[0].Path)
+	}
+}
+
+// TestFetchLayerBytes_RejectsOversizedBody proves fetchLayerBytes rejects
+// a registry that declares a small layer Size but streams more bytes
+// (chunked, no Content-Length). Without the LimitReader bound the server
+// would buffer the full body into RAM regardless of the declared size.
+func TestFetchLayerBytes_RejectsOversizedBody(t *testing.T) {
+	host := startTestRegistry(t)
+	src := t.TempDir()
+	writeFile(t, src, "pixi.toml", "[workspace]\nname = \"x\"\n")
+	writeFile(t, src, "pixi.lock", "version: 6\n")
+
+	res, err := Publish(context.Background(), src, testRegistry(host, "demo"), "fakesize", "v1")
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	// Wrap the inner registry with a shim that, on any blob fetch,
+	// strips Content-Length and appends extra bytes — simulating a
+	// hostile registry that lies about layer size.
+	innerHost := host
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if (r.Method == http.MethodGet) && strings.Contains(r.URL.Path, "/blobs/sha256:") {
+			// Proxy to inner registry, then append bogus bytes.
+			req, _ := http.NewRequestWithContext(r.Context(), r.Method, "http://"+innerHost+r.URL.RequestURI(), nil)
+			for k, vs := range r.Header {
+				for _, v := range vs {
+					req.Header.Add(k, v)
+				}
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadGateway)
+				return
+			}
+			defer resp.Body.Close()
+			// Drop Content-Length so client cannot pre-flight-reject;
+			// rely on chunked transfer.
+			for k, vs := range resp.Header {
+				if strings.EqualFold(k, "Content-Length") {
+					continue
+				}
+				for _, v := range vs {
+					w.Header().Add(k, v)
+				}
+			}
+			w.WriteHeader(resp.StatusCode)
+			body, _ := io.ReadAll(resp.Body)
+			w.Write(body)
+			// Append extra bytes — body now exceeds declared layer Size.
+			w.Write([]byte(strings.Repeat("X", 4096)))
+			return
+		}
+		req, _ := http.NewRequestWithContext(r.Context(), r.Method, "http://"+innerHost+r.URL.RequestURI(), nil)
+		for k, vs := range r.Header {
+			for _, v := range vs {
+				req.Header.Add(k, v)
+			}
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+		for k, vs := range resp.Header {
+			for _, v := range vs {
+				w.Header().Add(k, v)
+			}
+		}
+		w.WriteHeader(resp.StatusCode)
+		io.Copy(w, resp.Body)
+	}))
+	t.Cleanup(srv.Close)
+	shimHost := strings.TrimPrefix(srv.URL, "http://")
+
+	// Rewrite repoRef from the original host to the shim host.
+	repoRef := strings.Replace(res.Repository, host, shimHost, 1)
+
+	_, err = PullBundle(context.Background(), repoRef, "v1", PullOptions{PlainHTTP: true})
+	if err == nil {
+		t.Fatalf("expected oversized-body rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds declared size") {
+		t.Fatalf("expected size-mismatch error, got: %v", err)
 	}
 }
 

--- a/internal/oci/preview_assets.go
+++ b/internal/oci/preview_assets.go
@@ -1,0 +1,52 @@
+package oci
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/nebari-dev/nebi/internal/contenthash"
+)
+
+// PreviewAssetRefs walks a workspace directory with the same filters
+// Publish applies, and returns each asset (paths relative to workspaceDir,
+// forward-slash) paired with its SHA-256 content digest. pixi.toml and
+// pixi.lock are stripped — callers fold those in through
+// contenthash.HashBundle's first two arguments. The digest is the SHA-256
+// of the file bytes, not an OCI blob digest, but both the CLI-local
+// publish path and the server publish-defaults derive the hash the same
+// way from the same bytes, so the resulting tag is stable across paths.
+func PreviewAssetRefs(workspaceDir string) ([]contenthash.AssetRef, error) {
+	assets, err := Preview(context.Background(), workspaceDir)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]contenthash.AssetRef, 0, len(assets))
+	for _, a := range assets {
+		if a.RelPath == "pixi.toml" || a.RelPath == "pixi.lock" {
+			continue
+		}
+		sum, err := fileSHA256Preview(a.AbsPath)
+		if err != nil {
+			return nil, fmt.Errorf("hash %s: %w", a.RelPath, err)
+		}
+		out = append(out, contenthash.AssetRef{Path: a.RelPath, Digest: "sha256:" + sum})
+	}
+	return out, nil
+}
+
+func fileSHA256Preview(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/oci/preview_assets_test.go
+++ b/internal/oci/preview_assets_test.go
@@ -1,0 +1,68 @@
+package oci
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPreviewAssetRefs_SkipsCoreFiles(t *testing.T) {
+	dir := t.TempDir()
+	writePreviewFile(t, filepath.Join(dir, "pixi.toml"), `[project]
+name = "demo"
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+`)
+	writePreviewFile(t, filepath.Join(dir, "pixi.lock"), "version: 6\n")
+	writePreviewFile(t, filepath.Join(dir, "notebook.ipynb"), `{"cells": []}`)
+	writePreviewFile(t, filepath.Join(dir, "data.csv"), "a,b\n1,2\n")
+
+	refs, err := PreviewAssetRefs(dir)
+	if err != nil {
+		t.Fatalf("PreviewAssetRefs: %v", err)
+	}
+
+	gotPaths := map[string]string{}
+	for _, r := range refs {
+		gotPaths[r.Path] = r.Digest
+	}
+	for _, core := range []string{"pixi.toml", "pixi.lock"} {
+		if _, ok := gotPaths[core]; ok {
+			t.Errorf("PreviewAssetRefs included core file %s; expected skip", core)
+		}
+	}
+
+	for _, rel := range []string{"notebook.ipynb", "data.csv"} {
+		digest, ok := gotPaths[rel]
+		if !ok {
+			t.Errorf("expected asset %s in refs, got %+v", rel, refs)
+			continue
+		}
+		want := "sha256:" + sha256HexPreview(t, filepath.Join(dir, rel))
+		if digest != want {
+			t.Errorf("digest mismatch for %s: got %s want %s", rel, digest, want)
+		}
+	}
+}
+
+func writePreviewFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func sha256HexPreview(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/rbac/nil_enforcer_test.go
+++ b/internal/rbac/nil_enforcer_test.go
@@ -1,0 +1,75 @@
+package rbac
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// In local mode the router skips InitEnforcer because middleware bypasses
+// RBAC anyway. But WorkspaceService.Create still calls
+// rbac.GrantWorkspaceAccess unconditionally, so the data-layer functions
+// must tolerate a nil enforcer instead of nil-deref panicking. These
+// tests pin that contract.
+
+func TestGrantWorkspaceAccess_NilEnforcer_NoPanic(t *testing.T) {
+	saved := enforcer
+	enforcer = nil
+	t.Cleanup(func() { enforcer = saved })
+
+	if err := GrantWorkspaceAccess(uuid.New(), uuid.New(), "owner"); err != nil {
+		t.Fatalf("expected nil-safe no-op, got error: %v", err)
+	}
+}
+
+func TestRevokeWorkspaceAccess_NilEnforcer_NoPanic(t *testing.T) {
+	saved := enforcer
+	enforcer = nil
+	t.Cleanup(func() { enforcer = saved })
+
+	if err := RevokeWorkspaceAccess(uuid.New(), uuid.New()); err != nil {
+		t.Fatalf("expected nil-safe no-op, got error: %v", err)
+	}
+}
+
+func TestCanReadWorkspace_NilEnforcer_AllowsAll(t *testing.T) {
+	saved := enforcer
+	enforcer = nil
+	t.Cleanup(func() { enforcer = saved })
+
+	allowed, err := CanReadWorkspace(uuid.New(), uuid.New())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowed {
+		t.Fatal("expected nil-enforcer (local mode) to allow read")
+	}
+}
+
+func TestCanWriteWorkspace_NilEnforcer_AllowsAll(t *testing.T) {
+	saved := enforcer
+	enforcer = nil
+	t.Cleanup(func() { enforcer = saved })
+
+	allowed, err := CanWriteWorkspace(uuid.New(), uuid.New())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowed {
+		t.Fatal("expected nil-enforcer (local mode) to allow write")
+	}
+}
+
+func TestIsAdmin_NilEnforcer_AllowsAll(t *testing.T) {
+	saved := enforcer
+	enforcer = nil
+	t.Cleanup(func() { enforcer = saved })
+
+	allowed, err := IsAdmin(uuid.New())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowed {
+		t.Fatal("expected nil-enforcer (local mode) to be admin")
+	}
+}

--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -50,18 +50,33 @@ func GetEnforcer() *casbin.Enforcer {
 	return enforcer
 }
 
-// CanReadWorkspace checks if user can read a workspace
+// CanReadWorkspace checks if user can read a workspace.
+// Local mode (cfg.IsLocalMode()) skips InitEnforcer because the
+// middleware bypasses RBAC anyway, so the enforcer global stays nil.
+// The data-layer functions defend against that explicitly: nothing to
+// enforce against = treat as allowed. Without this guard
+// WorkspaceService.Create nil-derefs through GrantWorkspaceAccess on
+// a fresh local-mode boot.
 func CanReadWorkspace(userID uuid.UUID, wsID uuid.UUID) (bool, error) {
+	if enforcer == nil {
+		return true, nil
+	}
 	return enforcer.Enforce(userID.String(), fmt.Sprintf("ws:%s", wsID.String()), "read")
 }
 
 // CanWriteWorkspace checks if user can write to a workspace
 func CanWriteWorkspace(userID uuid.UUID, wsID uuid.UUID) (bool, error) {
+	if enforcer == nil {
+		return true, nil
+	}
 	return enforcer.Enforce(userID.String(), fmt.Sprintf("ws:%s", wsID.String()), "write")
 }
 
 // IsAdmin checks if user has admin privileges
 func IsAdmin(userID uuid.UUID) (bool, error) {
+	if enforcer == nil {
+		return true, nil
+	}
 	return enforcer.Enforce(userID.String(), "admin", "admin")
 }
 
@@ -77,6 +92,10 @@ func GrantWorkspaceAccess(userID uuid.UUID, wsID uuid.UUID, role string) error {
 		return fmt.Errorf("invalid role: %s", role)
 	}
 
+	if enforcer == nil {
+		return nil
+	}
+
 	_, err := enforcer.AddPolicy(userID.String(), fmt.Sprintf("ws:%s", wsID.String()), action)
 	if err != nil {
 		return err
@@ -87,6 +106,10 @@ func GrantWorkspaceAccess(userID uuid.UUID, wsID uuid.UUID, role string) error {
 
 // RevokeWorkspaceAccess revokes access to a workspace
 func RevokeWorkspaceAccess(userID uuid.UUID, wsID uuid.UUID) error {
+	if enforcer == nil {
+		return nil
+	}
+
 	obj := fmt.Sprintf("ws:%s", wsID.String())
 
 	// Remove both read and write permissions

--- a/internal/service/registry_endpoint.go
+++ b/internal/service/registry_endpoint.go
@@ -1,0 +1,63 @@
+package service
+
+import (
+	"fmt"
+
+	nebicrypto "github.com/nebari-dev/nebi/internal/crypto"
+	"github.com/nebari-dev/nebi/internal/models"
+	"github.com/nebari-dev/nebi/internal/oci"
+	"gorm.io/gorm"
+)
+
+// registryEndpoint captures everything a service needs to talk to an OCI
+// registry: the persisted record (for ID/Name in audit + publication
+// rows), the parsed URL, and the decrypted credentials. Construct via
+// loadRegistryEndpoint — never directly.
+type registryEndpoint struct {
+	Registry  *models.OCIRegistry
+	Host      string
+	Namespace string // may be empty
+	Username  string
+	Password  string
+	PlainHTTP bool
+}
+
+// RepoRef composes "host/[namespace/]repo" — the form oras-go expects.
+func (e *registryEndpoint) RepoRef(repo string) string {
+	if e.Namespace != "" {
+		return fmt.Sprintf("%s/%s/%s", e.Host, e.Namespace, repo)
+	}
+	return fmt.Sprintf("%s/%s", e.Host, repo)
+}
+
+// loadRegistryEndpoint loads a registry by ID, decrypts its password
+// (empty input is tolerated for anonymous registries), and parses the
+// URL into host/plainHTTP. Returns ErrNotFound if the registry row
+// does not exist. id may be a uuid.UUID, a uuid string, or any value
+// gorm can compare to the OCIRegistry primary key.
+func (s *WorkspaceService) loadRegistryEndpoint(id any) (*registryEndpoint, error) {
+	var reg models.OCIRegistry
+	if err := s.db.Where("id = ?", id).First(&reg).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	var password string
+	if reg.Password != "" {
+		p, err := nebicrypto.DecryptField(reg.Password, s.encKey)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt registry credentials: %w", err)
+		}
+		password = p
+	}
+	host, _, plainHTTP := oci.ParseRegistryURLFull(reg.URL)
+	return &registryEndpoint{
+		Registry:  &reg,
+		Host:      host,
+		Namespace: reg.Namespace,
+		Username:  reg.Username,
+		Password:  password,
+		PlainHTTP: plainHTTP,
+	}, nil
+}

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -8,11 +8,12 @@ import (
 
 // CreateRequest holds parameters for creating a workspace.
 type CreateRequest struct {
-	Name           string
-	PackageManager string
-	PixiToml       string
-	Source         string
-	Path           string
+	Name             string
+	PackageManager   string
+	PixiToml         string
+	Source           string
+	Path             string
+	ImportStagingDir string // absolute path to a pre-extracted bundle directory; worker hands it to the executor as SeedDir
 }
 
 // PushRequest holds parameters for pushing a new version.

--- a/internal/service/workspace.go
+++ b/internal/service/workspace.go
@@ -31,6 +31,9 @@ func New(db *gorm.DB, q queue.Queue, exec executor.Executor, isLocal bool, encKe
 	return &WorkspaceService{db: db, queue: q, executor: exec, isLocal: isLocal, encKey: encKey, rbac: rbacProvider}
 }
 
+// IsLocal reports whether the service is running in local/desktop mode.
+func (s *WorkspaceService) IsLocal() bool { return s.isLocal }
+
 // List returns workspaces visible to the given user.
 // In local mode all workspaces are returned (no ownership filtering).
 func (s *WorkspaceService) List(userID uuid.UUID) ([]WorkspaceResponse, error) {

--- a/internal/service/workspace.go
+++ b/internal/service/workspace.go
@@ -123,6 +123,9 @@ func (s *WorkspaceService) Create(ctx context.Context, req CreateRequest, userID
 		if req.PixiToml != "" {
 			metadata["pixi_toml"] = req.PixiToml
 		}
+		if req.ImportStagingDir != "" {
+			metadata["import_staging_dir"] = req.ImportStagingDir
+		}
 
 		job := &models.Job{
 			Type:        models.JobTypeCreate,

--- a/internal/service/workspace_import.go
+++ b/internal/service/workspace_import.go
@@ -1,0 +1,100 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/google/uuid"
+	nebicrypto "github.com/nebari-dev/nebi/internal/crypto"
+	"github.com/nebari-dev/nebi/internal/models"
+	"github.com/nebari-dev/nebi/internal/oci"
+	"gorm.io/gorm"
+)
+
+// ImportFromRegistryRequest selects the OCI bundle to import.
+type ImportFromRegistryRequest struct {
+	Repository string
+	Tag        string
+	Name       string
+}
+
+// ImportFromRegistry pulls an OCI bundle from a registered registry and
+// creates a new workspace populated from it.
+//
+// In local mode the full bundle (pixi.toml + pixi.lock + asset layers)
+// is extracted synchronously to a staging directory; the create job
+// metadata carries the path so the worker seeds the workspace directory
+// from it before pixi install runs. Network errors surface synchronously.
+//
+// In team mode only pixi.toml is fetched (existing behavior); asset
+// layers and the published pixi.lock are dropped pending a team-mode
+// bundle design.
+func (s *WorkspaceService) ImportFromRegistry(ctx context.Context, registryID string, req ImportFromRegistryRequest, userID uuid.UUID) (*models.Workspace, error) {
+	var reg models.OCIRegistry
+	if err := s.db.Where("id = ?", registryID).First(&reg).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	var password string
+	if reg.Password != "" {
+		var err error
+		password, err = nebicrypto.DecryptField(reg.Password, s.encKey)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt registry credentials: %w", err)
+		}
+	}
+
+	host, _, plainHTTP := oci.ParseRegistryURLFull(reg.URL)
+	repoPath := req.Repository
+	if reg.Namespace != "" {
+		repoPath = reg.Namespace + "/" + req.Repository
+	}
+	repoRef := fmt.Sprintf("%s/%s", host, repoPath)
+
+	if s.isLocal {
+		stagingDir, err := os.MkdirTemp(s.executor.StagingRoot(), "import-")
+		if err != nil {
+			return nil, fmt.Errorf("create staging dir: %w", err)
+		}
+
+		if _, err := oci.ExtractBundle(ctx, repoRef, req.Tag, stagingDir, oci.PullOptions{
+			Username:  reg.Username,
+			Password:  password,
+			PlainHTTP: plainHTTP,
+		}); err != nil {
+			_ = os.RemoveAll(stagingDir)
+			return nil, fmt.Errorf("extract bundle: %w", err)
+		}
+
+		ws, err := s.Create(ctx, CreateRequest{
+			Name:             req.Name,
+			PackageManager:   "pixi",
+			ImportStagingDir: stagingDir,
+		}, userID)
+		if err != nil {
+			_ = os.RemoveAll(stagingDir)
+			return nil, err
+		}
+		return ws, nil
+	}
+
+	// Team mode: pixi-only fallback (matches current ImportEnvironment
+	// handler behaviour).
+	result, err := oci.PullBundle(ctx, repoRef, req.Tag, oci.PullOptions{
+		Username:  reg.Username,
+		Password:  password,
+		PlainHTTP: plainHTTP,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pull environment: %w", err)
+	}
+	return s.Create(ctx, CreateRequest{
+		Name:           req.Name,
+		PackageManager: "pixi",
+		PixiToml:       result.PixiToml,
+	}, userID)
+}

--- a/internal/service/workspace_import.go
+++ b/internal/service/workspace_import.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/nebari-dev/nebi/internal/audit"
@@ -50,7 +51,19 @@ func (s *WorkspaceService) ImportFromRegistry(ctx context.Context, registryID st
 		Username:  ep.Username,
 		Password:  ep.Password,
 		PlainHTTP: ep.PlainHTTP,
+		// Cap total bundle size to defend against a malicious or
+		// misconfigured registry serving a runaway asset layer. 5 GiB
+		// is well above any reasonable Pixi environment but small
+		// enough that exhausting disk requires deliberate effort.
+		MaxBundleBytes: 5 * 1024 * 1024 * 1024,
 	}
+
+	// Cap the synchronous OCI pull so a slow or malicious registry
+	// cannot hold an HTTP request open indefinitely. Generous enough
+	// for legitimate large bundles on slow networks; tight enough that
+	// hung requests free up server resources.
+	pullCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	defer cancel()
 
 	stagingDir, err := os.MkdirTemp(s.executor.StagingRoot(), "import-")
 	if err != nil {
@@ -59,14 +72,14 @@ func (s *WorkspaceService) ImportFromRegistry(ctx context.Context, registryID st
 
 	var digest string
 	if s.isLocal {
-		result, err := oci.ExtractBundle(ctx, repoRef, req.Tag, stagingDir, pullOpts)
+		result, err := oci.ExtractBundle(pullCtx, repoRef, req.Tag, stagingDir, pullOpts)
 		if err != nil {
 			_ = os.RemoveAll(stagingDir)
 			return nil, fmt.Errorf("extract bundle: %w", err)
 		}
 		digest = result.Digest
 	} else {
-		result, err := oci.PullBundle(ctx, repoRef, req.Tag, pullOpts)
+		result, err := oci.PullBundle(pullCtx, repoRef, req.Tag, pullOpts)
 		if err != nil {
 			_ = os.RemoveAll(stagingDir)
 			return nil, fmt.Errorf("pull bundle: %w", err)

--- a/internal/service/workspace_import.go
+++ b/internal/service/workspace_import.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/google/uuid"
-	nebicrypto "github.com/nebari-dev/nebi/internal/crypto"
+	"github.com/nebari-dev/nebi/internal/audit"
 	"github.com/nebari-dev/nebi/internal/models"
 	"github.com/nebari-dev/nebi/internal/oci"
-	"gorm.io/gorm"
 )
 
 // ImportFromRegistryRequest selects the OCI bundle to import.
@@ -22,79 +22,85 @@ type ImportFromRegistryRequest struct {
 // ImportFromRegistry pulls an OCI bundle from a registered registry and
 // creates a new workspace populated from it.
 //
-// In local mode the full bundle (pixi.toml + pixi.lock + asset layers)
-// is extracted synchronously to a staging directory; the create job
-// metadata carries the path so the worker seeds the workspace directory
-// from it before pixi install runs. Network errors surface synchronously.
+// Flow is identical for both modes: resolve the registry, stage every
+// fetched artifact under the executor's import-staging root, then enqueue
+// a workspace-create job that points the worker at the staging dir
+// (CreateWorkspaceOptions.SeedDir). The mode difference is purely how
+// many bytes get staged:
 //
-// In team mode only pixi.toml is fetched (existing behavior); asset
-// layers and the published pixi.lock are dropped pending a team-mode
-// bundle design.
+//   - local mode: oci.ExtractBundle streams pixi.toml + pixi.lock + every
+//     asset layer to disk. The worker seeds the workspace from the full
+//     bundle, so asset files and the published lockfile both round-trip.
+//   - team mode: oci.PullBundle fetches only the two core layers; the
+//     handler writes them to the staging dir as plain files. Asset
+//     layers are listed in the manifest but not fetched. pixi.lock is
+//     still preserved on disk for the worker to use, fixing a latent
+//     bug where team-mode imports re-solved from pixi.toml alone.
+//
+// Network errors surface synchronously so the caller knows the import
+// did not start. On any failure after the staging dir is created, the
+// staging dir is removed before returning.
 func (s *WorkspaceService) ImportFromRegistry(ctx context.Context, registryID string, req ImportFromRegistryRequest, userID uuid.UUID) (*models.Workspace, error) {
-	var reg models.OCIRegistry
-	if err := s.db.Where("id = ?", registryID).First(&reg).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
-			return nil, ErrNotFound
-		}
+	ep, err := s.loadRegistryEndpoint(registryID)
+	if err != nil {
 		return nil, err
 	}
-
-	var password string
-	if reg.Password != "" {
-		var err error
-		password, err = nebicrypto.DecryptField(reg.Password, s.encKey)
-		if err != nil {
-			return nil, fmt.Errorf("decrypt registry credentials: %w", err)
-		}
+	repoRef := ep.RepoRef(req.Repository)
+	pullOpts := oci.PullOptions{
+		Username:  ep.Username,
+		Password:  ep.Password,
+		PlainHTTP: ep.PlainHTTP,
 	}
 
-	host, _, plainHTTP := oci.ParseRegistryURLFull(reg.URL)
-	repoPath := req.Repository
-	if reg.Namespace != "" {
-		repoPath = reg.Namespace + "/" + req.Repository
+	stagingDir, err := os.MkdirTemp(s.executor.StagingRoot(), "import-")
+	if err != nil {
+		return nil, fmt.Errorf("create staging dir: %w", err)
 	}
-	repoRef := fmt.Sprintf("%s/%s", host, repoPath)
 
+	var digest string
 	if s.isLocal {
-		stagingDir, err := os.MkdirTemp(s.executor.StagingRoot(), "import-")
+		result, err := oci.ExtractBundle(ctx, repoRef, req.Tag, stagingDir, pullOpts)
 		if err != nil {
-			return nil, fmt.Errorf("create staging dir: %w", err)
-		}
-
-		if _, err := oci.ExtractBundle(ctx, repoRef, req.Tag, stagingDir, oci.PullOptions{
-			Username:  reg.Username,
-			Password:  password,
-			PlainHTTP: plainHTTP,
-		}); err != nil {
 			_ = os.RemoveAll(stagingDir)
 			return nil, fmt.Errorf("extract bundle: %w", err)
 		}
-
-		ws, err := s.Create(ctx, CreateRequest{
-			Name:             req.Name,
-			PackageManager:   "pixi",
-			ImportStagingDir: stagingDir,
-		}, userID)
+		digest = result.Digest
+	} else {
+		result, err := oci.PullBundle(ctx, repoRef, req.Tag, pullOpts)
 		if err != nil {
 			_ = os.RemoveAll(stagingDir)
-			return nil, err
+			return nil, fmt.Errorf("pull bundle: %w", err)
 		}
-		return ws, nil
+		// Stage just the two core files; asset layers stay in the
+		// registry until team mode opts in to bundle support.
+		if err := os.WriteFile(filepath.Join(stagingDir, "pixi.toml"), []byte(result.PixiToml), 0o644); err != nil {
+			_ = os.RemoveAll(stagingDir)
+			return nil, fmt.Errorf("stage pixi.toml: %w", err)
+		}
+		if err := os.WriteFile(filepath.Join(stagingDir, "pixi.lock"), []byte(result.PixiLock), 0o644); err != nil {
+			_ = os.RemoveAll(stagingDir)
+			return nil, fmt.Errorf("stage pixi.lock: %w", err)
+		}
+		digest = result.Digest
 	}
 
-	// Team mode: pixi-only fallback (matches current ImportEnvironment
-	// handler behaviour).
-	result, err := oci.PullBundle(ctx, repoRef, req.Tag, oci.PullOptions{
-		Username:  reg.Username,
-		Password:  password,
-		PlainHTTP: plainHTTP,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("pull environment: %w", err)
-	}
-	return s.Create(ctx, CreateRequest{
-		Name:           req.Name,
-		PackageManager: "pixi",
-		PixiToml:       result.PixiToml,
+	ws, err := s.Create(ctx, CreateRequest{
+		Name:             req.Name,
+		PackageManager:   "pixi",
+		ImportStagingDir: stagingDir,
 	}, userID)
+	if err != nil {
+		_ = os.RemoveAll(stagingDir)
+		return nil, err
+	}
+
+	audit.LogAction(s.db, userID, audit.ActionImportWorkspace, fmt.Sprintf("ws:%s", ws.ID.String()), map[string]interface{}{
+		"name":       req.Name,
+		"registry":   ep.Registry.Name,
+		"repository": req.Repository,
+		"tag":        req.Tag,
+		"digest":     digest,
+	})
+
+	return ws, nil
 }

--- a/internal/service/workspace_import_test.go
+++ b/internal/service/workspace_import_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/registry"
@@ -114,16 +115,29 @@ platforms = ["linux-64"]
 		t.Fatalf("ImportFromRegistry: %v", err)
 	}
 
-	// Expect a JobTypeCreate job with pixi_toml set and NO import_staging_dir.
+	// Both modes stage to disk so the worker honours the published
+	// pixi.lock; team mode just stages fewer files (no asset layers).
 	var job models.Job
 	if err := db.Where("workspace_id = ? AND type = ?", ws.ID, models.JobTypeCreate).First(&job).Error; err != nil {
 		t.Fatalf("find create job: %v", err)
 	}
-	if _, ok := job.Metadata["import_staging_dir"]; ok {
-		t.Errorf("team mode should not set import_staging_dir in metadata; got %+v", job.Metadata)
+	stagingDir, _ := job.Metadata["import_staging_dir"].(string)
+	if stagingDir == "" {
+		t.Fatalf("team mode should stage pixi files for the worker, got %+v", job.Metadata)
 	}
-	got, _ := job.Metadata["pixi_toml"].(string)
-	if got == "" {
-		t.Errorf("team mode should stamp pixi_toml from registry; got empty, metadata=%+v", job.Metadata)
+	for _, rel := range []string{"pixi.toml", "pixi.lock"} {
+		if _, err := os.Stat(filepath.Join(stagingDir, rel)); err != nil {
+			t.Errorf("expected %s in team-mode staging dir, got %v", rel, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(stagingDir, "asset.txt")); !os.IsNotExist(err) {
+		t.Errorf("team mode must drop asset layers; asset.txt present in staging dir: %v", err)
+	}
+	// PullBundle whitespace-trims core layer bytes; the staged file
+	// must still carry the published lock content even after that
+	// transform (pixi tolerates the difference; both forms parse).
+	lockBytes, _ := os.ReadFile(filepath.Join(stagingDir, "pixi.lock"))
+	if !strings.Contains(string(lockBytes), "version: 6") {
+		t.Errorf("team mode should preserve published pixi.lock content, got %q", string(lockBytes))
 	}
 }

--- a/internal/service/workspace_import_test.go
+++ b/internal/service/workspace_import_test.go
@@ -1,0 +1,129 @@
+package service
+
+import (
+	"context"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/nebari-dev/nebi/internal/models"
+	"github.com/nebari-dev/nebi/internal/oci"
+)
+
+func TestImportFromRegistry_LocalMode_ExtractsBundleAndEnqueuesSeedJob(t *testing.T) {
+	svc, db := testSetup(t, true) // isLocal=true
+	userID := createTestUser(t, db, "alice")
+
+	// Stand up an in-memory registry and publish a bundle into it.
+	srv := httptest.NewServer(registry.New())
+	defer srv.Close()
+	u, _ := url.Parse(srv.URL)
+
+	srcDir := t.TempDir()
+	os.WriteFile(filepath.Join(srcDir, "pixi.toml"),
+		[]byte(`[project]
+name = "bundle-import"
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+`), 0o644)
+	os.WriteFile(filepath.Join(srcDir, "pixi.lock"), []byte("version: 6\n# published\n"), 0o644)
+	os.WriteFile(filepath.Join(srcDir, "notebook.ipynb"), []byte(`{"cells":[]}`), 0o644)
+
+	reg := oci.Registry{Host: u.Host, Namespace: "demo", PlainHTTP: true}
+	if _, err := oci.Publish(context.Background(), srcDir, reg, "bundle-import", "v1"); err != nil {
+		t.Fatalf("seed publish: %v", err)
+	}
+
+	dbReg := models.OCIRegistry{
+		Name:      "import-src",
+		URL:       "http://" + u.Host,
+		Namespace: "demo",
+		IsDefault: true,
+	}
+	db.Create(&dbReg)
+
+	ws, err := svc.ImportFromRegistry(context.Background(), dbReg.ID.String(), ImportFromRegistryRequest{
+		Repository: "bundle-import",
+		Tag:        "v1",
+		Name:       "imported-env",
+	}, userID)
+	if err != nil {
+		t.Fatalf("ImportFromRegistry: %v", err)
+	}
+	if ws.Name != "imported-env" {
+		t.Errorf("workspace name: got %q want %q", ws.Name, "imported-env")
+	}
+
+	// Expect a JobTypeCreate job with import_staging_dir pointing at an
+	// existing directory that contains the extracted bundle.
+	var job models.Job
+	if err := db.Where("workspace_id = ? AND type = ?", ws.ID, models.JobTypeCreate).First(&job).Error; err != nil {
+		t.Fatalf("find create job: %v", err)
+	}
+	stagingDir, _ := job.Metadata["import_staging_dir"].(string)
+	if stagingDir == "" {
+		t.Fatalf("expected import_staging_dir in job metadata, got %+v", job.Metadata)
+	}
+
+	for _, rel := range []string{"pixi.toml", "pixi.lock", "notebook.ipynb"} {
+		if _, err := os.Stat(filepath.Join(stagingDir, rel)); err != nil {
+			t.Errorf("expected %s in staging dir %q, got %v", rel, stagingDir, err)
+		}
+	}
+
+	lockBytes, _ := os.ReadFile(filepath.Join(stagingDir, "pixi.lock"))
+	if string(lockBytes) != "version: 6\n# published\n" {
+		t.Errorf("published pixi.lock was not preserved in staging: %q", string(lockBytes))
+	}
+}
+
+func TestImportFromRegistry_TeamMode_PixiOnly(t *testing.T) {
+	svc, db := testSetup(t, false) // isLocal=false
+	userID := createTestUser(t, db, "alice")
+
+	srv := httptest.NewServer(registry.New())
+	defer srv.Close()
+	u, _ := url.Parse(srv.URL)
+
+	srcDir := t.TempDir()
+	os.WriteFile(filepath.Join(srcDir, "pixi.toml"),
+		[]byte(`[project]
+name = "team-import"
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+`), 0o644)
+	os.WriteFile(filepath.Join(srcDir, "pixi.lock"), []byte("version: 6\n"), 0o644)
+	os.WriteFile(filepath.Join(srcDir, "asset.txt"), []byte("should-be-dropped\n"), 0o644)
+
+	reg := oci.Registry{Host: u.Host, Namespace: "demo", PlainHTTP: true}
+	if _, err := oci.Publish(context.Background(), srcDir, reg, "team-import", "v1"); err != nil {
+		t.Fatalf("seed publish: %v", err)
+	}
+	dbReg := models.OCIRegistry{
+		Name: "team-src", URL: "http://" + u.Host, Namespace: "demo", IsDefault: true,
+	}
+	db.Create(&dbReg)
+
+	ws, err := svc.ImportFromRegistry(context.Background(), dbReg.ID.String(), ImportFromRegistryRequest{
+		Repository: "team-import", Tag: "v1", Name: "imported-team",
+	}, userID)
+	if err != nil {
+		t.Fatalf("ImportFromRegistry: %v", err)
+	}
+
+	// Expect a JobTypeCreate job with pixi_toml set and NO import_staging_dir.
+	var job models.Job
+	if err := db.Where("workspace_id = ? AND type = ?", ws.ID, models.JobTypeCreate).First(&job).Error; err != nil {
+		t.Fatalf("find create job: %v", err)
+	}
+	if _, ok := job.Metadata["import_staging_dir"]; ok {
+		t.Errorf("team mode should not set import_staging_dir in metadata; got %+v", job.Metadata)
+	}
+	got, _ := job.Metadata["pixi_toml"].(string)
+	if got == "" {
+		t.Errorf("team mode should stamp pixi_toml from registry; got empty, metadata=%+v", job.Metadata)
+	}
+}

--- a/internal/service/workspace_import_test.go
+++ b/internal/service/workspace_import_test.go
@@ -79,6 +79,21 @@ platforms = ["linux-64"]
 	if string(lockBytes) != "version: 6\n# published\n" {
 		t.Errorf("published pixi.lock was not preserved in staging: %q", string(lockBytes))
 	}
+
+	// Audit row should record the import with the registry/repo/tag and
+	// manifest digest so IR can reconstruct what was pulled.
+	var audits []models.AuditLog
+	if err := db.Where("user_id = ? AND action = ?", userID, "import_workspace").Find(&audits).Error; err != nil {
+		t.Fatalf("query audit logs: %v", err)
+	}
+	if len(audits) != 1 {
+		t.Fatalf("expected exactly one import_workspace audit row, got %d", len(audits))
+	}
+	for _, want := range []string{`"registry":"import-src"`, `"repository":"bundle-import"`, `"tag":"v1"`, `"digest":"sha256:`} {
+		if !strings.Contains(audits[0].DetailsJSON, want) {
+			t.Errorf("audit details missing %s; got %s", want, audits[0].DetailsJSON)
+		}
+	}
 }
 
 func TestImportFromRegistry_TeamMode_PixiOnly(t *testing.T) {

--- a/internal/service/workspace_publishing.go
+++ b/internal/service/workspace_publishing.go
@@ -36,28 +36,15 @@ func (s *WorkspaceService) PublishWorkspace(ctx context.Context, wsID string, re
 		return nil, &ValidationError{Message: "Workspace has no versions to publish"}
 	}
 
-	// Get registry
-	var registry models.OCIRegistry
-	if err := s.db.Where("id = ?", req.RegistryID).First(&registry).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+	ep, err := s.loadRegistryEndpoint(req.RegistryID)
+	if err != nil {
+		if err == ErrNotFound {
 			return nil, &ValidationError{Message: "Registry not found"}
 		}
 		return nil, err
 	}
-
-	// Decrypt registry password
-	password, err := nebicrypto.DecryptField(registry.Password, s.encKey)
-	if err != nil {
-		return nil, fmt.Errorf("decrypt registry credentials: %w", err)
-	}
-
-	// Build full repository path
-	host, _, plainHTTP := oci.ParseRegistryURLFull(registry.URL)
-	repoPath := req.Repository
-	if registry.Namespace != "" {
-		repoPath = registry.Namespace + "/" + req.Repository
-	}
-	fullRepo := fmt.Sprintf("%s/%s", host, repoPath)
+	registry := *ep.Registry
+	fullRepo := ep.RepoRef(req.Repository)
 
 	wsPath := s.executor.GetWorkspacePath(&ws)
 
@@ -77,11 +64,11 @@ func (s *WorkspaceService) PublishWorkspace(ctx context.Context, wsID string, re
 	var digest string
 	if s.isLocal {
 		regEndpoint := oci.Registry{
-			Host:      host,
-			Namespace: registry.Namespace,
-			Username:  registry.Username,
-			Password:  password,
-			PlainHTTP: plainHTTP,
+			Host:      ep.Host,
+			Namespace: ep.Namespace,
+			Username:  ep.Username,
+			Password:  ep.Password,
+			PlainHTTP: ep.PlainHTTP,
 		}
 		res, err := oci.Publish(ctx, wsPath, regEndpoint, req.Repository, req.Tag,
 			oci.WithExtraTags(extraTags...),
@@ -95,9 +82,9 @@ func (s *WorkspaceService) PublishWorkspace(ctx context.Context, wsID string, re
 			Repository:   fullRepo,
 			Tag:          req.Tag,
 			ExtraTags:    extraTags,
-			Username:     registry.Username,
-			Password:     password,
-			RegistryHost: host,
+			Username:     ep.Username,
+			Password:     ep.Password,
+			RegistryHost: ep.Host,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("publish failed: %w", err)

--- a/internal/service/workspace_publishing.go
+++ b/internal/service/workspace_publishing.go
@@ -49,7 +49,7 @@ func (s *WorkspaceService) PublishWorkspace(ctx context.Context, wsID string, re
 	}
 
 	// Build full repository path
-	host, _ := oci.ParseRegistryURL(registry.URL)
+	host, _, plainHTTP := oci.ParseRegistryURLFull(registry.URL)
 	repoPath := req.Repository
 	if registry.Namespace != "" {
 		repoPath = registry.Namespace + "/" + req.Repository
@@ -71,16 +71,35 @@ func (s *WorkspaceService) PublishWorkspace(ctx context.Context, wsID string, re
 		extraTags = append(extraTags, t)
 	}
 
-	digest, err := oci.PublishWorkspace(ctx, wsPath, oci.PublishOptions{
-		Repository:   fullRepo,
-		Tag:          req.Tag,
-		ExtraTags:    extraTags,
-		Username:     registry.Username,
-		Password:     password,
-		RegistryHost: host,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("publish failed: %w", err)
+	var digest string
+	if s.isLocal {
+		regEndpoint := oci.Registry{
+			Host:      host,
+			Namespace: registry.Namespace,
+			Username:  registry.Username,
+			Password:  password,
+			PlainHTTP: plainHTTP,
+		}
+		res, err := oci.Publish(ctx, wsPath, regEndpoint, req.Repository, req.Tag,
+			oci.WithExtraTags(extraTags...),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("publish failed: %w", err)
+		}
+		digest = res.Digest
+	} else {
+		d, err := oci.PublishWorkspace(ctx, wsPath, oci.PublishOptions{
+			Repository:   fullRepo,
+			Tag:          req.Tag,
+			ExtraTags:    extraTags,
+			Username:     registry.Username,
+			Password:     password,
+			RegistryHost: host,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("publish failed: %w", err)
+		}
+		digest = d
 	}
 
 	// Create publication record

--- a/internal/service/workspace_publishing.go
+++ b/internal/service/workspace_publishing.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 
 	"github.com/google/uuid"
 	"github.com/nebari-dev/nebi/internal/audit"
+	"github.com/nebari-dev/nebi/internal/contenthash"
 	nebicrypto "github.com/nebari-dev/nebi/internal/crypto"
 	"github.com/nebari-dev/nebi/internal/models"
 	"github.com/nebari-dev/nebi/internal/oci"
@@ -221,8 +224,27 @@ func (s *WorkspaceService) GetPublishDefaults(wsID string) (*PublishDefaultsResu
 
 	tag := "latest"
 	var latestVersion models.WorkspaceVersion
-	if err := s.db.Where("workspace_id = ?", wsID).Order("version_number DESC").First(&latestVersion).Error; err == nil && latestVersion.ContentHash != "" {
-		tag = latestVersion.ContentHash
+	hasVersion := s.db.Where("workspace_id = ?", wsID).Order("version_number DESC").First(&latestVersion).Error == nil
+
+	if hasVersion {
+		if s.isLocal {
+			wsPath := s.executor.GetWorkspacePath(&ws)
+			pixiToml, err := os.ReadFile(filepath.Join(wsPath, "pixi.toml"))
+			if err != nil {
+				return nil, fmt.Errorf("read pixi.toml for bundle hash: %w", err)
+			}
+			pixiLock, err := os.ReadFile(filepath.Join(wsPath, "pixi.lock"))
+			if err != nil {
+				return nil, fmt.Errorf("read pixi.lock for bundle hash: %w", err)
+			}
+			refs, err := oci.PreviewAssetRefs(wsPath)
+			if err != nil {
+				return nil, fmt.Errorf("preview bundle for default tag: %w", err)
+			}
+			tag = contenthash.HashBundle(string(pixiToml), string(pixiLock), refs)
+		} else if latestVersion.ContentHash != "" {
+			tag = latestVersion.ContentHash
+		}
 	}
 
 	return &PublishDefaultsResult{

--- a/internal/service/workspace_publishing.go
+++ b/internal/service/workspace_publishing.go
@@ -216,19 +216,22 @@ func (s *WorkspaceService) GetPublishDefaults(wsID string) (*PublishDefaultsResu
 	if hasVersion {
 		if s.isLocal {
 			wsPath := s.executor.GetWorkspacePath(&ws)
-			pixiToml, err := os.ReadFile(filepath.Join(wsPath, "pixi.toml"))
-			if err != nil {
-				return nil, fmt.Errorf("read pixi.toml for bundle hash: %w", err)
+			pixiToml, tomlErr := os.ReadFile(filepath.Join(wsPath, "pixi.toml"))
+			pixiLock, lockErr := os.ReadFile(filepath.Join(wsPath, "pixi.lock"))
+			// A workspace that has been pushed to but never installed yet
+			// has no pixi.lock on disk — return the "latest" fallback so
+			// the publish dialog stays usable instead of 500'ing.
+			if (tomlErr == nil || os.IsNotExist(tomlErr)) && (lockErr == nil || os.IsNotExist(lockErr)) {
+				refs, err := oci.PreviewAssetRefs(wsPath)
+				if err != nil {
+					return nil, fmt.Errorf("preview bundle for default tag: %w", err)
+				}
+				tag = contenthash.HashBundle(string(pixiToml), string(pixiLock), refs)
+			} else if tomlErr != nil {
+				return nil, fmt.Errorf("read pixi.toml for bundle hash: %w", tomlErr)
+			} else {
+				return nil, fmt.Errorf("read pixi.lock for bundle hash: %w", lockErr)
 			}
-			pixiLock, err := os.ReadFile(filepath.Join(wsPath, "pixi.lock"))
-			if err != nil {
-				return nil, fmt.Errorf("read pixi.lock for bundle hash: %w", err)
-			}
-			refs, err := oci.PreviewAssetRefs(wsPath)
-			if err != nil {
-				return nil, fmt.Errorf("preview bundle for default tag: %w", err)
-			}
-			tag = contenthash.HashBundle(string(pixiToml), string(pixiLock), refs)
 		} else if latestVersion.ContentHash != "" {
 			tag = latestVersion.ContentHash
 		}

--- a/internal/service/workspace_publishing_test.go
+++ b/internal/service/workspace_publishing_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/google/uuid"
+	"github.com/nebari-dev/nebi/internal/contenthash"
 	"github.com/nebari-dev/nebi/internal/models"
 	"github.com/nebari-dev/nebi/internal/oci"
 )
@@ -293,4 +294,38 @@ func mustParseHost(t *testing.T, rawURL string) string {
 		t.Fatal(err)
 	}
 	return u.Host
+}
+
+func TestGetPublishDefaults_LocalMode_UsesBundleHash(t *testing.T) {
+	svc, db := testSetup(t, true)
+	userID := createTestUser(t, db, "alice")
+	ws := createReadyWorkspace(t, svc, db, "bundle-defaults", userID)
+
+	// Workspace on disk with pixi + one asset.
+	wsPath := svc.executor.GetWorkspacePath(ws)
+	os.MkdirAll(wsPath, 0o755)
+	pixiToml := "[project]\nname = \"bundle-defaults\"\nchannels = [\"conda-forge\"]\nplatforms = [\"linux-64\"]\n"
+	pixiLock := "version: 6\n"
+	assetBody := `{"cells":[]}`
+	os.WriteFile(filepath.Join(wsPath, "pixi.toml"), []byte(pixiToml), 0o644)
+	os.WriteFile(filepath.Join(wsPath, "pixi.lock"), []byte(pixiLock), 0o644)
+	os.WriteFile(filepath.Join(wsPath, "notebook.ipynb"), []byte(assetBody), 0o644)
+
+	db.Create(&models.OCIRegistry{Name: "r", URL: "https://ghcr.io", IsDefault: true})
+	// Seed a version so GetPublishDefaults doesn't short-circuit to "latest".
+	db.Create(&models.WorkspaceVersion{WorkspaceID: ws.ID, VersionNumber: 1, ContentHash: "sha-oldstyle"})
+
+	got, err := svc.GetPublishDefaults(ws.ID.String())
+	if err != nil {
+		t.Fatalf("GetPublishDefaults: %v", err)
+	}
+
+	refs, err := oci.PreviewAssetRefs(wsPath)
+	if err != nil {
+		t.Fatalf("PreviewAssetRefs: %v", err)
+	}
+	want := contenthash.HashBundle(pixiToml, pixiLock, refs)
+	if got.Tag != want {
+		t.Errorf("tag mismatch: got %q want %q", got.Tag, want)
+	}
 }

--- a/internal/service/workspace_publishing_test.go
+++ b/internal/service/workspace_publishing_test.go
@@ -2,10 +2,16 @@ package service
 
 import (
 	"context"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/google/uuid"
 	"github.com/nebari-dev/nebi/internal/models"
+	"github.com/nebari-dev/nebi/internal/oci"
 )
 
 // --- GetPublishDefaults tests ---
@@ -221,4 +227,70 @@ func TestUpdatePublication_NotFound(t *testing.T) {
 	if err != ErrNotFound {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
+}
+
+func TestPublishWorkspace_LocalMode_UploadsAssets(t *testing.T) {
+	svc, db := testSetup(t, true) // isLocal=true
+	userID := createTestUser(t, db, "alice")
+	ws := createReadyWorkspace(t, svc, db, "bundle-pub", userID)
+
+	// Seed the workspace on disk with pixi files + one asset.
+	wsPath := svc.executor.GetWorkspacePath(ws)
+	if err := os.MkdirAll(wsPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join(wsPath, "pixi.toml"),
+		[]byte("[project]\nname = \"bundle-pub\"\nchannels = [\"conda-forge\"]\nplatforms = [\"linux-64\"]\n"), 0o644)
+	os.WriteFile(filepath.Join(wsPath, "pixi.lock"), []byte("version: 6\n"), 0o644)
+	os.WriteFile(filepath.Join(wsPath, "notebook.ipynb"), []byte(`{"cells":[]}`), 0o644)
+
+	// Seed a version row so PublishWorkspace finds a latest version.
+	db.Create(&models.WorkspaceVersion{
+		WorkspaceID:   ws.ID,
+		VersionNumber: 1,
+		ContentHash:   "sha-abcdef",
+	})
+
+	// Spin up the in-memory registry.
+	srv := httptest.NewServer(registry.New())
+	defer srv.Close()
+	regHost := mustParseHost(t, srv.URL)
+
+	reg := models.OCIRegistry{
+		Name:      "test-reg",
+		URL:       "http://" + regHost,
+		Namespace: "demo",
+		IsDefault: true,
+	}
+	db.Create(&reg)
+
+	_, err := svc.PublishWorkspace(context.Background(), ws.ID.String(), PublishWorkspaceRequest{
+		RegistryID: reg.ID,
+		Repository: "bundle-pub",
+		Tag:        "v1",
+	}, userID)
+	if err != nil {
+		t.Fatalf("PublishWorkspace: %v", err)
+	}
+
+	// Pull back via oci.PullBundle and verify the asset layer exists.
+	result, err := oci.PullBundle(context.Background(),
+		regHost+"/demo/bundle-pub", "v1",
+		oci.PullOptions{PlainHTTP: true},
+	)
+	if err != nil {
+		t.Fatalf("PullBundle: %v", err)
+	}
+	if len(result.Assets) != 1 || result.Assets[0].Path != "notebook.ipynb" {
+		t.Errorf("expected one asset notebook.ipynb, got %+v", result.Assets)
+	}
+}
+
+func mustParseHost(t *testing.T, rawURL string) string {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return u.Host
 }

--- a/internal/service/workspace_test.go
+++ b/internal/service/workspace_test.go
@@ -513,3 +513,15 @@ func isConflictError(err error, target **ConflictError) bool {
 	}
 	return ok
 }
+
+func TestWorkspaceService_IsLocal(t *testing.T) {
+	localSvc, _ := testSetup(t, true)
+	if !localSvc.IsLocal() {
+		t.Error("expected IsLocal()=true when service constructed with isLocal=true")
+	}
+
+	teamSvc, _ := testSetup(t, false)
+	if teamSvc.IsLocal() {
+		t.Error("expected IsLocal()=false when service constructed with isLocal=false")
+	}
+}

--- a/internal/service/workspace_test.go
+++ b/internal/service/workspace_test.go
@@ -514,6 +514,28 @@ func isConflictError(err error, target **ConflictError) bool {
 	return ok
 }
 
+func TestCreate_ForwardsImportStagingDirToJob(t *testing.T) {
+	svc, db := testSetup(t, true)
+	userID := createTestUser(t, db, "alice")
+
+	ws, err := svc.Create(context.Background(), CreateRequest{
+		Name:             "import-seeded",
+		ImportStagingDir: "/tmp/fake-staging-path",
+	}, userID)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var job models.Job
+	if err := db.Where("workspace_id = ? AND type = ?", ws.ID, models.JobTypeCreate).First(&job).Error; err != nil {
+		t.Fatalf("find create job: %v", err)
+	}
+	got, _ := job.Metadata["import_staging_dir"].(string)
+	if got != "/tmp/fake-staging-path" {
+		t.Errorf("job metadata import_staging_dir = %q, want %q", got, "/tmp/fake-staging-path")
+	}
+}
+
 func TestWorkspaceService_IsLocal(t *testing.T) {
 	localSvc, _ := testSetup(t, true)
 	if !localSvc.IsLocal() {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -249,10 +249,7 @@ func (w *Worker) executeJob(ctx context.Context, job *models.Job, logWriter io.W
 	case models.JobTypeCreate:
 		w.svc.SetWorkspaceStatus(ws.ID, models.WsStatusCreating)
 
-		opts := executor.CreateWorkspaceOptions{}
-		if v, ok := job.Metadata["pixi_toml"].(string); ok {
-			opts.PixiToml = v
-		}
+		opts := buildCreateWorkspaceOptions(job.Metadata)
 
 		if err := w.executor.CreateWorkspace(ctx, ws, logWriter, opts); err != nil {
 			w.svc.SetWorkspaceStatus(ws.ID, models.WsStatusFailed)
@@ -414,6 +411,20 @@ func (w *Worker) executeRollback(ctx context.Context, ws *models.Workspace, vers
 
 	fmt.Fprintf(logWriter, "Workspace restored successfully\n")
 	return nil
+}
+
+// buildCreateWorkspaceOptions converts JobTypeCreate metadata into the
+// executor's CreateWorkspaceOptions. It is lenient — missing keys or
+// non-string values yield zero-value fields rather than errors.
+func buildCreateWorkspaceOptions(metadata map[string]interface{}) executor.CreateWorkspaceOptions {
+	opts := executor.CreateWorkspaceOptions{}
+	if v, ok := metadata["pixi_toml"].(string); ok {
+		opts.PixiToml = v
+	}
+	if v, ok := metadata["import_staging_dir"].(string); ok {
+		opts.SeedDir = v
+	}
+	return opts
 }
 
 // parsePackagesFromMetadata extracts the packages list from job metadata,

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -249,13 +249,12 @@ func (w *Worker) executeJob(ctx context.Context, job *models.Job, logWriter io.W
 	case models.JobTypeCreate:
 		w.svc.SetWorkspaceStatus(ws.ID, models.WsStatusCreating)
 
-		// Check if pixi_toml content is provided in metadata
-		var pixiToml string
-		if pixiTomlInterface, ok := job.Metadata["pixi_toml"]; ok {
-			pixiToml, _ = pixiTomlInterface.(string)
+		opts := executor.CreateWorkspaceOptions{}
+		if v, ok := job.Metadata["pixi_toml"].(string); ok {
+			opts.PixiToml = v
 		}
 
-		if err := w.executor.CreateWorkspace(ctx, ws, logWriter, pixiToml); err != nil {
+		if err := w.executor.CreateWorkspace(ctx, ws, logWriter, opts); err != nil {
 			w.svc.SetWorkspaceStatus(ws.ID, models.WsStatusFailed)
 			return err
 		}

--- a/internal/worker/worker_options_test.go
+++ b/internal/worker/worker_options_test.go
@@ -1,0 +1,67 @@
+package worker
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/nebari-dev/nebi/internal/executor"
+)
+
+func TestBuildCreateWorkspaceOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]interface{}
+		want     executor.CreateWorkspaceOptions
+	}{
+		{
+			name:     "empty metadata",
+			metadata: map[string]interface{}{},
+			want:     executor.CreateWorkspaceOptions{},
+		},
+		{
+			name: "pixi_toml only",
+			metadata: map[string]interface{}{
+				"pixi_toml": "[project]\nname = \"x\"\n",
+			},
+			want: executor.CreateWorkspaceOptions{
+				PixiToml: "[project]\nname = \"x\"\n",
+			},
+		},
+		{
+			name: "import_staging_dir only",
+			metadata: map[string]interface{}{
+				"import_staging_dir": "/tmp/staging-abc",
+			},
+			want: executor.CreateWorkspaceOptions{
+				SeedDir: "/tmp/staging-abc",
+			},
+		},
+		{
+			name: "both pixi_toml and import_staging_dir",
+			metadata: map[string]interface{}{
+				"pixi_toml":          "[project]\nname = \"x\"\n",
+				"import_staging_dir": "/tmp/staging-abc",
+			},
+			want: executor.CreateWorkspaceOptions{
+				PixiToml: "[project]\nname = \"x\"\n",
+				SeedDir:  "/tmp/staging-abc",
+			},
+		},
+		{
+			name: "ignores non-string values",
+			metadata: map[string]interface{}{
+				"pixi_toml":          123,
+				"import_staging_dir": true,
+			},
+			want: executor.CreateWorkspaceOptions{},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildCreateWorkspaceOptions(tc.metadata)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("buildCreateWorkspaceOptions() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Desktop App talks to Nebi over the API, but the publish/import endpoints only handled pixi.toml+pixi.lock. Asset layers were dropped on import and never uploaded on publish. This wires the bundle format through the API when the server is in local mode (team mode unchanged).

<img width="3820" height="814" alt="nebi-import-publish" src="https://github.com/user-attachments/assets/3f3500d9-a8c3-4038-a694-9fab45a14d97" />


- `POST /workspaces/:id/publish`: local mode uses `oci.Publish` (walks workspace, uploads asset layers). Team mode still uses `oci.PublishPixiOnly`.
- `POST /registries/:id/import`: local mode uses `oci.ExtractBundle` into a staging dir, worker seeds the new workspace from it before pixi install runs. Preserves the published pixi.lock (was lost before). Team mode still drops assets.
- `GetPublishDefaults` in local mode computes the default tag over the full bundle (matches CLI --local behaviour).

Executor change: `CreateWorkspace` now takes `CreateWorkspaceOptions{PixiToml, SeedDir}`. `SeedDir` recursively moves a pre-staged directory into the workspace before install.

Incidental fixes surfaced by the e2e test:
- `internal/config`: explicit `BindEnv` for nested keys — viper's AutomaticEnv doesn't propagate into nested structs, so things like `NEBI_STORAGE_WORKSPACES_DIR` were silently ignored.
- `internal/api/router`: skip `rbac.InitEnforcer` in local mode (middleware skips RBAC there anyway; re-init was clobbering the global enforcer).