### PR TITLE
fix SSE for multiline pixi logs

### DIFF
--- a/internal/api/handlers/job.go
+++ b/internal/api/handlers/job.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -102,19 +103,15 @@ func (h *JobHandler) StreamJobLogs(c *gin.Context) {
 
 	// If job is already completed or failed, send historical logs and close
 	if job.Status == models.JobStatusCompleted || job.Status == models.JobStatusFailed {
-		if job.Logs != "" {
-			fmt.Fprintf(c.Writer, "data: %s\n\n", job.Logs)
-		}
+		writeSSEData(c.Writer, job.Logs)
 		fmt.Fprintf(c.Writer, "event: done\ndata: Job already completed\n\n")
 		c.Writer.Flush()
 		return
 	}
 
 	// Send historical logs if any exist
-	if job.Logs != "" {
-		fmt.Fprintf(c.Writer, "data: %s\n\n", job.Logs)
-		c.Writer.Flush()
-	}
+	writeSSEData(c.Writer, job.Logs)
+	c.Writer.Flush()
 
 	// Stream real-time logs
 	if h.valkeyClient != nil {
@@ -137,7 +134,7 @@ func (h *JobHandler) streamLogsFromValkey(c *gin.Context, jobID uuid.UUID) {
 	err := h.valkeyClient.Receive(ctx, subscribeCmd, func(msg valkey.PubSubMessage) {
 		logLine := msg.Message
 
-		fmt.Fprintf(c.Writer, "data: %s\n\n", logLine)
+		writeSSEData(c.Writer, logLine)
 		if flusher, ok := c.Writer.(http.Flusher); ok {
 			flusher.Flush()
 		}
@@ -174,10 +171,22 @@ func (h *JobHandler) streamLogsFromBroker(c *gin.Context, jobID uuid.UUID) {
 				return
 			}
 
-			fmt.Fprintf(c.Writer, "data: %s\n\n", logLine)
+			writeSSEData(c.Writer, logLine)
 			if flusher, ok := c.Writer.(http.Flusher); ok {
 				flusher.Flush()
 			}
 		}
 	}
+}
+
+// writeSSEData writes text as SSE data: lines, splitting on newlines so
+// each line gets its own data: prefix. An empty text is a no-op.
+func writeSSEData(w http.ResponseWriter, text string) {
+	if text == "" {
+		return
+	}
+	for _, line := range strings.Split(text, "\n") {
+		fmt.Fprintf(w, "data: %s\n", line)
+	}
+	fmt.Fprint(w, "\n")
 }

--- a/internal/logstream/broker.go
+++ b/internal/logstream/broker.go
@@ -24,7 +24,7 @@ func (b *LogBroker) Subscribe(jobID uuid.UUID) chan string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	ch := make(chan string, 100) // Buffered channel to prevent blocking
+	ch := make(chan string, 4096) // Buffered channel to prevent blocking
 
 	if b.subscribers[jobID] == nil {
 		b.subscribers[jobID] = make(map[chan string]bool)


### PR DESCRIPTION
Previously we blindly wrote `"data: %s\n\n"`. If `%s` contains a linebreak `\n`, the event reader on the client terminated the message to early and discarded the remainder because it was not prefixed with `data: `. The result was that during workspace creation sometimes log lines were missing that should have been streamed in. The same lines were available after page refresh, because the data got lost in the transfer from server to client rather than on the client.