### PR TITLE
info: show resolved workspaces storage dir

### DIFF
--- a/cmd/nebi/e2e_test.go
+++ b/cmd/nebi/e2e_test.go
@@ -2004,3 +2004,34 @@ func TestE2E_InfoNoServer(t *testing.T) {
 		t.Errorf("expected 'Logged in: no', got: %s", res.Stdout)
 	}
 }
+
+func TestE2E_InfoWorkspacesDir(t *testing.T) {
+	dir := t.TempDir()
+
+	wsDir := filepath.Join(dir, "ws-storage")
+	os.Setenv("NEBI_STORAGE_WORKSPACES_DIR", wsDir)
+	defer os.Unsetenv("NEBI_STORAGE_WORKSPACES_DIR")
+
+	res := runCLI(t, dir, "info")
+	if res.ExitCode != 0 {
+		t.Fatalf("info failed (exit %d):\nstdout: %s\nstderr: %s", res.ExitCode, res.Stdout, res.Stderr)
+	}
+	if !strings.Contains(res.Stdout, "Workspaces dir") {
+		t.Errorf("expected 'Workspaces dir' field in output, got: %s", res.Stdout)
+	}
+	if !strings.Contains(res.Stdout, wsDir) {
+		t.Errorf("expected workspaces dir %q in output, got: %s", wsDir, res.Stdout)
+	}
+
+	res = runCLI(t, dir, "info", "--json")
+	if res.ExitCode != 0 {
+		t.Fatalf("info --json failed (exit %d):\nstdout: %s\nstderr: %s", res.ExitCode, res.Stdout, res.Stderr)
+	}
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(res.Stdout), &result); err != nil {
+		t.Fatalf("failed to parse JSON output: %v\nstdout: %s", err, res.Stdout)
+	}
+	if result["workspaces_dir"] != wsDir {
+		t.Errorf("expected workspaces_dir=%q, got: %v", wsDir, result["workspaces_dir"])
+	}
+}

--- a/cmd/nebi/info.go
+++ b/cmd/nebi/info.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/nebari-dev/nebi/internal/cliclient"
+	"github.com/nebari-dev/nebi/internal/config"
 	"github.com/nebari-dev/nebi/internal/store"
 	"github.com/spf13/cobra"
 )
@@ -36,9 +37,10 @@ Examples:
 
 type infoResult struct {
 	// Nebi section
-	Version  string `json:"version"`
-	Platform string `json:"platform"`
-	DataDir  string `json:"data_dir"`
+	Version       string `json:"version"`
+	Platform      string `json:"platform"`
+	DataDir       string `json:"data_dir"`
+	WorkspacesDir string `json:"workspaces_dir,omitempty"`
 
 	// Server section
 	ServerURL      string `json:"server_url"`
@@ -71,6 +73,13 @@ func runInfo(cmd *cobra.Command, args []string) error {
 	if err == nil {
 		home, _ := os.UserHomeDir()
 		result.DataDir = shortenPath(dataDir, home)
+	}
+
+	// Workspaces dir — same resolution `nebi serve` uses (config file,
+	// NEBI_STORAGE_WORKSPACES_DIR, or the built-in default)
+	if cfg, err := config.Load(); err == nil && cfg.Storage.WorkspacesDir != "" {
+		home, _ := os.UserHomeDir()
+		result.WorkspacesDir = shortenPath(cfg.Storage.WorkspacesDir, home)
 	}
 
 	// Resolve server URL, token, username from local sources (no API calls)
@@ -228,6 +237,9 @@ func printInfo(r infoResult) {
 	printField("Version", r.Version)
 	printField("Platform", r.Platform)
 	printField("Data dir", r.DataDir)
+	if r.WorkspacesDir != "" {
+		printField("Workspaces dir", r.WorkspacesDir)
+	}
 
 	fmt.Println()
 	fmt.Println("Server")


### PR DESCRIPTION
Adds a Workspaces dir field to the Nebi section of nebi info (and workspaces_dir in --json). The value is resolved the same way nebi serve resolves it: config file, then NEBI_STORAGE_WORKSPACES_DIR, then the built-in default. Useful for deployments that relocate workspace storage to a dedicated volume and want to confirm the active path from inside a session.