### PR TITLE
feat(auth): support separate OIDC discovery URL for back-channel calls

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -26,6 +26,14 @@ auth:
   # oidc_client_id: your-client-id.apps.googleusercontent.com
   # oidc_client_secret: your-client-secret
   # oidc_redirect_url: http://localhost:8460/api/v1/auth/oidc/callback
+  #
+  # Optional: separate discovery URL for split-horizon deployments where the
+  # issuer (the public URL browsers use, validated in the token's "iss" claim)
+  # is not reachable from where nebi runs. nebi fetches
+  # .well-known/openid-configuration from oidc_discovery_url while still
+  # validating "iss" against oidc_issuer_url. Defaults to oidc_issuer_url.
+  # Example (in-cluster Keycloak Service):
+  # oidc_discovery_url: http://keycloak-http.keycloak.svc.cluster.local/realms/nebari
 
 queue:
   type: memory  # or "valkey"

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -88,6 +88,7 @@ func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Exe
 		if cfg.Auth.OIDCIssuerURL != "" && cfg.Auth.OIDCClientID != "" {
 			oidcCfg := auth.OIDCConfig{
 				IssuerURL:    cfg.Auth.OIDCIssuerURL,
+				DiscoveryURL: cfg.Auth.OIDCDiscoveryURL,
 				ClientID:     cfg.Auth.OIDCClientID,
 				ClientSecret: cfg.Auth.OIDCClientSecret,
 				RedirectURL:  cfg.Auth.OIDCRedirectURL,

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -27,6 +27,7 @@ type OIDCAuthenticator struct {
 // OIDCConfig holds OIDC configuration
 type OIDCConfig struct {
 	IssuerURL    string
+	DiscoveryURL string
 	ClientID     string
 	ClientSecret string
 	RedirectURL  string
@@ -40,8 +41,24 @@ func NewOIDCAuthenticator(ctx context.Context, cfg OIDCConfig, db *gorm.DB, jwtS
 		ctx = context.Background()
 	}
 
-	// Discover OIDC provider configuration
-	provider, err := oidc.NewProvider(ctx, cfg.IssuerURL)
+	// Discover OIDC provider configuration.
+	//
+	// In split-horizon deployments (e.g. Keycloak behind an external gateway
+	// while pods reach it via an in-cluster Service) the URL nebi uses to fetch
+	// .well-known/openid-configuration differs from the issuer that appears in
+	// the token's "iss" claim. When DiscoveryURL is set we fetch discovery from
+	// it but keep validating "iss" against IssuerURL, using
+	// oidc.InsecureIssuerURLContext to tell go-oidc the two are intentionally
+	// different. When DiscoveryURL is empty the behavior is unchanged: discovery
+	// and issuer validation both use IssuerURL.
+	discoveryURL := cfg.DiscoveryURL
+	if discoveryURL != "" && discoveryURL != cfg.IssuerURL {
+		ctx = oidc.InsecureIssuerURLContext(ctx, cfg.IssuerURL)
+	} else {
+		discoveryURL = cfg.IssuerURL
+	}
+
+	provider, err := oidc.NewProvider(ctx, discoveryURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover OIDC provider: %w", err)
 	}

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -1,0 +1,67 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newDiscoveryServer starts a test server that serves an OIDC discovery
+// document advertising `issuer` regardless of the URL used to reach it. This
+// mimics a Keycloak that is reachable in-cluster at one URL while its tokens
+// carry the external (public) issuer.
+func newDiscoveryServer(t *testing.T, issuer string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		doc := map[string]any{
+			"issuer":                                issuer,
+			"authorization_endpoint":                issuer + "/protocol/openid-connect/auth",
+			"token_endpoint":                        srv.URL + "/protocol/openid-connect/token",
+			"jwks_uri":                              srv.URL + "/protocol/openid-connect/certs",
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(doc)
+	})
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestNewOIDCAuthenticator_DiscoveryURLAllowsIssuerMismatch verifies the
+// split-horizon case: discovery is fetched from an in-cluster URL while the
+// document advertises a different (public) issuer. Setting DiscoveryURL must
+// make this succeed; the issuer is still kept for "iss" validation.
+func TestNewOIDCAuthenticator_DiscoveryURLAllowsIssuerMismatch(t *testing.T) {
+	const publicIssuer = "https://keycloak.example.com/realms/nebari"
+	srv := newDiscoveryServer(t, publicIssuer)
+
+	cfg := OIDCConfig{
+		IssuerURL:    publicIssuer,
+		DiscoveryURL: srv.URL,
+		ClientID:     "nebi",
+	}
+	if _, err := NewOIDCAuthenticator(context.Background(), cfg, nil, "test-secret", nil); err != nil {
+		t.Fatalf("expected discovery via DiscoveryURL to succeed, got error: %v", err)
+	}
+}
+
+// TestNewOIDCAuthenticator_IssuerMismatchWithoutDiscoveryURLFails verifies the
+// default behavior is unchanged: with no DiscoveryURL, discovery is fetched
+// from IssuerURL and go-oidc still rejects an "iss" that does not match the
+// URL it was fetched from.
+func TestNewOIDCAuthenticator_IssuerMismatchWithoutDiscoveryURLFails(t *testing.T) {
+	const publicIssuer = "https://keycloak.example.com/realms/nebari"
+	srv := newDiscoveryServer(t, publicIssuer)
+
+	cfg := OIDCConfig{
+		IssuerURL: srv.URL, // document advertises publicIssuer, not srv.URL
+		ClientID:  "nebi",
+	}
+	if _, err := NewOIDCAuthenticator(context.Background(), cfg, nil, "test-secret", nil); err == nil {
+		t.Fatal("expected issuer mismatch to fail without DiscoveryURL, got nil error")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,7 @@ type AuthConfig struct {
 	Type               string `mapstructure:"type"`                  // "basic" or "oidc"
 	JWTSecret          string `mapstructure:"jwt_secret"`            // Secret for JWT signing
 	OIDCIssuerURL      string `mapstructure:"oidc_issuer_url"`       // OIDC provider issuer URL (e.g., https://accounts.google.com)
+	OIDCDiscoveryURL   string `mapstructure:"oidc_discovery_url"`    // Optional: URL for fetching .well-known/openid-configuration when it differs from the issuer (e.g. in-cluster Keycloak Service for back-channel calls); falls back to oidc_issuer_url when unset
 	OIDCClientID       string `mapstructure:"oidc_client_id"`        // OIDC client ID
 	OIDCClientSecret   string `mapstructure:"oidc_client_secret"`    // OIDC client secret
 	OIDCRedirectURL    string `mapstructure:"oidc_redirect_url"`     // OIDC redirect URL (e.g., http://localhost:8460/auth/oidc/callback)
@@ -97,6 +98,7 @@ func Load() (*Config, error) {
 	v.SetDefault("auth.type", "basic")
 	v.SetDefault("auth.jwt_secret", "change-me-in-production")
 	v.SetDefault("auth.oidc_issuer_url", "")
+	v.SetDefault("auth.oidc_discovery_url", "")
 	v.SetDefault("auth.oidc_client_id", "")
 	v.SetDefault("auth.oidc_client_secret", "")
 	v.SetDefault("auth.oidc_redirect_url", "http://localhost:8460/api/v1/auth/oidc/callback")
@@ -144,6 +146,7 @@ func Load() (*Config, error) {
 	_ = v.BindEnv("auth.type", "NEBI_AUTH_TYPE")
 	_ = v.BindEnv("auth.jwt_secret", "NEBI_AUTH_JWT_SECRET")
 	_ = v.BindEnv("auth.oidc_issuer_url", "NEBI_AUTH_OIDC_ISSUER_URL")
+	_ = v.BindEnv("auth.oidc_discovery_url", "NEBI_AUTH_OIDC_DISCOVERY_URL")
 	_ = v.BindEnv("auth.oidc_client_id", "NEBI_AUTH_OIDC_CLIENT_ID")
 	_ = v.BindEnv("auth.oidc_client_secret", "NEBI_AUTH_OIDC_CLIENT_SECRET")
 	_ = v.BindEnv("auth.oidc_redirect_url", "NEBI_AUTH_OIDC_REDIRECT_URL")


### PR DESCRIPTION
Closes #371

## What

Adds an optional `oidc_discovery_url` (`NEBI_AUTH_OIDC_DISCOVERY_URL`) that decouples where nebi fetches `.well-known/openid-configuration` from the issuer it validates in the token's `iss` claim.

## Why

In split-horizon deployments the public issuer URL that browsers use is not resolvable from inside the cluster. Today nebi uses a single `oidc_issuer_url` for both discovery and `iss` validation, so OIDC init fails on the discovery fetch and loops forever:

```
"msg":"OIDC initialization retry failed, will try again",
"error":"failed to discover OIDC provider: Get \"https://keycloak.<redacted>/realms/nebari/.well-known/openid-configuration\": dial tcp: lookup keycloak.<redacted> on 172.20.0.10:53: no such host"
```

This came up deploying the [nebari-nebi-pack](https://github.com/nebari-dev/nebari-nebi-pack) into a private cluster where Keycloak sits behind an external gateway (browsers can reach it, in-cluster pods can't). See nebari-dev/nebari-nebi-pack#13.

## How

When `oidc_discovery_url` is set, discovery is fetched from it (e.g. an in-cluster Keycloak `Service`) while `iss` is still validated against `oidc_issuer_url`, using `oidc.InsecureIssuerURLContext` to tell go-oidc the two are intentionally different. When unset, behavior is unchanged — discovery and issuer validation both use `oidc_issuer_url`.

```yaml
auth:
  oidc_issuer_url:    https://keycloak.example.com/realms/nebari            # public; validated in "iss"
  oidc_discovery_url: http://keycloak-http.keycloak.svc.cluster.local/realms/nebari  # in-cluster; discovery fetch
```

## Operator note

This is the same issuer-vs-discovery split that nebari-dev/nebari-operator#112 is tracking for the gateway's `SecurityPolicy.oidc`. This PR covers nebi's own direct OIDC (used by the CLI device-code flow); the two should stay consistent.

## Deployment caveat (not a code concern)

Discovery is necessary but not sufficient. After discovery, the endpoints in the document (`token_endpoint`, `jwks_uri`) are what nebi calls for code exchange and token verification. The IdP must return in-cluster-reachable URLs for those — for Keycloak that means `hostname-backchannel-dynamic=true` (`KC_HOSTNAME_STRICT_BACKCHANNEL=false`) so that fetching discovery via the internal URL echoes internal back-channel URLs. nebi leaves the endpoints as the IdP returns them.

## Tests

`internal/auth/oidc_test.go`:
- discovery via `DiscoveryURL` with a mismatched (public) issuer succeeds
- the default path (no `DiscoveryURL`) still rejects an `iss` that doesn't match the discovery URL

`go test ./internal/auth/...`, `go vet`, and `gofmt` all clean.

## Related Issues

- nebari-dev/nebari-nebi-pack#13
- 
