### PR TITLE
fix(e2e): cancel in-flight transitions before axe contrast checks

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -87,8 +87,10 @@ jobs:
           rm -rf internal/web/dist
           cp -r frontend/dist internal/web/dist
 
+      # Pin to the wails version in go.mod; @latest broke when wails v2.13.0
+      # started requiring a newer Go than this workflow uses.
       - name: Install wails
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0
 
       - name: Build desktop app
         run: wails build -platform ${{ matrix.platform }} ${{ matrix.build_tags }}

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -336,13 +336,15 @@ export const expectResolvedTheme = async (
 export const expectNoCriticalOrSeriousA11yViolations = async (page: Page) => {
   // Disable CSS transitions/animations so axe measures settled colors rather
   // than intermediate values mid-transition (e.g. right after a theme switch),
-  // which otherwise produces flaky color-contrast violations.
+  // which otherwise produces flaky color-contrast violations. Zeroing the
+  // duration is not enough: a transition already in flight keeps running with
+  // its original duration, and WebKit can leave it stuck at an intermediate
+  // color for seconds under CI load. Removing the transition property cancels
+  // in-flight transitions and snaps computed colors to their final values.
   await page.addStyleTag({
     content: `*, *::before, *::after {
-      transition-duration: 0s !important;
-      transition-delay: 0s !important;
-      animation-duration: 0s !important;
-      animation-delay: 0s !important;
+      transition: none !important;
+      animation: none !important;
     }`,
   });
 


### PR DESCRIPTION
Fixes the flaky webkit color-contrast failure in the theme-switch a11y test. The helper zeroed transition durations, but transitions already running keep their original duration, so axe could sample mid-transition text colors. Injecting transition: none cancels in-flight transitions so axe measures settled colors.