### PR TITLE
fix(auth): collapse leading-slash OIDC group paths to one group

### DIFF
--- a/internal/auth/group_sync.go
+++ b/internal/auth/group_sync.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/nebari-dev/nebi/internal/audit"
@@ -26,6 +27,12 @@ import (
 func SyncOIDCGroups(db *gorm.DB, userID uuid.UUID, claimGroups []string) error {
 	desired := make(map[string]struct{}, len(claimGroups))
 	for _, name := range claimGroups {
+		// Keycloak's group-membership mapper emits a leading-slash full path
+		// ("/developer") when full.path=true and the bare name ("developer")
+		// when false. A client can carry both mappers, so the same group
+		// arrives twice. Normalize to the bare name so the two forms collapse
+		// to one group instead of creating "/developer" and "developer".
+		name = strings.TrimPrefix(name, "/")
 		if name == "" {
 			continue
 		}

--- a/internal/auth/group_sync_test.go
+++ b/internal/auth/group_sync_test.go
@@ -52,6 +52,33 @@ func TestSyncOIDCGroups_CreatesGroupAndMembership(t *testing.T) {
 	}
 }
 
+func TestSyncOIDCGroups_StripsLeadingSlashAndDedups(t *testing.T) {
+	db := syncTestDB(t)
+	u := models.User{Username: "alice", Email: "alice@test"}
+	db.Create(&u)
+
+	// Keycloak can emit the same group twice in the `groups` claim: once as a
+	// full path ("/developer", from a full.path=true mapper) and once as the
+	// bare name ("developer"). Both refer to one group and must collapse.
+	if err := SyncOIDCGroups(db, u.ID, []string{"/developer", "developer"}); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	var groups []models.Group
+	db.Find(&groups)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group after dedup, got %d: %+v", len(groups), groups)
+	}
+	if groups[0].Name != "developer" {
+		t.Errorf("expected normalized name 'developer', got %q", groups[0].Name)
+	}
+
+	memberships, _ := rbac.GetUserGroups(u.ID)
+	if len(memberships) != 1 {
+		t.Fatalf("expected 1 casbin membership, got %d", len(memberships))
+	}
+}
+
 func TestSyncOIDCGroups_RemovesStaleMemberships(t *testing.T) {
 	db := syncTestDB(t)
 	u := models.User{Username: "alice", Email: "alice@test"}


### PR DESCRIPTION
When a Keycloak client carries both group-membership mappers (full.path=true → `/developer`, full.path=false → `developer`), the `groups` claim holds both forms and `SyncOIDCGroups` created two groups for one real group. Strip the leading `/` before upsert so they dedup to one. Adds a regression test.