### PR TITLE
[DOC] Launching nebi-desktop from CLI

### DIFF
--- a/docs/docs/ui.md
+++ b/docs/docs/ui.md
@@ -2,7 +2,7 @@
 
 Nebi has a graphical interface you can use in two ways:
 
-- **Desktop app**: a locally-installed application, started from your system Application drawer. See [installation](./installation.md) for how to get it.
+- **Desktop app**: a locally-installed application, started from your system Application drawer or from the CLI with `nebi-desktop`. See [installation](./installation.md) for how to get it.
 - **Nebi server**: the web UI served by a running Nebi server at `http://localhost:8460`. See [Server Setup](./server-setup.md).
 
 The screenshots and instructions below apply to either option.


### PR DESCRIPTION
Document that Nebi Desktop can be launched from the CLI with `nebi-desktop`.

## What does this implement/fix?

Documentation Update

### Access-centered content checklist

#### Text styling

- [x] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [x] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [x] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [x] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [x] If there are emojis, there are not more than three in a row.
- [x] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [x] If the content were to be read as plain text, it still makes sense, and no information is missing.
