### PR TITLE
docs(home): show CLI before Web UI in demo section

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -42,19 +42,19 @@ function HomepageDemo() {
         </Heading>
         <div className={styles.demoGrid}>
           <div className={styles.demoItem}>
-            <Heading as="h3" className={styles.demoLabel}>Web UI</Heading>
+            <Heading as="h3" className={styles.demoLabel}>CLI</Heading>
             <img
-              src="https://raw.githubusercontent.com/nebari-dev/nebi-video-demo-automation/25e0139cf70cc0e9f8a2cf938fddd85ecd83adee/assets/demo.gif"
-              alt="Nebi Web UI Demo"
+              src="/nebi-demo.gif"
+              alt="Nebi CLI Demo"
               className={styles.demoImage}
               loading="lazy"
             />
           </div>
           <div className={styles.demoItem}>
-            <Heading as="h3" className={styles.demoLabel}>CLI</Heading>
+            <Heading as="h3" className={styles.demoLabel}>Web UI</Heading>
             <img
-              src="/nebi-demo.gif"
-              alt="Nebi CLI Demo"
+              src="https://raw.githubusercontent.com/nebari-dev/nebi-video-demo-automation/25e0139cf70cc0e9f8a2cf938fddd85ecd83adee/assets/demo.gif"
+              alt="Nebi Web UI Demo"
               className={styles.demoImage}
               loading="lazy"
             />


### PR DESCRIPTION
## Reference Issues or PRs

N/A

## What does this implement/fix?

- Swaps the order of the "See Nebi in Action" demos on the home page so the CLI appears first and the Web UI second.
- Leads with the CLI, which is the primary entry point for most users, before showing the Web UI experience.

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

Verified the new order renders correctly on the local Docusaurus dev server.