### PR TITLE
Fix TOML discard mode switch

### DIFF
--- a/frontend/src/components/workspace/PixiTomlEditor.test.tsx
+++ b/frontend/src/components/workspace/PixiTomlEditor.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '@/test/utils';
+import { PixiTomlEditor } from './PixiTomlEditor';
+
+const DEFAULT_PIXI_TOML = `[workspace]
+name = ""
+channels = ["conda-forge"]
+platforms = ["osx-arm64", "linux-64"]
+
+[dependencies]
+python = ">=3.11"
+`;
+
+const getTomlName = (toml: string): string | null => {
+  const match = toml.match(/^name\s*=\s*"([^"]*)"/m);
+  return match ? match[1] : null;
+};
+
+function renderEditor() {
+  const EditorHarness = () => {
+    const [toml, setToml] = useState(DEFAULT_PIXI_TOML);
+
+    return (
+      <PixiTomlEditor
+        tomlValue={toml}
+        onTomlChange={setToml}
+        workspaceName={getTomlName(toml) || ''}
+      />
+    );
+  };
+
+  renderWithProviders(<EditorHarness />);
+}
+
+describe('PixiTomlEditor', () => {
+  it('discards TOML changes immediately when switching to UI mode', async () => {
+    const user = userEvent.setup();
+    renderEditor();
+
+    fireEvent.change(
+      screen.getByPlaceholderText('Enter your pixi.toml content'),
+      {
+        target: {
+          value: DEFAULT_PIXI_TOML.replace('name = ""', 'name = "edited"'),
+        },
+      },
+    );
+
+    await user.click(screen.getByRole('button', { name: /ui mode/i }));
+    await user.click(screen.getByRole('button', { name: /discard changes/i }));
+
+    expect(screen.getByPlaceholderText('Workspace name')).toHaveValue('');
+
+    await user.click(screen.getByRole('button', { name: /toml mode/i }));
+
+    expect(
+      screen.getByPlaceholderText('Enter your pixi.toml content'),
+    ).toHaveValue(DEFAULT_PIXI_TOML);
+  });
+});

--- a/frontend/src/components/workspace/PixiTomlEditor.tsx
+++ b/frontend/src/components/workspace/PixiTomlEditor.tsx
@@ -99,22 +99,30 @@ export const PixiTomlEditor = ({
     }
   }, [tomlValue, initialized]);
 
-  const performSwitch = async (newMode: 'ui' | 'toml') => {
-    if (newMode === 'toml') {
+  const performSwitch = async (
+    newMode: 'ui' | 'toml',
+    discardChanges = false,
+  ) => {
+    let source = onReloadToml ? tomlValue : initialTomlRef.current;
+
+    if (newMode === 'toml' || discardChanges) {
       if (onReloadToml) {
         setSwitching(true);
         try {
           const freshToml = await onReloadToml();
           onTomlChange(freshToml);
           initialTomlRef.current = freshToml;
+          source = freshToml;
         } finally {
           setSwitching(false);
         }
       } else {
-        onTomlChange(initialTomlRef.current);
+        source = initialTomlRef.current;
+        onTomlChange(source);
       }
-    } else {
-      const source = onReloadToml ? tomlValue : initialTomlRef.current;
+    }
+
+    if (newMode === 'ui') {
       const parsed = parsePixiTomlDependencies(source);
       if (parsed.length > 0) {
         setPackages(parsed);
@@ -138,7 +146,7 @@ export const PixiTomlEditor = ({
 
   const handleConfirmDiscard = async () => {
     setShowDiscardPrompt(false);
-    await performSwitch(pendingModeRef.current);
+    await performSwitch(pendingModeRef.current, true);
   };
 
   const handleAddPackage = () => {


### PR DESCRIPTION
## Reference Issues or PRs
Fixes #411 

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [x] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

Fixes the create-workspace TOML/UI mode switch so confirming “Discard changes” restores the original TOML immediately instead of leaving stale edits visible in UI mode until the next switch.

### Before


https://github.com/user-attachments/assets/979429ce-cbe7-4b80-9ea7-9ad7aa6d9cf5

### After


https://github.com/user-attachments/assets/5ce37531-1e3e-4a28-b522-43225ee29d55

