### PR TITLE
Add profile menu to header

### DIFF
--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,5 +1,4 @@
-import { Boxes, ExternalLink, LogOut, Settings, Shield } from 'lucide-react';
-import { useState } from 'react';
+import { Boxes, ExternalLink, Settings, Shield } from 'lucide-react';
 import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { useIsAdmin } from '@/hooks/useAdmin';
@@ -10,13 +9,13 @@ import { openExternal } from '@/lib/openExternal';
 import { useAuthStore } from '@/store/authStore';
 import { useModeStore } from '@/store/modeStore';
 import { useViewModeStore } from '@/store/viewModeStore';
+import { ProfileMenu } from './ProfileMenu';
 
 export const Layout = () => {
   const { user, clearAuth } = useAuthStore();
   const isLocalMode = useModeStore((s) => s.isLocalMode());
   const navigate = useNavigate();
   const { data: isAdmin } = useIsAdmin();
-  const [avatarError, setAvatarError] = useState(false);
   const { viewMode, setViewMode } = useViewModeStore();
   const { data: serverStatus } = useRemoteServer();
   const { data: versionInfo } = useVersion();
@@ -171,30 +170,7 @@ export const Layout = () => {
                 </NavLink>
               )}
               {!isLocalMode && (
-                <>
-                  {user?.avatar_url && !avatarError ? (
-                    <img
-                      src={user.avatar_url}
-                      alt={user.username}
-                      className="h-8 w-8 rounded-full"
-                      referrerPolicy="no-referrer-when-downgrade"
-                      crossOrigin="anonymous"
-                      onError={() => setAvatarError(true)}
-                    />
-                  ) : (
-                    <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center">
-                      <span className="text-sm font-medium text-primary">
-                        {user?.username?.charAt(0).toUpperCase()}
-                      </span>
-                    </div>
-                  )}
-                  <span className="text-sm font-medium text-foreground">
-                    {user?.username}
-                  </span>
-                  <Button variant="ghost" size="icon" onClick={handleLogout}>
-                    <LogOut className="h-4 w-4" />
-                  </Button>
-                </>
+                <ProfileMenu user={user} onLogout={handleLogout} />
               )}
             </div>
           </div>

--- a/frontend/src/components/layout/ProfileMenu.test.tsx
+++ b/frontend/src/components/layout/ProfileMenu.test.tsx
@@ -1,0 +1,66 @@
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { mockUser } from '@/test/handlers';
+import { render, screen } from '@/test/utils';
+import { ProfileMenu } from './ProfileMenu';
+
+describe('ProfileMenu', () => {
+  it('opens a profile menu with the current user and sign out action', async () => {
+    const user = userEvent.setup();
+
+    render(<ProfileMenu user={mockUser} onLogout={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /testuser/i }));
+
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    expect(screen.getByText('test@example.com')).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: /sign out/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('closes on outside click and Escape', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <>
+        <button type="button">Outside</button>
+        <ProfileMenu user={mockUser} onLogout={vi.fn()} />
+      </>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /testuser/i }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Outside' }));
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+
+    const trigger = screen.getByRole('button', { name: /testuser/i });
+    await user.click(trigger);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it('supports tabbing to sign out and activating it with the keyboard', async () => {
+    const user = userEvent.setup();
+    const onLogout = vi.fn();
+
+    render(<ProfileMenu user={mockUser} onLogout={onLogout} />);
+
+    screen.getByRole('button', { name: /testuser/i }).focus();
+    await user.keyboard('{Enter}');
+
+    const signOut = screen.getByRole('menuitem', { name: /sign out/i });
+    await user.tab();
+    expect(signOut).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+
+    expect(onLogout).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/layout/ProfileMenu.tsx
+++ b/frontend/src/components/layout/ProfileMenu.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, LogOut } from 'lucide-react';
-import { useEffect, useId, useRef, useState } from 'react';
+import { useId, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 import type { User } from '@/types';
 
@@ -15,35 +15,11 @@ export const ProfileMenu = ({ user, onLogout }: ProfileMenuProps) => {
   const [open, setOpen] = useState(false);
   const [failedAvatarUrl, setFailedAvatarUrl] = useState<string | null>(null);
   const menuId = useId();
-  const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
 
   const displayName = user?.username || user?.email || 'User';
   const avatarUrl = user?.avatar_url;
   const avatarError = Boolean(avatarUrl && failedAvatarUrl === avatarUrl);
-
-  useEffect(() => {
-    if (!open) return;
-
-    const handlePointerDown = (event: MouseEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) {
-        setOpen(false);
-      }
-    };
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setOpen(false);
-        triggerRef.current?.focus();
-      }
-    };
-
-    document.addEventListener('mousedown', handlePointerDown);
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('mousedown', handlePointerDown);
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [open]);
 
   const handleLogout = () => {
     setOpen(false);
@@ -61,7 +37,21 @@ export const ProfileMenu = ({ user, onLogout }: ProfileMenuProps) => {
   };
 
   return (
-    <div ref={rootRef} className="relative">
+    // biome-ignore lint/a11y/noStaticElementInteractions: This container observes bubbled React focus and keyboard events from its child controls.
+    <div
+      className="relative"
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          setOpen(false);
+        }
+      }}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') {
+          setOpen(false);
+          triggerRef.current?.focus();
+        }
+      }}
+    >
       <button
         ref={triggerRef}
         type="button"

