### PR TITLE
only poll remote server from frontend in local mode

### DIFF
--- a/frontend/src/hooks/useRemote.test.ts
+++ b/frontend/src/hooks/useRemote.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { HttpResponse, http } from 'msw';
 import { beforeEach, describe, expect, it } from 'vitest';
+import { useModeStore } from '@/store/modeStore';
 import {
   mockJob,
   mockRegistry,
@@ -35,6 +36,7 @@ const mockRemoteWorkspace = {
 
 describe('useRemoteServer', () => {
   beforeEach(() => {
+    useModeStore.setState({ mode: 'local' });
     server.use(
       http.get('/api/v1/remote/server', () =>
         HttpResponse.json(mockRemoteServer),

--- a/frontend/src/hooks/useRemote.test.ts
+++ b/frontend/src/hooks/useRemote.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { HttpResponse, http } from 'msw';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { useModeStore } from '@/store/modeStore';
 import { useViewModeStore } from '@/store/viewModeStore';
 import {
@@ -138,11 +138,25 @@ describe('useRemoteView', () => {
 
 describe('useRemoteServer', () => {
   beforeEach(() => {
+    useModeStore.setState({ mode: 'local', features: {}, loading: false });
     server.use(
       http.get('/api/v1/remote/server', () =>
         HttpResponse.json(mockRemoteServer),
       ),
     );
+  });
+
+  afterEach(() => {
+    useModeStore.setState({ mode: null, features: {}, loading: true });
+  });
+
+  it('does not fetch in team mode', async () => {
+    useModeStore.setState({ mode: 'team', features: {}, loading: false });
+    const { result } = renderHook(() => useRemoteServer(), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(result.current.isPending).toBe(true);
   });
 
   it('fetches remote server info', async () => {

--- a/frontend/src/hooks/useRemote.ts
+++ b/frontend/src/hooks/useRemote.ts
@@ -1,15 +1,18 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { remoteApi } from '@/api/remote';
+import { useModeStore } from '@/store/modeStore';
 import type {
   ConnectServerRequest,
   CreateRemoteWorkspaceRequest,
 } from '@/types';
 
 export const useRemoteServer = () => {
+  const isLocalMode = useModeStore((s) => s.isLocalMode());
   return useQuery({
     queryKey: ['remote', 'server'],
     queryFn: remoteApi.getServer,
     refetchInterval: 10000, // Check connection status every 10s
+    enabled: isLocalMode,
   });
 };
 

--- a/frontend/src/hooks/useRemote.ts
+++ b/frontend/src/hooks/useRemote.ts
@@ -38,6 +38,7 @@ export const retryWhileUnreachable = ({
 }) => (state.status === 'error' ? ERROR_BACKOFF_INTERVAL : false);
 
 export const useRemoteServer = () => {
+  const isLocalMode = useModeStore((s) => s.isLocalMode());
   return useQuery({
     queryKey: ['remote', 'server'],
     queryFn: remoteApi.getServer,
@@ -46,6 +47,9 @@ export const useRemoteServer = () => {
     // useRemoteView) never unmounts — it is the app's only connection-status
     // self-heal, so a transient local error must not stop it.
     refetchInterval: 10000,
+    // The /remote/* endpoints are only registered by the backend in local
+    // mode; polling them in remote mode just produces a 404 every cycle.
+    enabled: isLocalMode,
   });
 };
 


### PR DESCRIPTION
Regression from #93. Without this guard, the frontend unconditionally polls the `/api/v1/remote/server` endpoint, which only exists in local mode.