### PR TITLE
docs: align reference pages and example with bundle format

### DIFF
--- a/docs/docs/cli-reference.md
+++ b/docs/docs/cli-reference.md
@@ -2,6 +2,13 @@
 
 Nebi's CLI is organized into command groups: **Workspace**, **Sync**, **Connection**, and **Admin**.
 
+## Specs vs. Bundles
+
+Two terms appear throughout these commands:
+
+- **Workspace spec**: `pixi.toml` and `pixi.lock`. The minimal environment definition. Stored on the Nebi server.
+- **Workspace bundle**: `pixi.toml` + `pixi.lock` + any project files (READMEs, source code, data), packaged for an OCI registry.
+
 ## Workspace Commands
 
 | Command | Description |
@@ -21,8 +28,8 @@ Nebi's CLI is organized into command groups: **Workspace**, **Sync**, **Connecti
 | `nebi push [<name>][:<tag>]` | Push workspace specs to a server (tag optional, auto-tags with content hash + latest) |
 | `nebi pull [<name>[:<tag>]]` | Pull workspace specs from a server |
 | `nebi diff [<ref-a>] [<ref-b>]` | Compare workspace specs |
-| `nebi publish [name]` | Publish to an OCI registry (uses content hash tag by default) |
-| `nebi import <oci-reference>` | Import a workspace from a public OCI registry |
+| `nebi publish [name]` | Publish a workspace bundle to an OCI registry (uses content hash tag by default) |
+| `nebi import <oci-reference>` | Import a workspace bundle from an OCI registry, restoring pixi files and asset layers |
 
 ## Connection Commands
 
@@ -42,4 +49,5 @@ Nebi's CLI is organized into command groups: **Workspace**, **Sync**, **Connecti
 ## Common Flags
 
 - `-r, --remote` — Target the server instead of local workspaces (on `workspace list` and `workspace remove`)
+- `--concurrency N` — On `publish` and `import`, the number of files uploaded or downloaded at the same time (default 8)
 - `--version` — Print version information

--- a/docs/docs/examples/sharing-environments.md
+++ b/docs/docs/examples/sharing-environments.md
@@ -60,38 +60,34 @@ scikit-learn = ">=1.4"
 streamlit = ">=1.30"
 ```
 
-### Step 2: Add tasks
+### Step 2: Add code and tasks
 
-Alice adds a training task directly in `pixi.toml`. Since the task is defined inline, it travels with the environment when published:
+Alice writes the training code in `train.py`:
 
-```toml
-[tasks]
-train = """python -c "
+```python title="train.py"
 from sklearn.datasets import load_iris
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score, confusion_matrix
 
 X, y = load_iris(return_X_y=True)
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3, random_state=42)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.3, random_state=42
+)
 
 model = DecisionTreeClassifier(random_state=42)
 model.fit(X_train, y_train)
 
 y_pred = model.predict(X_test)
-print(f'Accuracy: {accuracy_score(y_test, y_pred):.2f}')
+print(f"Accuracy: {accuracy_score(y_test, y_pred):.2f}")
 cm = confusion_matrix(y_test, y_pred)
-print('Confusion Matrix:')
+print("Confusion Matrix:")
 print(cm)
-" """
 ```
 
-She also adds a Streamlit app for interactive predictions:
+And a Streamlit app for interactive predictions in `app.py`:
 
-```toml
-app = """python -c "
-import tempfile, os, subprocess, sys
-code = '''
+```python title="app.py"
 import streamlit as st
 from sklearn.datasets import load_iris
 from sklearn.tree import DecisionTreeClassifier
@@ -100,21 +96,24 @@ iris = load_iris()
 model = DecisionTreeClassifier(random_state=42)
 model.fit(iris.data, iris.target)
 
-st.title('Iris Species Predictor')
-features = [[
-    st.slider('Sepal length', 4.0, 8.0, 5.8),
-    st.slider('Sepal width', 2.0, 4.5, 3.0),
-    st.slider('Petal length', 1.0, 7.0, 4.0),
-    st.slider('Petal width', 0.1, 2.5, 1.2),
-]]
-st.subheader(f'Predicted: {iris.target_names[model.predict(features)[0]]}')
-'''
-f = tempfile.NamedTemporaryFile(suffix='.py', delete=False, mode='w')
-f.write(code)
-f.close()
-subprocess.run([sys.executable, '-m', 'streamlit', 'run', f.name])
-os.unlink(f.name)
-" """
+st.title("Iris Species Predictor")
+features = [
+    [
+        st.slider("Sepal length", 4.0, 8.0, 5.8),
+        st.slider("Sepal width", 2.0, 4.5, 3.0),
+        st.slider("Petal length", 1.0, 7.0, 4.0),
+        st.slider("Petal width", 0.1, 2.5, 1.2),
+    ]
+]
+st.subheader(f"Predicted: {iris.target_names[model.predict(features)[0]]}")
+```
+
+Alice wires the scripts up as named tasks in `pixi.toml` so they can be run with a short command (`pixi run train`, `pixi run app`):
+
+```toml
+[tasks]
+train = "python train.py"
+app = "streamlit run app.py"
 ```
 
 Alice installs the environment to generate the lock file:
@@ -147,6 +146,17 @@ pixi run app
 
 ![Streamlit prediction app](/img/example-streamlit-app.png)
 
+Alice's workspace now looks like this:
+
+```text
+.
+├── README.md
+├── app.py
+├── pixi.lock
+├── pixi.toml
+└── train.py
+```
+
 ### Step 3: Publish to an OCI registry
 
 Before publishing, configure a default registry (see [Registry Setup](../registry-setup.md) for details):
@@ -157,8 +167,7 @@ nebi registry add \
   --name <name> \
   --url <url> \
   --namespace <namespace> \
-  --username <username> \
-  --local
+  --username <username>
 ```
 
 For example, here's how it looks with Docker Hub:
