### PR TITLE
docs(home): equalize demo GIF heights

### DIFF
--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -72,9 +72,9 @@
 }
 
 .demoItem {
-  flex: 1;
-  min-width: 300px;
-  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .demoLabel {
@@ -83,7 +83,9 @@
 }
 
 .demoImage {
-  width: 100%;
+  height: 320px;
+  width: auto;
+  max-width: 100%;
   border-radius: 8px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -42,19 +42,19 @@ function HomepageDemo() {
         </Heading>
         <div className={styles.demoGrid}>
           <div className={styles.demoItem}>
-            <Heading as="h3" className={styles.demoLabel}>Web UI</Heading>
+            <Heading as="h3" className={styles.demoLabel}>CLI</Heading>
             <img
-              src="https://raw.githubusercontent.com/nebari-dev/nebi-video-demo-automation/25e0139cf70cc0e9f8a2cf938fddd85ecd83adee/assets/demo.gif"
-              alt="Nebi Web UI Demo"
+              src="/nebi-demo.gif"
+              alt="Nebi CLI Demo"
               className={styles.demoImage}
               loading="lazy"
             />
           </div>
           <div className={styles.demoItem}>
-            <Heading as="h3" className={styles.demoLabel}>CLI</Heading>
+            <Heading as="h3" className={styles.demoLabel}>Web UI</Heading>
             <img
-              src="/nebi-demo.gif"
-              alt="Nebi CLI Demo"
+              src="https://raw.githubusercontent.com/nebari-dev/nebi-video-demo-automation/25e0139cf70cc0e9f8a2cf938fddd85ecd83adee/assets/demo.gif"
+              alt="Nebi Web UI Demo"
               className={styles.demoImage}
               loading="lazy"
             />


### PR DESCRIPTION
## Reference Issues or PRs

None.

## What does this implement/fix?

- Makes the CLI and Web UI demo GIFs on the home page render at the same height, so the "See Nebi in Action" section looks balanced.
- Constrains the demo images by a fixed height with auto width (centered) instead of full width, preserving each GIF's aspect ratio with no cropping or stretching.

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

Ran the Docusaurus dev server and confirmed both GIFs share the same height, stay centered, and scale down cleanly on narrow viewports.