### PR TITLE
fix(desktop): re-apply SA_ONSTACK to survive WebKitGTK JSC signal handler clobbering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/swaggo/gin-swagger v1.6.1
 	github.com/swaggo/swag v1.16.6
 	github.com/valkey-io/valkey-go v1.0.67
-	github.com/wailsapp/wails/v2 v2.11.0
+	github.com/wailsapp/wails/v2 v2.12.0
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/crypto v0.43.0
 	golang.org/x/oauth2 v0.33.0
@@ -34,6 +34,7 @@ require (
 )
 
 require (
+	git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/bep/debounce v1.2.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3 h1:N3IGoHHp9pb6mj1cbXbuaSXV/UMKwmbKLf53nQmtqMA=
+git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3/go.mod h1:QtOLZGz8olr4qH2vWK0QH0w0O4T9fEIjMuWpKUsH7nc=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
@@ -265,8 +267,8 @@ github.com/wailsapp/go-webview2 v1.0.22 h1:YT61F5lj+GGaat5OB96Aa3b4QA+mybD0Ggq6N
 github.com/wailsapp/go-webview2 v1.0.22/go.mod h1:qJmWAmAmaniuKGZPWwne+uor3AHMB5PFhqiK0Bbj8kc=
 github.com/wailsapp/mimetype v1.4.1 h1:pQN9ycO7uo4vsUUuPeHEYoUkLVkaRntMnHJxVwYhwHs=
 github.com/wailsapp/mimetype v1.4.1/go.mod h1:9aV5k31bBOv5z6u+QP8TltzvNGJPmNJD4XlAL3U+j3o=
-github.com/wailsapp/wails/v2 v2.11.0 h1:seLacV8pqupq32IjS4Y7V8ucab0WZwtK6VvUVxSBtqQ=
-github.com/wailsapp/wails/v2 v2.11.0/go.mod h1:jrf0ZaM6+GBc1wRmXsM8cIvzlg0karYin3erahI4+0k=
+github.com/wailsapp/wails/v2 v2.12.0 h1:BHO/kLNWFHYjCzucxbzAYZWUjub1Tvb4cSguQozHn5c=
+github.com/wailsapp/wails/v2 v2.12.0/go.mod h1:mo1bzK1DEJrobt7YrBjgxvb5Sihb1mhAY09hppbibQg=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
 github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=

--- a/signal_fix_linux.go
+++ b/signal_fix_linux.go
@@ -1,0 +1,44 @@
+//go:build linux
+
+package main
+
+/*
+#include <signal.h>
+
+static void fix_signal_sa_onstack(int signum) {
+	struct sigaction st;
+	if (sigaction(signum, NULL, &st) < 0) return;
+	if (!(st.sa_flags & SA_ONSTACK)) {
+		st.sa_flags |= SA_ONSTACK;
+		sigaction(signum, &st, NULL);
+	}
+}
+
+static void fix_webkit_signal_handlers(void) {
+	fix_signal_sa_onstack(SIGSEGV);
+	fix_signal_sa_onstack(SIGBUS);
+	fix_signal_sa_onstack(SIGFPE);
+	fix_signal_sa_onstack(SIGILL);
+	fix_signal_sa_onstack(SIGABRT);
+}
+*/
+import "C"
+
+import "time"
+
+// WebKitGTK's JavaScriptCore installs SIGSEGV/SIGBUS handlers (used for GC
+// thread suspension and Wasm trap handling) without SA_ONSTACK, which Go's
+// runtime refuses to tolerate. Wails 2.12 runs install_signal_handlers() via
+// g_idle_add after gtk_init, but JSC installs its handlers lazily when the
+// first JavaScript context is created — usually after that idle pass. We
+// re-apply SA_ONSTACK on a short interval so JSC's late install gets corrected
+// regardless of when it lands.
+func init() {
+	go func() {
+		t := time.NewTicker(50 * time.Millisecond)
+		defer t.Stop()
+		for range t.C {
+			C.fix_webkit_signal_handlers()
+		}
+	}()
+}

--- a/signal_fix_linux.go
+++ b/signal_fix_linux.go
@@ -20,6 +20,7 @@ static void fix_webkit_signal_handlers(void) {
 	fix_signal_sa_onstack(SIGFPE);
 	fix_signal_sa_onstack(SIGILL);
 	fix_signal_sa_onstack(SIGABRT);
+	fix_signal_sa_onstack(SIGUSR1); // JSC GC thread sync — see wails#5507
 }
 */
 import "C"
@@ -33,6 +34,12 @@ import "time"
 // first JavaScript context is created — usually after that idle pass. We
 // re-apply SA_ONSTACK on a short interval so JSC's late install gets corrected
 // regardless of when it lands.
+//
+// REMOVE WHEN: wailsapp/wails#5507 ships in a tagged Wails release and we've
+// bumped to it. That PR adds an equivalent g_timeout_add_full re-fix loop +
+// a DomReady-hooked re-fix upstream, making this Go-side workaround redundant.
+// Upstream tracking: https://github.com/wailsapp/wails/issues/5506
+// Downstream tracking: https://github.com/nebari-dev/nebi/issues/350
 func init() {
 	go func() {
 		t := time.NewTicker(50 * time.Millisecond)


### PR DESCRIPTION
Fixes #350.

WebKitGTK's JavaScriptCore installs SIGSEGV/SIGBUS/SIGUSR1 handlers (for
GC thread suspension, write barriers, Wasm trap handling) without
SA_ONSTACK, which Go's runtime refuses to tolerate. Wails 2.12.0 added
a one-shot mitigation but JSC installs its handlers lazily on first JS
context creation — usually after that one-shot fix has already run.

This PR:
- bumps `wails/v2` from 2.11.0 → 2.12.0
- adds `signal_fix_linux.go`: a 50ms cgo ticker that re-applies SA_ONSTACK,
  doing explicitly what Go's runtime was doing accidentally via OS-thread
  `sigaction` calls (see issue #350 for the bisect that uncovered this)

Verified on Ubuntu 26.04 LTS + libwebkit2gtk-4.1 v2.52.3.

## Suggested follow-up: release after merge

The broken 0.10.5 and 0.11 linux-64 builds are being marked broken on
conda-forge via [conda-forge/admin-requests#2104](https://github.com/conda-forge/admin-requests/pull/2104).
Once that lands, `pixi global install nebi` on linux-64 will resolve to
0.10.4 (the last known-good release). Once this fix PR is merged we
should cut a new release (suggest **0.11.1** or **0.12**) so linux-64
users get a current `nebi-desktop` back rather than being pinned to
0.10.4 indefinitely.

## Removal of the workaround

Once [wailsapp/wails#5507](https://github.com/wailsapp/wails/pull/5507)
ships in a tagged Wails release and we bump to it, `signal_fix_linux.go`
can be deleted (the comment in that file documents this).
