### PR TITLE
fix(frontend): show group shares in Collaborators tab

### DIFF
--- a/frontend/src/components/sharing/CollaboratorsList.test.tsx
+++ b/frontend/src/components/sharing/CollaboratorsList.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { Collaborator } from '@/types/models';
+import { CollaboratorsList } from './CollaboratorsList';
+
+const owner: Collaborator = {
+  kind: 'user',
+  user_id: 'u-1',
+  username: 'alice',
+  email: 'alice@example.com',
+  role: 'owner',
+  is_owner: true,
+};
+
+const groupViewer: Collaborator = {
+  kind: 'group',
+  group_id: 'g-1',
+  name: 'admin',
+  source: 'oidc',
+  role: 'viewer',
+  is_owner: false,
+};
+
+describe('CollaboratorsList', () => {
+  it('renders user collaborators', () => {
+    render(<CollaboratorsList collaborators={[owner]} />);
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Owner')).toBeInTheDocument();
+  });
+
+  it('renders group collaborators alongside users', () => {
+    render(<CollaboratorsList collaborators={[owner, groupViewer]} />);
+    // The group name and its source label must be visible.
+    expect(screen.getByText('admin')).toBeInTheDocument();
+    expect(screen.getByText('OIDC group')).toBeInTheDocument();
+    expect(screen.getByText('Viewer')).toBeInTheDocument();
+  });
+
+  it('labels native groups distinctly from OIDC groups', () => {
+    render(
+      <CollaboratorsList
+        collaborators={[{ ...groupViewer, source: 'native', name: 'devs' }]}
+      />,
+    );
+    expect(screen.getByText('devs')).toBeInTheDocument();
+    expect(screen.getByText('Native group')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when there are no collaborators', () => {
+    render(<CollaboratorsList collaborators={[]} />);
+    expect(screen.getByText('No collaborators yet')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/sharing/CollaboratorsList.tsx
+++ b/frontend/src/components/sharing/CollaboratorsList.tsx
@@ -1,0 +1,57 @@
+import type { Collaborator } from '@/types/models';
+import { RoleBadge } from './RoleBadge';
+
+interface CollaboratorsListProps {
+  collaborators: Collaborator[];
+}
+
+/**
+ * Read-only list of everyone with access to a workspace: both individual users
+ * and shared groups. The Share dialog renders the same data with extra controls
+ * (remove buttons); this view is display-only for the Collaborators tab.
+ */
+export const CollaboratorsList = ({
+  collaborators,
+}: CollaboratorsListProps) => {
+  if (collaborators.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground text-center py-8">
+        No collaborators yet
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {collaborators.map((collab) =>
+        collab.kind === 'user' ? (
+          <div
+            key={`u-${collab.user_id}`}
+            className="flex justify-between items-center p-3 rounded-lg border"
+          >
+            <div className="flex-1">
+              <div className="font-medium">{collab.username}</div>
+              <div className="text-sm text-muted-foreground">
+                {collab.email}
+              </div>
+            </div>
+            <RoleBadge role={collab.role} />
+          </div>
+        ) : (
+          <div
+            key={`g-${collab.group_id}`}
+            className="flex justify-between items-center p-3 rounded-lg border"
+          >
+            <div className="flex-1">
+              <div className="font-medium">{collab.name}</div>
+              <div className="text-sm text-muted-foreground">
+                {collab.source === 'oidc' ? 'OIDC group' : 'Native group'}
+              </div>
+            </div>
+            <RoleBadge role={collab.role} />
+          </div>
+        ),
+      )}
+    </div>
+  );
+};

--- a/frontend/src/pages/WorkspaceDetail.tsx
+++ b/frontend/src/pages/WorkspaceDetail.tsx
@@ -27,7 +27,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { workspacesApi } from '@/api/workspaces';
 import { Jobs } from '@/components/jobs/Jobs';
 import { PublishButton } from '@/components/publishing/PublishButton';
-import { RoleBadge } from '@/components/sharing/RoleBadge';
+import { CollaboratorsList } from '@/components/sharing/CollaboratorsList';
 import { ShareButton } from '@/components/sharing/ShareButton';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -260,7 +260,7 @@ export const WorkspaceDetail = () => {
           </TabsTrigger>
           {!isLocalWs && !isLocalMode && (
             <TabsTrigger value="collaborators">
-              Collaborators ({userCollaborators?.length || 0})
+              Collaborators ({collaborators?.length || 0})
             </TabsTrigger>
           )}
         </TabsList>
@@ -843,27 +843,7 @@ export const WorkspaceDetail = () => {
                 View all collaborators for this workspace
               </p>
             </div>
-            <div className="space-y-2">
-              {userCollaborators?.map((collab) => (
-                <div
-                  key={collab.user_id}
-                  className="flex justify-between items-center p-3 rounded-lg border"
-                >
-                  <div className="flex-1">
-                    <div className="font-medium">{collab.username}</div>
-                    <div className="text-sm text-muted-foreground">
-                      {collab.email}
-                    </div>
-                  </div>
-                  <RoleBadge role={collab.role} />
-                </div>
-              ))}
-            </div>
-            {(!userCollaborators || userCollaborators.length === 0) && (
-              <p className="text-sm text-muted-foreground text-center py-8">
-                No collaborators yet
-              </p>
-            )}
+            <CollaboratorsList collaborators={collaborators || []} />
           </TabsContent>
         )}
       </Tabs>


### PR DESCRIPTION
## Problem

Sharing a workspace with a group added the group to the backend grants and showed it in the Share dialog's "Current Access" list, but the **Collaborators tab** on the workspace detail page rendered nothing for that group. The tab fetched both user and group grants, then only mapped over the user list, so groups were silently dropped (and the tab count excluded them).

## Fix

- Add a read-only `CollaboratorsList` component that renders both users and groups. Group rows show the group name, its source (`Native group` / `OIDC group`), and the role badge, matching how the Share dialog already presents groups.
- Use it in the Collaborators tab in place of the user-only map.
- Base the tab count on the full collaborator list instead of just users.

Backend (`GET /workspaces/{id}/collaborators`) already returned groups, so no server change was needed.

## Tests

New `CollaboratorsList.test.tsx`: renders user rows, renders group rows alongside users, distinguishes native vs OIDC group labels, and shows the empty state.