### PR TITLE
Add explicit repository_path for registry imports

### DIFF
--- a/cmd/nebi/bundle_api_e2e_test.go
+++ b/cmd/nebi/bundle_api_e2e_test.go
@@ -159,9 +159,9 @@ func TestE2E_BundlePublishImportViaAPI_LocalMode(t *testing.T) {
 
 	// ---- Import via POST /registries/:id/import ----
 	wsID := importViaAPI(t, serverURL, token, registryID, map[string]interface{}{
-		"repository": repoName,
-		"tag":        bundleTag,
-		"name":       "notebook-imported",
+		"repository_path": ociNS + "/" + repoName,
+		"tag":             bundleTag,
+		"name":            "notebook-imported",
 	})
 
 	// ---- Poll workspace until ready (or fail after 30s) ----

--- a/frontend/src/pages/Registries.tsx
+++ b/frontend/src/pages/Registries.tsx
@@ -167,7 +167,7 @@ const RepositoryRow = ({
       await importMutation.mutateAsync({
         registryId,
         data: {
-          repository: repoName,
+          repository_path: repoName,
           tag: effectiveTag,
           name: importName.trim(),
         },

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -257,7 +257,8 @@ export interface RegistryTag {
 }
 
 export interface ImportEnvironmentRequest {
-  repository: string;
+  repository?: string;
+  repository_path?: string;
   tag: string;
   name: string;
 }

--- a/internal/api/handlers/registry_browse.go
+++ b/internal/api/handlers/registry_browse.go
@@ -21,11 +21,15 @@ func NewRegistryBrowseHandler(registrySvc *service.RegistryService, wsSvc *servi
 	return &RegistryBrowseHandler{registrySvc: registrySvc, wsSvc: wsSvc}
 }
 
-// ImportRequest is the JSON body for the import endpoint
+// ImportRequest is the JSON body for the import endpoint.
+// Repository is the existing namespace-relative name. RepositoryPath is the full
+// OCI repository path below the registry host, for example
+// "namespace/repository" in "host/namespace/repository:tag".
 type ImportRequest struct {
-	Repository string `json:"repository" binding:"required"`
-	Tag        string `json:"tag" binding:"required"`
-	Name       string `json:"name" binding:"required"`
+	Repository     string `json:"repository"`
+	RepositoryPath string `json:"repository_path"`
+	Tag            string `json:"tag" binding:"required"`
+	Name           string `json:"name" binding:"required"`
 }
 
 // ListRepositories lists repositories in a registry.
@@ -161,10 +165,22 @@ func (h *RegistryBrowseHandler) ImportEnvironment(c *gin.Context) {
 		return
 	}
 
+	repository := strings.TrimSpace(req.Repository)
+	repositoryPath := strings.TrimSpace(req.RepositoryPath)
+	if repository == "" && repositoryPath == "" {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "repository or repository_path is required"})
+		return
+	}
+	if repository != "" && repositoryPath != "" {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "provide either repository or repository_path, not both"})
+		return
+	}
+
 	ws, err := h.wsSvc.ImportFromRegistry(c.Request.Context(), registryID, service.ImportFromRegistryRequest{
-		Repository: req.Repository,
-		Tag:        req.Tag,
-		Name:       req.Name,
+		Repository:     repository,
+		RepositoryPath: repositoryPath,
+		Tag:            req.Tag,
+		Name:           req.Name,
 	}, userID)
 	if err != nil {
 		handleServiceError(c, err)

--- a/internal/service/registry.go
+++ b/internal/service/registry.go
@@ -248,13 +248,30 @@ func (s *RegistryService) GetRegistryWithCredentials(id string) (*RegistryWithCr
 	}, nil
 }
 
-// FallbackRepositories returns distinct repository names from publication records for a registry.
+// FallbackRepositories returns distinct repository paths from publication records for a registry.
 func (s *RegistryService) FallbackRepositories(registryID string) []string {
 	var repositories []string
 	s.db.Model(&models.Publication{}).
 		Where("registry_id = ?", registryID).
 		Distinct("repository").
 		Pluck("repository", &repositories)
+
+	var registry models.OCIRegistry
+	if err := s.db.Select("namespace").Where("id = ?", registryID).First(&registry).Error; err != nil {
+		return repositories
+	}
+
+	namespace := strings.TrimSpace(registry.Namespace)
+	if namespace == "" {
+		return repositories
+	}
+	for index, repository := range repositories {
+		repository = strings.TrimSpace(repository)
+		if repository != "" && !strings.HasPrefix(repository, namespace+"/") {
+			repository = namespace + "/" + repository
+		}
+		repositories[index] = repository
+	}
 	return repositories
 }
 

--- a/internal/service/registry_endpoint.go
+++ b/internal/service/registry_endpoint.go
@@ -22,12 +22,19 @@ type registryEndpoint struct {
 	PlainHTTP bool
 }
 
-// RepoRef composes "host/[namespace/]repo" — the form oras-go expects.
-func (e *registryEndpoint) RepoRef(repo string) string {
+// NamespaceRelativeRepoRef composes "host/[namespace/]repo" for callers
+// whose repository value is relative to the registry's configured namespace.
+func (e *registryEndpoint) NamespaceRelativeRepoRef(repo string) string {
 	if e.Namespace != "" {
 		return fmt.Sprintf("%s/%s/%s", e.Host, e.Namespace, repo)
 	}
 	return fmt.Sprintf("%s/%s", e.Host, repo)
+}
+
+// RepositoryPathRef composes "host/repository" when repository is already
+// the full OCI repository path under the registry host, e.g. "org/name".
+func (e *registryEndpoint) RepositoryPathRef(repository string) string {
+	return fmt.Sprintf("%s/%s", e.Host, repository)
 }
 
 // loadRegistryEndpoint loads a registry by ID, decrypts its password

--- a/internal/service/registry_test.go
+++ b/internal/service/registry_test.go
@@ -3,6 +3,8 @@ package service
 import (
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/nebari-dev/nebi/internal/models"
 	"gorm.io/gorm"
 )
 
@@ -198,5 +200,42 @@ func TestRegistryDelete_NotFound(t *testing.T) {
 	err := svc.DeleteRegistry("nonexistent")
 	if err != ErrNotFound {
 		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestFallbackRepositories_ReturnsNamespaceQualifiedPaths(t *testing.T) {
+	svc, db := registryTestSetup(t)
+
+	created, err := svc.CreateRegistry(CreateRegistryReq{Name: "fallback", URL: "https://quay.io", Namespace: "demo"})
+	if err != nil {
+		t.Fatalf("CreateRegistry: %v", err)
+	}
+
+	publishedBy := uuid.New()
+	for _, repository := range []string{"notebook", "demo/already-qualified"} {
+		if err := db.Create(&models.Publication{
+			WorkspaceID:   uuid.New(),
+			VersionNumber: 1,
+			RegistryID:    created.ID,
+			Repository:    repository,
+			Tag:           "v1",
+			PublishedBy:   publishedBy,
+		}).Error; err != nil {
+			t.Fatalf("create publication: %v", err)
+		}
+	}
+
+	repositories := svc.FallbackRepositories(created.ID.String())
+	seen := make(map[string]bool, len(repositories))
+	for _, repository := range repositories {
+		seen[repository] = true
+	}
+	for _, want := range []string{"demo/notebook", "demo/already-qualified"} {
+		if !seen[want] {
+			t.Fatalf("expected fallback repository %q in %v", want, repositories)
+		}
+	}
+	if seen["demo/demo/already-qualified"] {
+		t.Fatalf("did not expect namespace to be duplicated in %v", repositories)
 	}
 }

--- a/internal/service/workspace_import.go
+++ b/internal/service/workspace_import.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -15,9 +16,14 @@ import (
 
 // ImportFromRegistryRequest selects the OCI bundle to import.
 type ImportFromRegistryRequest struct {
+	// Repository is the existing namespace-relative repository name. It is
+	// resolved against the registry's configured namespace.
 	Repository string
-	Tag        string
-	Name       string
+	// RepositoryPath is the full OCI repository path below the registry host,
+	// for example "namespace/repository" in "host/namespace/repository:tag".
+	RepositoryPath string
+	Tag            string
+	Name           string
 }
 
 // ImportFromRegistry pulls an OCI bundle from a registered registry and
@@ -46,7 +52,22 @@ func (s *WorkspaceService) ImportFromRegistry(ctx context.Context, registryID st
 	if err != nil {
 		return nil, err
 	}
-	repoRef := ep.RepoRef(req.Repository)
+	repository := strings.TrimSpace(req.Repository)
+	repositoryPath := strings.TrimSpace(req.RepositoryPath)
+	if repository != "" && repositoryPath != "" {
+		return nil, &ValidationError{Message: "provide either repository or repository_path, not both"}
+	}
+
+	auditRepository := repository
+	var repoRef string
+	if repositoryPath != "" {
+		auditRepository = repositoryPath
+		repoRef = ep.RepositoryPathRef(repositoryPath)
+	} else if repository != "" {
+		repoRef = ep.NamespaceRelativeRepoRef(repository)
+	} else {
+		return nil, &ValidationError{Message: "repository or repository_path is required"}
+	}
 	pullOpts := oci.PullOptions{
 		Username:  ep.Username,
 		Password:  ep.Password,
@@ -110,7 +131,7 @@ func (s *WorkspaceService) ImportFromRegistry(ctx context.Context, registryID st
 	audit.LogAction(s.db, userID, audit.ActionImportWorkspace, fmt.Sprintf("ws:%s", ws.ID.String()), map[string]interface{}{
 		"name":       req.Name,
 		"registry":   ep.Registry.Name,
-		"repository": req.Repository,
+		"repository": auditRepository,
 		"tag":        req.Tag,
 		"digest":     digest,
 	})

--- a/internal/service/workspace_import_test.go
+++ b/internal/service/workspace_import_test.go
@@ -124,7 +124,7 @@ platforms = ["linux-64"]
 	db.Create(&dbReg)
 
 	ws, err := svc.ImportFromRegistry(context.Background(), dbReg.ID.String(), ImportFromRegistryRequest{
-		Repository: "team-import", Tag: "v1", Name: "imported-team",
+		RepositoryPath: "demo/team-import", Tag: "v1", Name: "imported-team",
 	}, userID)
 	if err != nil {
 		t.Fatalf("ImportFromRegistry: %v", err)

--- a/internal/service/workspace_publishing.go
+++ b/internal/service/workspace_publishing.go
@@ -44,7 +44,7 @@ func (s *WorkspaceService) PublishWorkspace(ctx context.Context, wsID string, re
 		return nil, err
 	}
 	registry := *ep.Registry
-	fullRepo := ep.RepoRef(req.Repository)
+	fullRepo := ep.NamespaceRelativeRepoRef(req.Repository)
 
 	wsPath := s.executor.GetWorkspacePath(&ws)
 


### PR DESCRIPTION
## Motivation
This PR avoids changing the existing `repository` contract while adding an explicit field for callers that already have Docker/OCI-style repository paths.

Use existing namespace-relative import:

```json
{ "repository": "repo", "tag": "v1", "name": "repo" }
```

or full-path import:

```json
{ "repository_path": "ns/repo", "tag": "v1", "name": "repo" }
```

Both resolve to:

```text
quay.io/ns/repo:v1
```

## Summary of Changes
- add `repository_path` to the registered-registry import API for full OCI repository paths below the registry host
- keep existing `repository` behavior unchanged: namespace-relative to the configured registry namespace
- update the registry browser import flow to send `repository_path`
- return namespace-qualified fallback repositories from publication records so browse/import rows keep the same repository-path contract

## Current behavior
- CLI import uses full OCI refs: `nebi import quay.io/ns/repo:tag`, where the repository path is `ns/repo`.
- Server import/publish APIs currently use `repository` as namespace-relative to the configured registry namespace. With registry `quay.io` + namespace `ns`, `repository: "repo"` resolves to `quay.io/ns/repo`.
- The registry browser works with full repository paths like `ns/repo` so copied CLI commands are correct, but sending that value through the existing `repository` API field causes namespace duplication: `quay.io/ns/ns/repo`.