@@ -169,8 +178,7 @@ nebi registry add \
   --url docker.io \
   --namespace alice \
   --username alice \
-  --default \
-  --local
+  --default
 Password:
 Added local registry 'dockerhub' (docker.io)
 ```
@@ -178,7 +186,7 @@ Added local registry 'dockerhub' (docker.io)
 Then publish. The `--tag` sets the version and `--repo` names the repository:
 
 ```bash
-nebi publish data-science-demo --tag v1.0 --repo data-science-demo --local
+nebi publish data-science-demo --tag v1.0 --repo data-science-demo
 ```
 
 Example output with Docker Hub:
@@ -187,11 +195,15 @@ Example output with Docker Hub:
 Published docker.io/alice/data-science-demo:v1.0 (digest: sha256:...)
 ```
 
+The bundle now lives at `docker.io/alice/data-science-demo:v1.0` and contains every file from Alice's workspace: `pixi.toml`, `pixi.lock`, `train.py`, `app.py`, `README.md`.
+
 ## Bob: Download and Run the Environment
 
 Bob doesn't need to know what packages Alice chose or how the environment was built. He just needs one command.
 
 ### Import from the OCI registry
+
+To recreate Alice's environment locally, Bob just needs to import the bundle:
 
 ```bash
 nebi import <url>/<namespace>/data-science-demo:v1.0
@@ -203,7 +215,16 @@ For example, with Alice's Docker Hub registry, the command would be:
 nebi import docker.io/alice/data-science-demo:v1.0
 ```
 
-This creates `pixi.toml` and `pixi.lock` in the current directory.
+This restores all of Alice's workspace files into the current directory at their original relative paths:
+
+```text
+.
+├── README.md
+├── app.py
+├── pixi.lock
+├── pixi.toml
+└── train.py
+```
 
 ### Run the task
 
@@ -239,4 +260,4 @@ Here's the full flow at a glance:
 | Import environment | Bob | `nebi import` |
 | Run task | Bob | `pixi run train` |
 
-With Nebi, Bob gets the same packages, the same versions, and the same results as Alice without any manual setup.
+With Nebi, Bob gets the same packages, the same versions, the same project files, and the same results as Alice without any manual setup.

--- a/docs/docs/examples/sharing-environments.md
+++ b/docs/docs/examples/sharing-environments.md
@@ -179,6 +179,9 @@ nebi registry add \
   --namespace alice \
   --username alice \
   --default
