### PR TITLE
refactor(service): RecomputeWorkspaceSize takes ID, writes only size_bytes

### DIFF
--- a/internal/service/workspace_worker.go
+++ b/internal/service/workspace_worker.go
@@ -119,23 +119,27 @@ func (s *WorkspaceService) CreateVersionSnapshot(ctx context.Context, ws *models
 	return nil
 }
 
-// UpdateWorkspaceSize calculates and updates the workspace size in the database.
-// Uses a column-scoped UPDATE rather than db.Save so a stale in-memory ws
-// cannot clobber other columns (see #294 for the path-clobber bug this avoids).
-func (s *WorkspaceService) UpdateWorkspaceSize(ws *models.Workspace) {
-	envPath := s.executor.GetWorkspacePath(ws)
-	sizeBytes, err := utils.GetDirectorySize(envPath)
-	if err != nil {
-		slog.Warn("Failed to calculate workspace size", "ws_id", ws.ID, "error", err)
-		return
+// RecomputeWorkspaceSize measures the workspace's on-disk size and persists it.
+// Loads the workspace fresh by ID so callers do not need to maintain an
+// up-to-date struct, and writes only the size_bytes column so other fields
+// cannot be clobbered (see #294 for the path-clobber bug this shape avoids).
+func (s *WorkspaceService) RecomputeWorkspaceSize(wsID uuid.UUID) error {
+	var ws models.Workspace
+	if err := s.db.First(&ws, "id = ?", wsID).Error; err != nil {
+		return fmt.Errorf("load workspace: %w", err)
 	}
 
-	if err := s.db.Model(&models.Workspace{}).Where("id = ?", ws.ID).Update("size_bytes", sizeBytes).Error; err != nil {
-		slog.Warn("Failed to update workspace size", "ws_id", ws.ID, "error", err)
-		return
+	envPath := s.executor.GetWorkspacePath(&ws)
+	sizeBytes, err := utils.GetDirectorySize(envPath)
+	if err != nil {
+		return fmt.Errorf("measure workspace dir: %w", err)
 	}
-	ws.SizeBytes = sizeBytes
-	slog.Info("Updated workspace size", "ws_id", ws.ID, "size", utils.FormatBytes(sizeBytes))
+
+	if err := s.db.Model(&models.Workspace{}).Where("id = ?", wsID).Update("size_bytes", sizeBytes).Error; err != nil {
+		return fmt.Errorf("update size_bytes: %w", err)
+	}
+	slog.Info("Updated workspace size", "ws_id", wsID, "size", utils.FormatBytes(sizeBytes))
+	return nil
 }
 
 // SetWorkspaceStatus updates the workspace status in the database.

--- a/internal/service/workspace_worker.go
+++ b/internal/service/workspace_worker.go
@@ -120,6 +120,8 @@ func (s *WorkspaceService) CreateVersionSnapshot(ctx context.Context, ws *models
 }
 
 // UpdateWorkspaceSize calculates and updates the workspace size in the database.
+// Uses a column-scoped UPDATE rather than db.Save so a stale in-memory ws
+// cannot clobber other columns (see #294 for the path-clobber bug this avoids).
 func (s *WorkspaceService) UpdateWorkspaceSize(ws *models.Workspace) {
 	envPath := s.executor.GetWorkspacePath(ws)
 	sizeBytes, err := utils.GetDirectorySize(envPath)
@@ -128,8 +130,11 @@ func (s *WorkspaceService) UpdateWorkspaceSize(ws *models.Workspace) {
 		return
 	}
 
+	if err := s.db.Model(&models.Workspace{}).Where("id = ?", ws.ID).Update("size_bytes", sizeBytes).Error; err != nil {
+		slog.Warn("Failed to update workspace size", "ws_id", ws.ID, "error", err)
+		return
+	}
 	ws.SizeBytes = sizeBytes
-	s.db.Save(ws)
 	slog.Info("Updated workspace size", "ws_id", ws.ID, "size", utils.FormatBytes(sizeBytes))
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -266,7 +266,9 @@ func (w *Worker) executeJob(ctx context.Context, job *models.Job, logWriter io.W
 			w.logger.Error("Failed to sync packages", "error", err)
 		}
 
-		w.svc.UpdateWorkspaceSize(ws)
+		if err := w.svc.RecomputeWorkspaceSize(ws.ID); err != nil {
+			w.logger.Warn("Failed to recompute workspace size", "error", err)
+		}
 		w.svc.SetWorkspaceStatus(ws.ID, models.WsStatusReady)
 
 		// Create version snapshot
@@ -285,7 +287,9 @@ func (w *Worker) executeJob(ctx context.Context, job *models.Job, logWriter io.W
 		}
 
 		w.svc.SaveInstalledPackages(ws.ID, packages)
-		w.svc.UpdateWorkspaceSize(ws)
+		if err := w.svc.RecomputeWorkspaceSize(ws.ID); err != nil {
+			w.logger.Warn("Failed to recompute workspace size", "error", err)
+		}
 
 		if err := w.svc.CreateVersionSnapshot(ctx, ws, job.ID, userID, fmt.Sprintf("Installed packages: %v", packages)); err != nil {
 			w.logger.Error("Failed to create version snapshot", "error", err)
@@ -302,7 +306,9 @@ func (w *Worker) executeJob(ctx context.Context, job *models.Job, logWriter io.W
 		}
 
 		w.svc.DeletePackagesByName(ws.ID, packages)
-		w.svc.UpdateWorkspaceSize(ws)
+		if err := w.svc.RecomputeWorkspaceSize(ws.ID); err != nil {
+			w.logger.Warn("Failed to recompute workspace size", "error", err)
+		}
 
 		if err := w.svc.CreateVersionSnapshot(ctx, ws, job.ID, userID, fmt.Sprintf("Removed packages: %v", packages)); err != nil {
 			w.logger.Error("Failed to create version snapshot", "error", err)
@@ -319,7 +325,9 @@ func (w *Worker) executeJob(ctx context.Context, job *models.Job, logWriter io.W
 			w.logger.Error("Failed to sync packages after solve", "error", err)
 		}
 
-		w.svc.UpdateWorkspaceSize(ws)
+		if err := w.svc.RecomputeWorkspaceSize(ws.ID); err != nil {
+			w.logger.Warn("Failed to recompute workspace size", "error", err)
+		}
 
 		if err := w.svc.CreateVersionSnapshot(ctx, ws, job.ID, userID, "Solved environment from updated pixi.toml"); err != nil {
 			w.logger.Error("Failed to create version snapshot", "error", err)
@@ -366,7 +374,9 @@ func (w *Worker) executeJob(ctx context.Context, job *models.Job, logWriter io.W
 			w.logger.Error("Failed to sync packages after rollback", "error", err)
 		}
 
-		w.svc.UpdateWorkspaceSize(ws)
+		if err := w.svc.RecomputeWorkspaceSize(ws.ID); err != nil {
+			w.logger.Warn("Failed to recompute workspace size after rollback", "error", err)
+		}
 
 		if err := w.svc.CreateVersionSnapshot(ctx, ws, job.ID, userID, fmt.Sprintf("Rolled back to version %d", version.VersionNumber)); err != nil {
 			w.logger.Error("Failed to create version snapshot after rollback", "error", err)


### PR DESCRIPTION
## Summary

Follow-up to #306. That PR fixed the symptom of #294 (workspace `path` clobbered after creation) by syncing the in-memory struct before `db.Save(ws)` runs. This PR removes the underlying footgun so the class of bug can't recur for any other column.

### Two changes

**1. Column-scoped write.** `UpdateWorkspaceSize` previously called `db.Save(ws)` — a full-row write driven by the in-memory struct. If anything else updated the row in the DB between `ws` being loaded at job start and this call (e.g. `SetWorkspacePath`, a future targeted update on another column, a concurrent admin write), the stale value on `ws` overwrote it. Switched to `db.Model(...).Where("id = ?", wsID).Update("size_bytes", sizeBytes)` so the function writes only the column it owns.

**2. Signature + rename to match the rest of the file.** `SetWorkspaceStatus(wsID, status)` and `SetWorkspacePath(wsID, path)` take an ID and return an error. The old `UpdateWorkspaceSize(ws *Workspace)` took a full struct and silently dropped errors. Now `RecomputeWorkspaceSize(wsID uuid.UUID) error`:
- Loads the workspace fresh inside the function — callers no longer maintain an up-to-date struct.
- Returns the error to the caller.
- Renamed because "Update" reads like a pure setter; "Recompute" better captures that the function measures the directory and persists the result.

The five worker callsites now log a warning on failure, matching the existing pattern around `SyncPackagesFromWorkspace` and `CreateVersionSnapshot`.

## Impact on #306

The in-memory `ws.Path = resolvedPath` line added there becomes defense-in-depth rather than load-bearing — the targeted update means `RecomputeWorkspaceSize` cannot clobber `path` (or any other column) even with a stale struct. Worth keeping for in-memory/DB consistency, but no longer the only thing preventing the regression.

## How to test

`go test ./internal/service/... ./internal/worker/...` — all existing tests pass, including the #294 regression test added in #306. `go build ./...` clean.