--- a/frontend/src/components/layout/ProfileMenu.tsx
+++ b/frontend/src/components/layout/ProfileMenu.tsx
@@ -13,17 +13,14 @@ const getInitial = (user: User | null) =>
 
 export const ProfileMenu = ({ user, onLogout }: ProfileMenuProps) => {
   const [open, setOpen] = useState(false);
-  const [avatarError, setAvatarError] = useState(false);
+  const [failedAvatarUrl, setFailedAvatarUrl] = useState<string | null>(null);
   const menuId = useId();
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
 
   const displayName = user?.username || user?.email || 'User';
   const avatarUrl = user?.avatar_url;
-
-  useEffect(() => {
-    setAvatarError(false);
-  }, [avatarUrl]);
+  const avatarError = Boolean(avatarUrl && failedAvatarUrl === avatarUrl);
 
   useEffect(() => {
     if (!open) return;
@@ -53,6 +50,16 @@ export const ProfileMenu = ({ user, onLogout }: ProfileMenuProps) => {
     onLogout();
   };
 
+  const handleAvatarError = () => {
+    if (avatarUrl) {
+      setFailedAvatarUrl(avatarUrl);
+    }
+  };
+
+  const handleAvatarLoad = () => {
+    setFailedAvatarUrl(null);
+  };
+
   return (
     <div ref={rootRef} className="relative">
       <button
@@ -71,7 +78,8 @@ export const ProfileMenu = ({ user, onLogout }: ProfileMenuProps) => {
             className="h-8 w-8 shrink-0 rounded-full object-cover"
             referrerPolicy="no-referrer-when-downgrade"
             crossOrigin="anonymous"
-            onError={() => setAvatarError(true)}
+            onError={handleAvatarError}
+            onLoad={handleAvatarLoad}
           />
         ) : (
           <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-medium text-primary">
@@ -104,7 +112,8 @@ export const ProfileMenu = ({ user, onLogout }: ProfileMenuProps) => {
                 className="h-10 w-10 shrink-0 rounded-full object-cover"
                 referrerPolicy="no-referrer-when-downgrade"
                 crossOrigin="anonymous"
-                onError={() => setAvatarError(true)}
+                onError={handleAvatarError}
+                onLoad={handleAvatarLoad}
               />
             ) : (
               <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-base font-medium text-primary">

--- a/frontend/src/components/layout/ProfileMenu.tsx
+++ b/frontend/src/components/layout/ProfileMenu.tsx
@@ -19,10 +19,11 @@ export const ProfileMenu = ({ user, onLogout }: ProfileMenuProps) => {
   const triggerRef = useRef<HTMLButtonElement>(null);
 
   const displayName = user?.username || user?.email || 'User';
+  const avatarUrl = user?.avatar_url;
 
   useEffect(() => {
     setAvatarError(false);
-  }, [user?.avatar_url]);
+  }, [avatarUrl]);
 
   useEffect(() => {
     if (!open) return;
@@ -63,9 +64,9 @@ export const ProfileMenu = ({ user, onLogout }: ProfileMenuProps) => {
         aria-controls={open ? menuId : undefined}
         onClick={() => setOpen((value) => !value)}
       >
-        {user?.avatar_url && !avatarError ? (
+        {avatarUrl && !avatarError ? (
           <img
-            src={user.avatar_url}
+            src={avatarUrl}
             alt=""
             className="h-8 w-8 shrink-0 rounded-full object-cover"
             referrerPolicy="no-referrer-when-downgrade"
@@ -96,9 +97,9 @@ export const ProfileMenu = ({ user, onLogout }: ProfileMenuProps) => {
             role="presentation"
             className="flex items-center gap-3 px-2 py-2"
           >
-            {user?.avatar_url && !avatarError ? (
+            {avatarUrl && !avatarError ? (
               <img
-                src={user.avatar_url}
+                src={avatarUrl}
                 alt=""
                 className="h-10 w-10 shrink-0 rounded-full object-cover"
                 referrerPolicy="no-referrer-when-downgrade"

--- a/frontend/src/components/layout/ProfileMenu.tsx
+++ b/frontend/src/components/layout/ProfileMenu.tsx
@@ -1,0 +1,138 @@
+import { ChevronDown, LogOut } from 'lucide-react';
+import { useEffect, useId, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
+import type { User } from '@/types';
+
+type ProfileMenuProps = {
+  user: User | null;
+  onLogout: () => void;
+};
+
+const getInitial = (user: User | null) =>
+  (user?.username || user?.email || 'U').charAt(0).toUpperCase();
+
+export const ProfileMenu = ({ user, onLogout }: ProfileMenuProps) => {
+  const [open, setOpen] = useState(false);
+  const [avatarError, setAvatarError] = useState(false);
+  const menuId = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const displayName = user?.username || user?.email || 'User';
+
+  useEffect(() => {
+    setAvatarError(false);
+  }, [user?.avatar_url]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open]);
+
+  const handleLogout = () => {
+    setOpen(false);
+    onLogout();
+  };
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        className="flex h-10 max-w-56 items-center gap-2 rounded-md px-2 text-sm font-medium text-foreground transition-colors hover:bg-nav-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        onClick={() => setOpen((value) => !value)}
+      >
+        {user?.avatar_url && !avatarError ? (
+          <img
+            src={user.avatar_url}
+            alt=""
+            className="h-8 w-8 shrink-0 rounded-full object-cover"
+            referrerPolicy="no-referrer-when-downgrade"
+            crossOrigin="anonymous"
+            onError={() => setAvatarError(true)}
+          />
+        ) : (
+          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-medium text-primary">
+            {getInitial(user)}
+          </span>
+        )}
+        <span className="min-w-0 truncate">{displayName}</span>
+        <ChevronDown
+          className={cn(
+            'h-4 w-4 shrink-0 text-muted-foreground transition-transform',
+            open && 'rotate-180',
+          )}
+        />
+      </button>
+      {open && (
+        <div
+          id={menuId}
+          role="menu"
+          aria-label="Profile menu"
+          className="absolute right-0 top-full z-50 mt-2 w-72 max-w-[calc(100vw-2rem)] rounded-md border bg-popover p-2 text-popover-foreground shadow-lg"
+        >
+          <div
+            role="presentation"
+            className="flex items-center gap-3 px-2 py-2"
+          >
+            {user?.avatar_url && !avatarError ? (
+              <img
+                src={user.avatar_url}
+                alt=""
+                className="h-10 w-10 shrink-0 rounded-full object-cover"
+                referrerPolicy="no-referrer-when-downgrade"
+                crossOrigin="anonymous"
+                onError={() => setAvatarError(true)}
+              />
+            ) : (
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-base font-medium text-primary">
+                {getInitial(user)}
+              </span>
+            )}
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-foreground">
+                {displayName}
+              </p>
+              {user?.email && (
+                <p className="truncate text-sm text-muted-foreground">
+                  {user.email}
+                </p>
+              )}
+            </div>
+          </div>
+          <hr className="my-1 border-border" />
+          <button
+            type="button"
+            role="menuitem"
+            className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm font-medium text-red-500 transition-colors hover:bg-red-500/10 focus:bg-red-500/10 focus:outline-none"
+            onClick={handleLogout}
+          >
+            <LogOut className="h-4 w-4" />
+            Sign out
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## Reference Issues or PRs
Closes #373 


## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [x] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

- Replace the static header user display with an interactive profile menu trigger.
- Add a dropdown anchored to the header trigger with user identity and Sign out.
- Preserve the existing logout flow, including external logout URL handling.
- Support closing the menu with outside clicks and Escape.
- Add focused tests for menu rendering, close behavior, and keyboard tab activation.

<img width="1421" height="692" alt="Screenshot 2026-06-26 at 5 46 10 AM" src="https://github.com/user-attachments/assets/feedfdee-ea69-487f-b238-9fbc2f27ac40" />


Accessibility visuals:-

https://github.com/user-attachments/assets/08adb1c3-66eb-4c7a-9349-db5d39436181

