### PR TITLE
fix: invalid CORS header combo blocks SPA load

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -486,11 +486,17 @@ func loggingMiddleware() gin.HandlerFunc {
 	}
 }
 
-// corsMiddleware adds CORS headers
+// corsMiddleware adds CORS headers.
+//
+// The API is reached with a bearer Authorization header (CLI and the
+// same-origin SPA), never with cross-origin cookies, so we do not set
+// Access-Control-Allow-Credentials. A credentialed response is required by the
+// CORS spec to name an explicit origin, and combining it with the "*" wildcard
+// is invalid: browsers reject any such response, which in turn blocks the SPA's
+// <script type="module" crossorigin> bundle from loading.
 func corsMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
-		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
 		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		// Prevent WebView (WKWebView) from caching API responses,

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/nebari-dev/nebi/internal/config"
+	"github.com/nebari-dev/nebi/internal/db"
+	"github.com/nebari-dev/nebi/internal/executor"
+	"github.com/nebari-dev/nebi/internal/queue"
+)
+
+// buildTestRouter builds the real production router (local mode, so RBAC init is
+// skipped) backed by an on-disk SQLite database, the in-memory queue, and the
+// local executor. Driving the actual router exercises the real CORS middleware
+// wiring and the real embedded-SPA static handler, not a hand-built stand-in.
+func buildTestRouter(t *testing.T, basePath string) http.Handler {
+	t.Helper()
+
+	cfg := &config.Config{Mode: "local"}
+	cfg.Server.BasePath = basePath
+	cfg.Auth.JWTSecret = "test-secret-for-router-test"
+	cfg.Database.Driver = "sqlite"
+	cfg.Database.DSN = filepath.Join(t.TempDir(), "router-test.db")
+
+	database, err := db.New(cfg.Database)
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+	if err := db.Migrate(database); err != nil {
+		t.Fatalf("db.Migrate: %v", err)
+	}
+
+	exec, err := executor.NewLocalExecutor(cfg)
+	if err != nil {
+		t.Fatalf("NewLocalExecutor: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return NewRouter(cfg, database, queue.NewMemoryQueue(16), exec, nil, nil, logger)
+}
+
+func TestCORSMiddlewareNoInvalidCredentialedWildcard(t *testing.T) {
+	r := buildTestRouter(t, "")
+
+	// /api/v1/health is a real public route; /assets/* flows through the real
+	// SPA static handler. Both pass through the global CORS middleware.
+	for _, path := range []string{"/api/v1/health", "/assets/index-abc123.js"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		acao := w.Header().Get("Access-Control-Allow-Origin")
+		acac := w.Header().Get("Access-Control-Allow-Credentials")
+
+		if acao == "*" && acac == "true" {
+			t.Fatalf("%s: invalid CORS combo: ACAO=%q ACAC=%q (wildcard origin cannot be credentialed)", path, acao, acac)
+		}
+		if acao == "" {
+			t.Fatalf("%s: expected Access-Control-Allow-Origin to be set, got empty", path)
+		}
+		if acac != "" {
+			t.Fatalf("%s: expected no Access-Control-Allow-Credentials, got %q", path, acac)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #384.

`corsMiddleware` set both `Access-Control-Allow-Origin: *` and `Access-Control-Allow-Credentials: true`. That combination is invalid per the CORS spec, so browsers reject the response. Behind a gateway this blocks the SPA's `<script type="module" crossorigin>` bundle from loading, leaving users in a `/login` reload loop.

The API is reached with a bearer `Authorization` header (CLI and same-origin SPA), never cross-origin cookies, so the credentials header buys nothing. Removed it; kept the wildcard origin.

`*` without credentials is safe here: a cross-origin browser request defaults to no-credentials, so the OIDC IdToken cookie is never sent and only unauthenticated endpoints are reachable cross-origin.

Test drives the real `NewRouter` (real CORS wiring + embedded-SPA static handler) and asserts the invalid combo is gone; verified it fails on the old behavior.

The `Cache-Control: no-store` on static assets noted in the issue is left for a separate change.