### PR TITLE
fix: allow configuration editing on failed workspaces

### DIFF
--- a/frontend/src/pages/WorkspaceDetail.tsx
+++ b/frontend/src/pages/WorkspaceDetail.tsx
@@ -65,7 +65,7 @@ export const WorkspaceDetail = () => {
 
   // Load pixi.toml when switching to that tab
   useEffect(() => {
-    if (activeTab === 'toml' && !pixiToml && workspace?.status === 'ready') {
+    if (activeTab === 'toml' && !pixiToml) {
       loadPixiToml();
     }
   }, [activeTab, workspace?.status]);
@@ -162,7 +162,6 @@ export const WorkspaceDetail = () => {
             variant="outline"
             size="sm"
             className="gap-2"
-            disabled={workspace.status !== 'ready'}
             onClick={async () => {
               if (!pixiToml) {
                 setLoadingToml(true);
@@ -527,11 +526,7 @@ export const WorkspaceDetail = () => {
                 )}
               </div>
             </div>
-            {workspace.status !== 'ready' ? (
-              <div className="text-center py-8 text-muted-foreground">
-                Workspace must be ready to view pixi.toml
-              </div>
-            ) : loadingToml ? (
+            {loadingToml ? (
               <div className="flex items-center justify-center py-12">
                 <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
               </div>


### PR DESCRIPTION
## Summary

- When a workspace fails during initial creation (e.g. a bad pixi solve), the Configuration tab was completely locked — showing only "Workspace must be ready to view pixi.toml" with no way to edit
- This forced users to delete and recreate the workspace from scratch just to fix a typo in their config
- The backend (`GetPixiToml` / `SavePixiToml`) already supports reading and writing `pixi.toml` regardless of workspace status, so this was purely a frontend restriction
- Removed the `status === 'ready'` guard from the useEffect loader, the Edit button's `disabled` prop, and the conditional block that replaced the editor with a "must be ready" message

## Test plan

- [x] Create a workspace with an intentionally broken pixi.toml (e.g. invalid package name)
- [x] Confirm the workspace enters a failed state
- [x] Navigate to the Configuration tab and verify the pixi.toml content is visible
- [x] Click Edit, fix the configuration, and click Save & Install
- [x] Confirm the workspace re-solves and transitions to ready