### PR TITLE
Preserve hand-edited pixi.toml fields in UI mode

### DIFF
--- a/frontend/src/components/workspace/PixiTomlEditor.test.tsx
+++ b/frontend/src/components/workspace/PixiTomlEditor.test.tsx
@@ -1,0 +1,45 @@
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@/test/utils';
+import { PixiTomlEditor } from './PixiTomlEditor';
+
+const customPixiToml = `# hand-written project note
+[workspace]
+name = "demo"
+channels = ["conda-forge", "bioconda"]
+platforms = ["linux-64"]
+
+[dependencies]
+python = ">=3.11"
+
+[tasks]
+hello = "echo hello"
+`;
+
+describe('PixiTomlEditor', () => {
+  it('preserves hand-edited TOML content when UI mode adds a package', async () => {
+    const user = userEvent.setup();
+    let latestToml = customPixiToml;
+
+    render(
+      <PixiTomlEditor
+        tomlValue={customPixiToml}
+        onTomlChange={(value) => {
+          latestToml = value;
+        }}
+        workspaceName="demo"
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /ui mode/i }));
+    await user.type(screen.getByPlaceholderText(/package name/i), 'numpy');
+    await user.click(screen.getByRole('button', { name: /add package/i }));
+
+    expect(latestToml).toContain('# hand-written project note');
+    expect(latestToml).toContain('channels = ["conda-forge", "bioconda"]');
+    expect(latestToml).toContain('platforms = ["linux-64"]');
+    expect(latestToml).toContain('[tasks]');
+    expect(latestToml).toContain('hello = "echo hello"');
+    expect(latestToml).toContain('numpy = "*"');
+  });
+});