+```
+
+```bash title="Output"
 Password:
 Added local registry 'dockerhub' (docker.io)
 ```

--- a/docs/docs/nebi-components.md
+++ b/docs/docs/nebi-components.md
@@ -12,7 +12,7 @@ The CLI is a standalone tool for managing and tracking Pixi workspaces on your l
 
 - **Local database**: Track workspace names, paths, and versions in a local database
 - **Pixi shell/run**: Open a pixi shell or run pixi tasks by workspace name
-- **Publish/import - OCI registries**: Push workspace specs directly to OCI registries, and import specs from published registries
+- **Publish/import - OCI registries**: Push workspace bundles (specs plus optional asset layers) directly to OCI registries, and import them on another machine
 - **Push/pull - Nebi server**: Sync (push) versioned `pixi.toml` and `pixi.lock` specs to a Nebi server, and pull from a different machine
 - **Track state (diff)**: Compare specs between local directories, workspace names, or server versions
 
@@ -22,12 +22,12 @@ The [desktop app](./ui.md) is another tool for managing Pixi workspaces on your 
 
 ## OCI Registries
 
-Nebi can publish workspace specifications (`pixi.toml` & `pixi.lock`) as OCI artifacts to any [OCI-compliant registry](./registry-setup.md) such as GitHub Container Registry, Quay.io, or self-hosted registries.
+Nebi can publish **workspace bundles** to any [OCI-compliant registry](./registry-setup.md) such as GitHub Container Registry, Quay.io, or self-hosted registries. A bundle always contains `pixi.toml` and `pixi.lock`, and may also include other project files (READMEs, source code, data).
 
 - Publishing can be done from the CLI (`nebi publish`) or triggered from the desktop app or server
-- The desktop app and server UI includes a registry browser for discovering and pulling published workspaces
+- The desktop app and server UI include a registry browser for discovering and pulling published bundles
 
-Specs are packed into an OCI Image Manifest with custom media types (`application/vnd.pixi.toml.v1+toml`, `application/vnd.pixi.lock.v1+yaml`). Each push creates a content-addressed tag (`sha-<hash>`) plus a `latest` tag and any user-specified tags.
+Bundles are packed into an OCI Image Manifest with custom media types for the spec and for each asset layer. Each push creates a content-addressed tag (`sha-<hash>`) plus a `latest` tag and any user-specified tags.
 
 ## Nebi Server
 

--- a/docs/docs/registry-setup.md
+++ b/docs/docs/registry-setup.md
@@ -94,7 +94,7 @@ nebi import quay.io/nebari_environments/data-science-demo:0.1.0
 This writes `pixi.toml`, `pixi.lock`, and any asset files in the bundle into the current directory, ready to run with `pixi run`.
 
 :::note Imports do not overwrite existing files
-When a bundle contains asset layers, the output directory must be empty (or not yet exist) to avoid clobbering files you already have. Use `-o ./some-new-dir` to import into a fresh location:
+When a bundle contains asset layers, the output directory must be empty (or not yet exist) to avoid clobbering files you already have. Use `-o ./some-new-dir` to import into a fresh location, for example:
 
 ```bash
 nebi import quay.io/nebari_environments/data-science-demo:0.1.0 -o ./demo

--- a/docs/docs/registry-setup.md
+++ b/docs/docs/registry-setup.md
@@ -4,7 +4,7 @@ sidebar_position: 6
 
 # Registry Setup
 
