### PR TITLE
fix(rbac): drop redundant enforcer.SavePolicy() after grant/revoke

### DIFF
--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -96,11 +96,7 @@ func GrantWorkspaceAccess(userID uuid.UUID, wsID uuid.UUID, role string) error {
 	}
 
 	_, err := enforcer.AddPolicy(userID.String(), fmt.Sprintf("ws:%s", wsID.String()), action)
-	if err != nil {
-		return err
-	}
-
-	return enforcer.SavePolicy()
+	return err
 }
 
 // RevokeWorkspaceAccess revokes access to a workspace
@@ -111,29 +107,23 @@ func RevokeWorkspaceAccess(userID uuid.UUID, wsID uuid.UUID) error {
 
 	obj := fmt.Sprintf("ws:%s", wsID.String())
 
-	// Remove both read and write permissions
-	enforcer.RemovePolicy(userID.String(), obj, "read")
-	enforcer.RemovePolicy(userID.String(), obj, "write")
-
-	return enforcer.SavePolicy()
+	if _, err := enforcer.RemovePolicy(userID.String(), obj, "read"); err != nil {
+		return err
+	}
+	_, err := enforcer.RemovePolicy(userID.String(), obj, "write")
+	return err
 }
 
 // MakeAdmin grants admin privileges to a user
 func MakeAdmin(userID uuid.UUID) error {
 	_, err := enforcer.AddPolicy(userID.String(), "admin", "admin")
-	if err != nil {
-		return err
-	}
-	return enforcer.SavePolicy()
+	return err
 }
 
 // RevokeAdmin removes admin privileges from a user
 func RevokeAdmin(userID uuid.UUID) error {
 	_, err := enforcer.RemovePolicy(userID.String(), "admin", "admin")
-	if err != nil {
-		return err
-	}
-	return enforcer.SavePolicy()
+	return err
 }
 
 // GetAllAdminUserIDs returns a set of all user IDs that have admin privileges


### PR DESCRIPTION
## Summary

`AddPolicy` / `RemovePolicy` already persist via the adapter's AutoSave (enabled by default). The following `SavePolicy()` call is therefore unnecessary for correctness, but expensive: it deletes every row in `casbin_rule` and bulk-reinserts every policy from the in-memory model on every grant.

The custom in-tree adapter's `SavePolicy` confirms the cost:

https://github.com/nebari-dev/nebi/blob/0afe891/internal/rbac/adapter.go#L71-L92

And `AddPolicy` on the same adapter already does the single-row INSERT that AutoSave triggers:

https://github.com/nebari-dev/nebi/blob/0afe891/internal/rbac/adapter.go#L94-L97

Upstream guidance: https://casbin.apache.org/docs/adapters/#autosave

Discussed on #346.

## Changes

- Drop `enforcer.SavePolicy()` from `GrantWorkspaceAccess`, `RevokeWorkspaceAccess`, `MakeAdmin`, `RevokeAdmin`.
- Propagate the two previously-swallowed errors from `RemovePolicy` calls in `RevokeWorkspaceAccess`.