### PR TITLE
ci(desktop): smoke-test built binaries by launching them for 10s

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -50,12 +50,13 @@ jobs:
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 
-      # Linux dependencies for wails (Ubuntu 24.04 uses webkit2gtk-4.1)
+      # Linux dependencies for wails (Ubuntu 24.04 uses webkit2gtk-4.1).
+      # xvfb is needed for the post-build smoke test below.
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev xvfb
 
       - name: Build frontend
         shell: bash
@@ -94,6 +95,52 @@ jobs:
         with:
           name: nebi-windows
           path: build/bin/Nebi.exe
+
+      # Smoke test: launch the built binary and confirm it doesn't crash within
+      # 10s. Catches runtime regressions a build-only step misses — e.g. the
+      # WebKitGTK/JSC signal-handler SIGSEGV fixed in #351, which only triggers
+      # once the JS context lazy-inits at runtime.
+      - name: Smoke test (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          set +e
+          xvfb-run -a timeout 10 ./build/bin/Nebi
+          code=$?
+          set -e
+          # `timeout` exits 124 when it kills the still-running process, which
+          # is the success case here — the GUI is expected to stay alive.
+          if [ "$code" -ne 124 ]; then
+            echo "Smoke test failed: binary exited with code $code within 10s (expected 124)"
+            exit 1
+          fi
+          echo "Smoke test passed: binary stayed alive for 10s"
+
+      - name: Smoke test (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          open ./build/bin/Nebi.app
+          sleep 10
+          if pgrep -x Nebi > /dev/null; then
+            echo "Smoke test passed: binary stayed alive for 10s"
+            pkill -x Nebi || true
+          else
+            echo "Smoke test failed: Nebi.app exited or crashed within 10s"
+            exit 1
+          fi
+
+      - name: Smoke test (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $proc = Start-Process -FilePath "build/bin/Nebi.exe" -PassThru
+          Start-Sleep -Seconds 10
+          if (-not $proc.HasExited) {
+            Write-Host "Smoke test passed: binary stayed alive for 10s"
+            Stop-Process -Id $proc.Id
+          } else {
+            Write-Host "Smoke test failed: exited with code $($proc.ExitCode) within 10s"
+            exit 1
+          }
 
       # For releases: compress and upload to GitHub release
       - name: Compress for release (Linux)


### PR DESCRIPTION
## Summary
- Add a post-build smoke test on each OS that launches the built Nebi binary, waits 10s, and fails if it exited or crashed within that window.
- Catches runtime regressions that build-only CI misses — e.g. the WebKitGTK/JSC signal-handler SIGSEGV fixed in #351, which only triggered once the JS context lazy-inits.
- Runs *before* release upload, so a regression gates `v*` tag releases too, not just PRs.

## How each platform decides pass/fail
- **Linux** (`xvfb-run -a timeout 10 ./build/bin/Nebi`): success iff `timeout` exits 124 (still-running process killed at deadline). A SIGSEGV would exit 139, SIGBUS 138 — both fail.
- **macOS** (`open Nebi.app`, `pgrep -x Nebi` after 10s): success iff still running.
- **Windows** (`Start-Process -PassThru`, check `HasExited` after 10s): success iff false.

Adds `xvfb` to the Linux apt deps.

## Test plan
- [ ] Desktop CI runs on this PR and all three smoke-test steps pass
- [ ] Confirm Linux smoke step is the one that would have caught #350 (it would: pre-#351 the binary segfaulted within the first second on Ubuntu)
- [ ] No measurable slowdown on macOS/Windows builds beyond the added 10s