-An OCI registry is a server that stores and distributes packages using the [Open Container Initiative](https://opencontainers.org/) standard. Nebi uses OCI registries to publish environment specs (`pixi.toml` and `pixi.lock`) so anyone can import them without needing access to your Nebi server.
+An OCI registry is a server that stores and distributes packages using the [Open Container Initiative](https://opencontainers.org/) standard. Nebi uses OCI registries to publish workspace bundles (`pixi.toml`, `pixi.lock`, and any project files you choose to include as asset layers) so anyone can import them without needing access to your Nebi server.
 
 Nebi works with any OCI-compliant registry, for example:
 
@@ -91,4 +91,14 @@ For example:
 nebi import quay.io/nebari_environments/data-science-demo:0.1.0
 ```
 
-This writes `pixi.toml` and `pixi.lock` into the current directory, ready to run with `pixi run`. To discover public environments visually, see [Browse Public Registries](./ui.md#browse-public-registries).
+This writes `pixi.toml`, `pixi.lock`, and any asset files in the bundle into the current directory, ready to run with `pixi run`.
+
+:::note Imports do not overwrite existing files
+When a bundle contains asset layers, the output directory must be empty (or not yet exist) to avoid clobbering files you already have. Use `-o ./some-new-dir` to import into a fresh location:
+
+```bash
+nebi import quay.io/nebari_environments/data-science-demo:0.1.0 -o ./demo
+```
+:::
+
+To discover public environments visually, see [Browse Public Registries](./ui.md#browse-public-registries).

--- a/docs/examples/data-science-demo/app.py
+++ b/docs/examples/data-science-demo/app.py
@@ -1,0 +1,18 @@
+import streamlit as st
+from sklearn.datasets import load_iris
+from sklearn.tree import DecisionTreeClassifier
+
+iris = load_iris()
+model = DecisionTreeClassifier(random_state=42)
+model.fit(iris.data, iris.target)
+
+st.title("Iris Species Predictor")
+features = [
+    [
+        st.slider("Sepal length", 4.0, 8.0, 5.8),
+        st.slider("Sepal width", 2.0, 4.5, 3.0),
+        st.slider("Petal length", 1.0, 7.0, 4.0),
+        st.slider("Petal width", 0.1, 2.5, 1.2),
+    ]
+]
+st.subheader(f"Predicted: {iris.target_names[model.predict(features)[0]]}")

--- a/docs/examples/data-science-demo/pixi.toml
+++ b/docs/examples/data-science-demo/pixi.toml
@@ -9,52 +9,6 @@ python = ">=3.11"
 scikit-learn = ">=1.4"
 streamlit = ">=1.30"
 
-# ---------------------------------------------------------------------------
-# Shared tasks
-# ---------------------------------------------------------------------------
 [tasks]
-train = """python -c "
-from sklearn.datasets import load_iris
-from sklearn.tree import DecisionTreeClassifier
-from sklearn.model_selection import train_test_split
-from sklearn.metrics import accuracy_score, confusion_matrix
-
-X, y = load_iris(return_X_y=True)
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3, random_state=42)
-
-model = DecisionTreeClassifier(random_state=42)
-model.fit(X_train, y_train)
-
-y_pred = model.predict(X_test)
-print(f'Accuracy: {accuracy_score(y_test, y_pred):.2f}')
-cm = confusion_matrix(y_test, y_pred)
-print('Confusion Matrix:')
-print(cm)
-" """
-
-app = """python -c "
-import tempfile, os, subprocess, sys
-code = '''
-import streamlit as st
-from sklearn.datasets import load_iris
-from sklearn.tree import DecisionTreeClassifier
-
-iris = load_iris()
-model = DecisionTreeClassifier(random_state=42)
-model.fit(iris.data, iris.target)
-
-st.title('Iris Species Predictor')
-features = [[
-    st.slider('Sepal length', 4.0, 8.0, 5.8),
-    st.slider('Sepal width', 2.0, 4.5, 3.0),
-    st.slider('Petal length', 1.0, 7.0, 4.0),
-    st.slider('Petal width', 0.1, 2.5, 1.2),
-]]
-st.subheader(f'Predicted: {iris.target_names[model.predict(features)[0]]}')
-'''
-f = tempfile.NamedTemporaryFile(suffix='.py', delete=False, mode='w')
-f.write(code)
-f.close()
-subprocess.run([sys.executable, '-m', 'streamlit', 'run', f.name])
-os.unlink(f.name)
-" """
+train = "python train.py"
+app = "streamlit run app.py"

--- a/docs/examples/data-science-demo/train.py
+++ b/docs/examples/data-science-demo/train.py
@@ -1,0 +1,18 @@
+from sklearn.datasets import load_iris
+from sklearn.tree import DecisionTreeClassifier
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score, confusion_matrix
+
+X, y = load_iris(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.3, random_state=42
+)
+
+model = DecisionTreeClassifier(random_state=42)
+model.fit(X_train, y_train)
+
+y_pred = model.predict(X_test)
+print(f"Accuracy: {accuracy_score(y_test, y_pred):.2f}")
+cm = confusion_matrix(y_test, y_pred)
+print("Confusion Matrix:")
+print(cm)


### PR DESCRIPTION
## Summary
Align user-facing docs with PR #295's workspace bundle format. Updates reference pages (`cli-reference.md`, `nebi-components.md`, `registry-setup.md`) and the sharing-environments example.

Closes #334

## Test plan
- [x] Render the docs site locally and verify the updated pages
- [x] Run through the sharing-environments tutorial to confirm the commands work