### PR TITLE
ci(docker): fallback REGISTRY/PROJECT for fork PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,8 +11,10 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  REGISTRY: ${{ vars.DOCKER_REGISTRY }}
-  PROJECT: ${{ vars.DOCKER_PROJECT }}
+  # vars.* are not exposed to fork-PR runs on public repos, so fallbacks
+  # keep the image tag valid for the local build + smoke test.
+  REGISTRY: ${{ vars.DOCKER_REGISTRY || 'localhost' }}
+  PROJECT: ${{ vars.DOCKER_PROJECT || 'fork-pr' }}
   IMAGE_NAME: nebi
   IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
 


### PR DESCRIPTION
Follow-up to #341. On public repos, `vars.*` are not passed to fork-PR workflow runs, so REGISTRY and PROJECT resolved to empty strings and produced `invalid tag "//nebi:pr-308"` (run 25221907572 on #308).

Fall back to `localhost` / `fork-pr` when the vars are absent. Push is already gated off for fork PRs by #341, so the placeholder tag is only used for the local build + smoke test.