### PR TITLE
docs: clarify nebi publish does not require a server

### DIFF
--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -94,7 +94,7 @@ pixi install
 
 ### Share environments across your team
 
-Instead of sharing environments through git repos, the Nebi server lets you publish them to an OCI registry (the same standard behind Docker Hub). Anyone on your team can pull and reproduce your setup from anywhere:
+Instead of sharing environments through git repos, Nebi publishes them to an OCI registry (the same standard behind Docker Hub). Anyone on your team can pull and reproduce your setup from anywhere:
 
 ```bash
 # Publish to an OCI registry


### PR DESCRIPTION
## Summary
Fix the wording in `introduction.md` that implied `nebi publish` requires a Nebi server. The command falls back to local mode when no server is configured.

Closes #331

## Test plan
- [x] Render the docs site locally and verify the updated paragraph