### PR TITLE
security: harden OIDC state cookie flags and drop auth PII from logs

### DIFF
--- a/internal/api/handlers/oidc.go
+++ b/internal/api/handlers/oidc.go
@@ -6,10 +6,33 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/nebari-dev/nebi/internal/auth"
 )
+
+// isRequestHTTPS reports whether the request reached Nebi over HTTPS, as seen
+// by the client. It trusts the terminating proxy's X-Forwarded-Proto header
+// (the common Kubernetes/ingress deployment terminates TLS upstream) and falls
+// back to the direct TLS connection state. Used to set the Secure flag on
+// auth cookies from the externally visible origin, not just backend transport.
+func isRequestHTTPS(c *gin.Context) bool {
+	if c.Request.TLS != nil {
+		return true
+	}
+	return strings.EqualFold(c.GetHeader("X-Forwarded-Proto"), "https")
+}
+
+// setStateCookie writes the OIDC state cookie with hardened flags: HttpOnly,
+// SameSite=Lax (the IdP callback is a top-level GET redirect, which Lax still
+// carries; Strict would drop it), and Secure whenever the request origin is
+// HTTPS. Pass maxAge -1 to clear the cookie. Both login and callback go
+// through here so the flags can never diverge.
+func setStateCookie(c *gin.Context, value string, maxAge int) {
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie("oidc_state", value, maxAge, "/", "", isRequestHTTPS(c), true)
+}
 
 // OIDCLogin godoc
 // @Summary Initiate OIDC login
@@ -29,7 +52,7 @@ func OIDCLogin(oidcAuth *auth.OIDCAuthenticator) gin.HandlerFunc {
 		}
 
 		// Store state in session/cookie (for simplicity, we'll use a cookie)
-		c.SetCookie("oidc_state", state, 600, "/", "", false, true)
+		setStateCookie(c, state, 600)
 
 		// Get auth URL and redirect
 		authURL := oidcAuth.GetAuthURL(state)
@@ -55,13 +78,13 @@ func OIDCCallback(oidcAuth *auth.OIDCAuthenticator, codeStore *auth.AuthCodeStor
 		state := c.Query("state")
 		storedState, err := c.Cookie("oidc_state")
 		if err != nil || state == "" || state != storedState {
-			slog.Warn("Invalid OIDC state", "state", state, "stored_state", storedState)
+			slog.Warn("Invalid OIDC state", "had_state_cookie", err == nil)
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid state parameter"})
 			return
 		}
 
 		// Clear the state cookie
-		c.SetCookie("oidc_state", "", -1, "/", "", false, true)
+		setStateCookie(c, "", -1)
 
 		// Get authorization code from OIDC provider
 		oidcCode := c.Query("code")

--- a/internal/api/handlers/oidc_test.go
+++ b/internal/api/handlers/oidc_test.go
@@ -1,0 +1,83 @@
+package handlers
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// newTestContext builds a gin.Context wrapping the given request and a fresh
+// recorder, for exercising handler-level helpers directly.
+func newTestContext(req *http.Request) (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = req
+	return c, rec
+}
+
+func TestIsRequestHTTPS_PlainHTTP(t *testing.T) {
+	c, _ := newTestContext(httptest.NewRequest(http.MethodGet, "http://nebi.example.com/auth/oidc/login", nil))
+	if isRequestHTTPS(c) {
+		t.Fatal("plain HTTP request must not be treated as HTTPS")
+	}
+}
+
+func TestIsRequestHTTPS_DirectTLS(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "https://nebi.example.com/auth/oidc/login", nil)
+	req.TLS = &tls.ConnectionState{}
+	c, _ := newTestContext(req)
+	if !isRequestHTTPS(c) {
+		t.Fatal("request served over TLS must be treated as HTTPS")
+	}
+}
+
+func TestIsRequestHTTPS_ForwardedProto(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://nebi.example.com/auth/oidc/login", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	c, _ := newTestContext(req)
+	if !isRequestHTTPS(c) {
+		t.Fatal("X-Forwarded-Proto: https (TLS-terminating proxy) must be treated as HTTPS")
+	}
+}
+
+func TestSetStateCookie_FlagsOverHTTP(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://nebi.example.com/auth/oidc/login", nil)
+	c, rec := newTestContext(req)
+
+	setStateCookie(c, "state-value", 600)
+
+	sc := rec.Header().Get("Set-Cookie")
+	if !strings.Contains(sc, "oidc_state=state-value") {
+		t.Fatalf("expected oidc_state cookie, got %q", sc)
+	}
+	if !strings.Contains(sc, "SameSite=Lax") {
+		t.Fatalf("expected SameSite=Lax, got %q", sc)
+	}
+	if !strings.Contains(sc, "HttpOnly") {
+		t.Fatalf("expected HttpOnly, got %q", sc)
+	}
+	if strings.Contains(sc, "Secure") {
+		t.Fatalf("plain HTTP must not set Secure, got %q", sc)
+	}
+}
+
+func TestSetStateCookie_SecureOverHTTPS(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://nebi.example.com/auth/oidc/login", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	c, rec := newTestContext(req)
+
+	setStateCookie(c, "state-value", 600)
+
+	sc := rec.Header().Get("Set-Cookie")
+	if !strings.Contains(sc, "Secure") {
+		t.Fatalf("HTTPS request must set Secure, got %q", sc)
+	}
+	if !strings.Contains(sc, "SameSite=Lax") {
+		t.Fatalf("expected SameSite=Lax, got %q", sc)
+	}
+}

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -140,7 +140,9 @@ func (a *OIDCAuthenticator) HandleCallback(ctx context.Context, code string) (*L
 		return nil, fmt.Errorf("failed to parse claims: %w", err)
 	}
 
-	slog.Info("OIDC login claims", "email", claims.Email, "name", claims.Name, "sub", claims.Sub, "picture", claims.Picture)
+	// Do not log identity claims (email, name, subject, picture) - they are PII
+	// and end up in aggregated log stores. A presence marker is enough for ops.
+	slog.Debug("OIDC login claims parsed")
 
 	// Determine username
 	username := claims.Email


### PR DESCRIPTION
Sets `SameSite=Lax` and `Secure` (derived from the request's HTTPS origin, including `X-Forwarded-Proto`) on the `oidc_state` cookie via one shared helper, and stops logging raw state values and OIDC identity claims.

Closes #454