### PR TITLE
Fix installation commands

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -15,7 +15,7 @@ See the [Pixi installation docs](https://pixi.sh) for more options.
 Install the CLI (`nebi` package) and the desktop application (`nebi-desktop`) with [pixi global install](https://pixi.prefix.dev/latest/reference/cli/pixi/global/install/#pixi-global-install).
 
 ```bash
-pixi global install nebi nebi-desktop
+pixi global install nebi
 ```
 
 ## Installation script
@@ -39,7 +39,7 @@ export PATH="$HOME/.local/bin:$PATH"
 ### Install only CLI
 
 ```bash
-curl -fsSL https://pixi.sh/install.sh | bash
+curl -fsSL https://nebi.nebari.dev/install.sh | bash
 ```
 
 ### Install a specific version


### PR DESCRIPTION
Updates to the installation commands.

* `nebi-desktop` is included with `nebi` (does not need to be installed separately)
* CLI-only command points to pixi (oversight/mistake)