--- a/frontend/src/components/workspace/PixiTomlEditor.tsx
+++ b/frontend/src/components/workspace/PixiTomlEditor.tsx
@@ -38,31 +38,165 @@ ${dependenciesLines || 'python = ">=3.11"'}
 `;
 };
 
-const parsePixiTomlDependencies = (toml: string): Package[] => {
-  const lines = toml.split('\n');
-  const packages: Package[] = [];
-  let inDependencies = false;
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-
-    if (trimmed === '[dependencies]') {
-      inDependencies = true;
+const findSectionRange = (
+  lines: string[],
+  sectionNames: string[],
+): { start: number; end: number } | null => {
+  for (let index = 0; index < lines.length; index++) {
+    const tableMatch = lines[index].match(/^\s*\[([^[\]]+)\]\s*(?:#.*)?$/);
+    if (!tableMatch || !sectionNames.includes(tableMatch[1].trim())) {
       continue;
     }
 
-    if (inDependencies && trimmed.startsWith('[')) {
-      break;
+    let end = lines.length;
+    for (let next = index + 1; next < lines.length; next++) {
+      if (/^\s*\[+.+\]\s*(?:#.*)?$/.test(lines[next])) {
+        end = next;
+        break;
+      }
     }
 
-    if (inDependencies && trimmed && !trimmed.startsWith('#')) {
-      const match = trimmed.match(/^([^\s=]+)\s*=\s*"([^"]*)"$/);
-      if (match) {
-        packages.push({
-          name: match[1],
-          version: match[2] === '*' ? '' : match[2],
-        });
-      }
+    return { start: index, end };
+  }
+
+  return null;
+};
+
+const parseDependencyLine = (
+  line: string,
+): {
+  indent: string;
+  name: string;
+  version: string;
+  comment: string;
+} | null => {
+  const match = line.match(/^(\s*)([^\s=#]+)\s*=\s*"([^"]*)"\s*(#.*)?$/);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    indent: match[1],
+    name: match[2],
+    version: match[3],
+    comment: match[4] ? ` ${match[4].trimStart()}` : '',
+  };
+};
+
+const formatDependencyLine = (
+  pkg: Package,
+  indent = '',
+  comment = '',
+): string => {
+  const name = pkg.name.trim();
+  const version = pkg.version.trim() || '*';
+  return `${indent}${name} = "${version}"${comment}`;
+};
+
+const patchPixiTomlDependencies = (
+  toml: string,
+  packages: Package[],
+): string => {
+  const lines = toml.split(/\r?\n/);
+  const desiredByName = new Map(packages.map((pkg) => [pkg.name, pkg]));
+  const sectionRange = findSectionRange(lines, ['dependencies']);
+
+  if (!sectionRange) {
+    if (packages.length === 0) {
+      return toml;
+    }
+
+    const nextLines = toml ? [...lines] : [];
+    if (nextLines.length > 0 && nextLines[nextLines.length - 1] !== '') {
+      nextLines.push('');
+    }
+    nextLines.push(
+      '[dependencies]',
+      ...packages.map((pkg) => formatDependencyLine(pkg)),
+    );
+    return nextLines.join('\n');
+  }
+
+  const emittedNames = new Set<string>();
+  const patchedSectionLines: string[] = [];
+
+  for (const line of lines.slice(sectionRange.start + 1, sectionRange.end)) {
+    const dependency = parseDependencyLine(line);
+    if (!dependency) {
+      patchedSectionLines.push(line);
+      continue;
+    }
+
+    const desiredPackage = desiredByName.get(dependency.name);
+    if (!desiredPackage) {
+      continue;
+    }
+
+    patchedSectionLines.push(
+      formatDependencyLine(
+        desiredPackage,
+        dependency.indent,
+        dependency.comment,
+      ),
+    );
+    emittedNames.add(dependency.name);
+  }
+
+  const newDependencyLines = packages
+    .filter((pkg) => !emittedNames.has(pkg.name))
+    .map((pkg) => formatDependencyLine(pkg));
+
+  if (newDependencyLines.length > 0) {
+    let insertAt = patchedSectionLines.length;
+    while (insertAt > 0 && patchedSectionLines[insertAt - 1].trim() === '') {
+      insertAt--;
+    }
+    patchedSectionLines.splice(insertAt, 0, ...newDependencyLines);
+  }
+
+  return [
+    ...lines.slice(0, sectionRange.start + 1),
+    ...patchedSectionLines,
+    ...lines.slice(sectionRange.end),
+  ].join('\n');
+};
+
+const patchPixiTomlWorkspaceName = (toml: string, workspaceName: string) => {
+  const lines = toml.split(/\r?\n/);
+  const sectionRange = findSectionRange(lines, ['workspace', 'project']);
+  const nameLine = `name = "${workspaceName}"`;
+
+  if (!sectionRange) {
+    return toml;
+  }
+
+  const nextLines = [...lines];
+  for (let index = sectionRange.start + 1; index < sectionRange.end; index++) {
+    const nameMatch = nextLines[index].match(/^(\s*)name\s*=.*?(\s+#.*)?$/);
+    if (nameMatch) {
+      nextLines[index] = `${nameMatch[1]}${nameLine}${nameMatch[2] ?? ''}`;
+      return nextLines.join('\n');
+    }
+  }
+
+  return toml;
+};
+
+const parsePixiTomlDependencies = (toml: string): Package[] => {
+  const lines = toml.split(/\r?\n/);
+  const packages: Package[] = [];
+  const sectionRange = findSectionRange(lines, ['dependencies']);
+  if (!sectionRange) {
+    return packages;
+  }
+
+  for (const line of lines.slice(sectionRange.start + 1, sectionRange.end)) {
+    const dependency = parseDependencyLine(line);
+    if (dependency) {
+      packages.push({
+        name: dependency.name,
+        version: dependency.version === '*' ? '' : dependency.version,
+      });
     }
   }
 
@@ -141,6 +275,14 @@ export const PixiTomlEditor = ({
     await performSwitch(pendingModeRef.current);
   };
 
+  const getCurrentToml = () => {
+    return (
+      tomlValue ||
+      initialTomlRef.current ||
+      buildPixiToml(packages, workspaceName || 'my-project')
+    );
+  };
+
   const handleAddPackage = () => {
     if (!newPackageName.trim()) return;
     const updated = [
@@ -151,14 +293,14 @@ export const PixiTomlEditor = ({
     setDirty(true);
     setNewPackageName('');
     setNewPackageVersion('');
-    onTomlChange(buildPixiToml(updated, workspaceName || 'my-project'));
+    onTomlChange(patchPixiTomlDependencies(getCurrentToml(), updated));
   };
 
   const handleRemovePackage = (index: number) => {
     const updated = packages.filter((_, i) => i !== index);
     setPackages(updated);
     setDirty(true);
-    onTomlChange(buildPixiToml(updated, workspaceName || 'my-project'));
+    onTomlChange(patchPixiTomlDependencies(getCurrentToml(), updated));
   };
 
   const handleTomlEdit = (value: string) => {
@@ -216,8 +358,10 @@ export const PixiTomlEditor = ({
               value={workspaceName || 'my-project'}
               onChange={(e) => {
                 const newName = e.target.value;
-                const updated = buildPixiToml(packages, newName);
-                onTomlChange(updated);
+                setDirty(true);
+                onTomlChange(
+                  patchPixiTomlWorkspaceName(getCurrentToml(), newName),
+                );
               }}
               placeholder="Workspace name"
               className="font-mono"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
Fixes #410 

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [x] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

Fixes UI Mode edits in the workspace TOML editor so package and workspace-name changes patch only the fields owned by the UI instead of regenerating the entire `pixi.toml`. This preserves hand-edited content such as custom channels, platforms, comments, and tasks.
Added a regression test covering the issue where adding a package in UI Mode previously removed custom TOML content. Verified with the focused Vitest test and Biome check.

### Before

https://github.com/user-attachments/assets/54d9013a-94d1-445d-b1cf-01a998184fcc

### After

https://github.com/user-attachments/assets/063ecf45-d95d-4643-8fc4-86b7e0e85ca1

