### PR TITLE
use HEAD sha for docker tag on PR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,8 @@ jobs:
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        env:
+          DOCKER_METADATA_PR_HEAD_SHA: true
         with:
           images: ${{ env.REGISTRY }}/${{ env.PROJECT }}/${{ env.IMAGE_NAME }}
           tags: |


### PR DESCRIPTION
By default, the commit in Github Action on PRs is a merge commit of the PR branch into its target, e.g. `main`. This means that by default the SHA inside the workflow does not match the HEAD on the branch. For the version computation we are correctly checking out the branch HEAD

https://github.com/nebari-dev/nebi/blob/18d3e59e914b89c70e384dfe1f82b2930030e772/.github/workflows/docker.yml#L25-L28

However, this is not respected by the docker-metadata action

https://github.com/nebari-dev/nebi/blob/18d3e59e914b89c70e384dfe1f82b2930030e772/.github/workflows/docker.yml#L45-L53

This PR fixes this by setting the [`DOCKER_METADATA_PR_HEAD_SHA=true` environment variable](https://github.com/docker/metadata-action#environment-variables).