### PR TITLE
fix: scope local mode API to the local machine

### DIFF
--- a/app.go
+++ b/app.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/nebari-dev/nebi/internal/api"
@@ -16,6 +18,7 @@ import (
 	"github.com/nebari-dev/nebi/internal/db"
 	"github.com/nebari-dev/nebi/internal/executor"
 	"github.com/nebari-dev/nebi/internal/models"
+	"github.com/nebari-dev/nebi/internal/netguard"
 	"github.com/nebari-dev/nebi/internal/pkgmgr/pixi"
 	"github.com/nebari-dev/nebi/internal/queue"
 	"github.com/nebari-dev/nebi/internal/rbac"
@@ -200,11 +203,15 @@ func (a *App) startEmbeddedServer(cfg *config.Config, database *gorm.DB) {
 	close(a.ready) // signal that router is ready for Wails handler
 	logToFile("startEmbeddedServer: router initialized")
 
-	// Create HTTP server on port 8460 (fallback for CLI/external access)
-	addr := fmt.Sprintf(":%d", cfg.Server.Port)
+	// Create HTTP server on port 8460 (fallback for CLI access).
+	// The desktop app is a single-user, on-device setup, so bind loopback
+	// only and accept only requests with a local Host/Origin. The Wails UI
+	// does not use this listener; it reaches the router in-process via
+	// Handler().
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(cfg.Server.Port))
 	a.server = &http.Server{
 		Addr:    addr,
-		Handler: router,
+		Handler: netguard.Middleware(router, false),
 	}
 
 	logToFile(fmt.Sprintf("startEmbeddedServer: starting server on %s", addr))

--- a/cmd/nebi/localmode_guard_e2e_test.go
+++ b/cmd/nebi/localmode_guard_e2e_test.go
@@ -1,0 +1,95 @@
+//go:build e2e
+
+package main
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// TestE2E_LocalModeNetworkGuard verifies that a real local-mode server only
+// accepts requests from the local machine: loopback requests succeed, a
+// request addressed to a non-local hostname is rejected, a request with a
+// non-local Origin is rejected, and the listener is not reachable on
+// non-loopback interfaces.
+func TestE2E_LocalModeNetworkGuard(t *testing.T) {
+	env := startLocalModeServer(t)
+
+	healthURL := env.serverURL + "/api/v1/health"
+
+	t.Run("loopback request succeeds", func(t *testing.T) {
+		resp, err := http.Get(healthURL)
+		if err != nil {
+			t.Fatalf("GET %s: %v", healthURL, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("non-local Host header rejected", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, healthURL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Host = "evil.example.com"
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("expected 403 for non-local Host, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("non-local Origin rejected", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, healthURL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Origin", "https://evil.example.com")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("expected 403 for non-local Origin, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("listener not reachable on non-loopback interfaces", func(t *testing.T) {
+		u, err := url.Parse(env.serverURL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		port := u.Port()
+
+		addrs, err := net.InterfaceAddrs()
+		if err != nil {
+			t.Fatalf("InterfaceAddrs: %v", err)
+		}
+		checked := false
+		for _, addr := range addrs {
+			ipNet, ok := addr.(*net.IPNet)
+			if !ok || ipNet.IP.IsLoopback() || ipNet.IP.To4() == nil {
+				continue
+			}
+			checked = true
+			target := net.JoinHostPort(ipNet.IP.String(), port)
+			conn, err := net.DialTimeout("tcp", target, 2*time.Second)
+			if err == nil {
+				conn.Close()
+				t.Fatalf("local mode server is reachable on non-loopback address %s", target)
+			}
+		}
+		if !checked {
+			t.Skip("no non-loopback IPv4 interface available")
+		}
+	})
+}

--- a/cmd/nebi/serve.go
+++ b/cmd/nebi/serve.go
@@ -36,7 +36,8 @@ Examples:
 
 Environment variables:
   NEBI_MODE                         Server mode: "local" or "team" (default: "team")
-  NEBI_SERVER_HOST                  Bind host/IP (e.g. 127.0.0.1). If unset, bind all interfaces.
+  NEBI_SERVER_HOST                  Bind host/IP (e.g. 127.0.0.1). If unset: team mode binds all
+                                    interfaces; local mode binds loopback only
   NEBI_SERVER_PORT                  Server port (default: 8460)
   NEBI_SERVER_MODE                  Server environment: "development" or "production" (default: "development")
   NEBI_SERVER_BASE_PATH             URL path prefix for reverse proxy (e.g. "/nebi")
@@ -68,7 +69,7 @@ Environment variables:
 }
 
 func init() {
-	serveCmd.Flags().StringVar(&serveHost, "host", "", "Bind host/IP (overrides config), e.g. 127.0.0.1. Empty keeps all-interface bind")
+	serveCmd.Flags().StringVar(&serveHost, "host", "", "Bind host/IP (overrides config), e.g. 127.0.0.1. Empty: all interfaces in team mode, loopback in local mode")
 	serveCmd.Flags().IntVarP(&servePort, "port", "p", 0, "Port to run server on (overrides config)")
 	serveCmd.Flags().StringVarP(&serveMode, "mode", "m", "both", "Run mode: server, worker, or both")
 }

--- a/docs/docs/server-setup.md
+++ b/docs/docs/server-setup.md
@@ -31,7 +31,7 @@ Start the server:
 nebi serve
 ```
 
-By default (`--host` unset), Nebi binds all interfaces on port `8460`.
+By default (`--host` unset), Nebi binds all interfaces on port `8460` in team mode. Local mode (`NEBI_MODE=local`) is a single-user, on-device setup, so the server binds only the loopback interface (`127.0.0.1`) and only accepts requests addressed to a local host/origin. To bind a local-mode server to another interface, set `--host` (or `NEBI_SERVER_HOST`) explicitly.
 
 To use a different port:
 
@@ -44,8 +44,6 @@ To explicitly bind a host/interface, use `--host` (or `NEBI_SERVER_HOST`):
 ```bash
 nebi serve --host 127.0.0.1 --port 8460
 ```
-
-For local-only usage (desktop/IPC scenarios), always set `--host 127.0.0.1` (or `NEBI_SERVER_HOST=127.0.0.1`).
 
 Once the server is running, authenticate from any client machine with [`nebi login`](./cli-team.md#connect-to-a-server).
 

--- a/internal/api/cors_test.go
+++ b/internal/api/cors_test.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func corsTestRouter(localMode bool) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(corsMiddleware(localMode))
+	r.GET("/ping", func(c *gin.Context) { c.String(http.StatusOK, "pong") })
+	return r
+}
+
+func doCORSRequest(t *testing.T, r *gin.Engine, origin string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	if origin != "" {
+		req.Header.Set("Origin", origin)
+	}
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestCORSLocalModeNeverWildcards(t *testing.T) {
+	r := corsTestRouter(true)
+
+	for _, origin := range []string{"", "https://evil.example.com", "http://localhost:8461"} {
+		rec := doCORSRequest(t, r, origin)
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got == "*" {
+			t.Errorf("Origin %q: local mode must not send wildcard Access-Control-Allow-Origin", origin)
+		}
+	}
+}
+
+func TestCORSLocalModeEchoesOnlyLocalOrigins(t *testing.T) {
+	r := corsTestRouter(true)
+
+	allowed := []string{
+		"http://localhost:8461",
+		"http://127.0.0.1:8460",
+		"wails://wails",
+		"null",
+	}
+	for _, origin := range allowed {
+		rec := doCORSRequest(t, r, origin)
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != origin {
+			t.Errorf("Origin %q: expected echo, got %q", origin, got)
+		}
+		if vary := rec.Header().Get("Vary"); vary != "Origin" {
+			t.Errorf("Origin %q: expected Vary: Origin, got %q", origin, vary)
+		}
+	}
+
+	for _, origin := range []string{"https://evil.example.com", "http://evil.example.com:8460", ""} {
+		rec := doCORSRequest(t, r, origin)
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+			t.Errorf("Origin %q: expected no Access-Control-Allow-Origin, got %q", origin, got)
+		}
+	}
+}
+
+func TestCORSTeamModeKeepsWildcard(t *testing.T) {
+	r := corsTestRouter(false)
+
+	rec := doCORSRequest(t, r, "https://anywhere.example.com")
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("team mode: expected wildcard Access-Control-Allow-Origin, got %q", got)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -17,6 +17,7 @@ import (
 	nebicrypto "github.com/nebari-dev/nebi/internal/crypto"
 	"github.com/nebari-dev/nebi/internal/executor"
 	"github.com/nebari-dev/nebi/internal/logstream"
+	"github.com/nebari-dev/nebi/internal/netguard"
 	"github.com/nebari-dev/nebi/internal/queue"
 	"github.com/nebari-dev/nebi/internal/rbac"
 	"github.com/nebari-dev/nebi/internal/service"
@@ -62,7 +63,7 @@ func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Exe
 	// Middleware
 	router.Use(gin.Recovery())
 	router.Use(loggingMiddleware())
-	router.Use(corsMiddleware())
+	router.Use(corsMiddleware(localMode))
 
 	// Initialize authenticator based on mode
 	var authenticator auth.Authenticator
@@ -531,9 +532,24 @@ func loggingMiddleware() gin.HandlerFunc {
 // CORS spec to name an explicit origin, and combining it with the "*" wildcard
 // is invalid: browsers reject any such response, which in turn blocks the SPA's
 // <script type="module" crossorigin> bundle from loading.
-func corsMiddleware() gin.HandlerFunc {
+//
+// In local mode the API is used only by local UIs, so instead of a wildcard
+// the allowed origin is echoed only for those: loopback http(s) origins (the
+// SPA served by this process, the Vite dev server) and the desktop webview
+// ("wails://..." on macOS/Linux, opaque "null" origins some webviews produce).
+// Those webview requests arrive through the in-process Wails handler, never
+// the network listener (see netguard.Middleware).
+func corsMiddleware(localMode bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+		if localMode {
+			origin := c.Request.Header.Get("Origin")
+			if netguard.IsLoopbackOrigin(origin) || strings.HasPrefix(origin, "wails://") || origin == "null" {
+				c.Writer.Header().Set("Access-Control-Allow-Origin", origin)
+				c.Writer.Header().Set("Vary", "Origin")
+			}
+		} else {
+			c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+		}
 		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		// Prevent WebView (WKWebView) from caching API responses,

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -49,8 +49,12 @@ func TestCORSMiddlewareNoInvalidCredentialedWildcard(t *testing.T) {
 
 	// /api/v1/health is a real public route; /assets/* flows through the real
 	// SPA static handler. Both pass through the global CORS middleware.
+	// The router is in local mode, where the allowed origin is echoed for
+	// local UIs (e.g. the Vite dev server) instead of a wildcard.
+	const origin = "http://localhost:8461"
 	for _, path := range []string{"/api/v1/health", "/assets/index-abc123.js"} {
 		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.Header.Set("Origin", origin)
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)
 
@@ -60,8 +64,8 @@ func TestCORSMiddlewareNoInvalidCredentialedWildcard(t *testing.T) {
 		if acao == "*" && acac == "true" {
 			t.Fatalf("%s: invalid CORS combo: ACAO=%q ACAC=%q (wildcard origin cannot be credentialed)", path, acao, acac)
 		}
-		if acao == "" {
-			t.Fatalf("%s: expected Access-Control-Allow-Origin to be set, got empty", path)
+		if acao != origin {
+			t.Fatalf("%s: expected Access-Control-Allow-Origin %q, got %q", path, origin, acao)
 		}
 		if acac != "" {
 			t.Fatalf("%s: expected no Access-Control-Allow-Credentials, got %q", path, acac)

--- a/internal/netguard/guard.go
+++ b/internal/netguard/guard.go
@@ -1,0 +1,77 @@
+// Package netguard restricts an HTTP listener to clients on the local
+// machine. Local/desktop mode is a single-user, on-device setup, so the
+// listener only accepts requests addressed to a local host and origin.
+package netguard
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Middleware wraps next and only allows requests addressed to the local
+// machine:
+//
+//   - The Host header must name a loopback host (localhost, *.localhost,
+//     127.0.0.1, ::1). Set allowAnyHost when the operator explicitly bound a
+//     non-loopback interface and therefore expects non-loopback Host values.
+//
+//   - The Origin header, when present, must be a loopback http(s) origin.
+//     Requests without an Origin (CLI, curl, same-origin GET) pass through.
+func Middleware(next http.Handler, allowAnyHost bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !allowAnyHost && !isLoopbackHostPort(r.Host) {
+			http.Error(w, "Forbidden: local mode only accepts requests addressed to a local host", http.StatusForbidden)
+			return
+		}
+		if origin := r.Header.Get("Origin"); origin != "" && !IsLoopbackOrigin(origin) {
+			http.Error(w, "Forbidden: local mode only accepts requests from a local origin", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// IsLoopbackOrigin reports whether an Origin header value is an http(s)
+// origin on a loopback host (e.g. "http://localhost:8461").
+func IsLoopbackOrigin(origin string) bool {
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false
+	}
+	return isLoopbackHost(u.Hostname())
+}
+
+// IsLoopbackHost reports whether a bare hostname or IP (no port) is a
+// loopback host. Used to decide whether a configured bind host keeps the
+// listener private to this machine.
+func IsLoopbackHost(host string) bool {
+	return isLoopbackHost(host)
+}
+
+// isLoopbackHostPort reports whether a Host header value ("host", "host:port",
+// "[v6]:port") names a loopback host.
+func isLoopbackHostPort(hostPort string) bool {
+	host := hostPort
+	if h, _, err := net.SplitHostPort(hostPort); err == nil {
+		host = h
+	} else {
+		host = strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+	}
+	return isLoopbackHost(host)
+}
+
+func isLoopbackHost(host string) bool {
+	host = strings.ToLower(host)
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}

--- a/internal/netguard/guard_test.go
+++ b/internal/netguard/guard_test.go
@@ -1,0 +1,113 @@
+package netguard_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nebari-dev/nebi/internal/netguard"
+)
+
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestMiddlewareAllowsLoopbackHosts(t *testing.T) {
+	guard := netguard.Middleware(okHandler(), false)
+
+	for _, host := range []string{
+		"localhost:8460",
+		"localhost",
+		"127.0.0.1:8460",
+		"[::1]:8460",
+		"wails.localhost",
+		"LOCALHOST:8460",
+	} {
+		req := httptest.NewRequest(http.MethodGet, "http://placeholder/api/v1/health", nil)
+		req.Host = host
+		rec := httptest.NewRecorder()
+		guard.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("Host %q: expected 200, got %d", host, rec.Code)
+		}
+	}
+}
+
+func TestMiddlewareRejectsNonLoopbackHost(t *testing.T) {
+	guard := netguard.Middleware(okHandler(), false)
+
+	req := httptest.NewRequest(http.MethodGet, "http://evil.example.com:8460/api/v1/workspaces", nil)
+	rec := httptest.NewRecorder()
+	guard.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-loopback Host, got %d", rec.Code)
+	}
+}
+
+func TestMiddlewareRejectsNonLocalOrigins(t *testing.T) {
+	guard := netguard.Middleware(okHandler(), false)
+
+	for _, origin := range []string{
+		"https://evil.example.com",
+		"http://evil.example.com:8460",
+		"null",
+		"file://",
+	} {
+		req := httptest.NewRequest(http.MethodPost, "http://localhost:8460/api/v1/workspaces", nil)
+		req.Header.Set("Origin", origin)
+		rec := httptest.NewRecorder()
+		guard.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("Origin %q: expected 403, got %d", origin, rec.Code)
+		}
+	}
+}
+
+func TestMiddlewareAllowAnyHostStillRejectsNonLocalOrigins(t *testing.T) {
+	guard := netguard.Middleware(okHandler(), true)
+
+	req := httptest.NewRequest(http.MethodGet, "http://192.0.2.10:8460/api/v1/health", nil)
+	rec := httptest.NewRecorder()
+	guard.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("allowAnyHost: expected 200 for non-loopback Host, got %d", rec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "http://192.0.2.10:8460/api/v1/workspaces", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	rec = httptest.NewRecorder()
+	guard.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("allowAnyHost: expected 403 for non-local Origin, got %d", rec.Code)
+	}
+}
+
+func TestMiddlewareAllowsLoopbackAndAbsentOrigins(t *testing.T) {
+	guard := netguard.Middleware(okHandler(), false)
+
+	for _, origin := range []string{
+		"", // CLI / same-origin GET: no Origin header
+		"http://localhost:8460",
+		"http://localhost:8461", // vite dev server
+		"http://127.0.0.1:8460",
+		"http://[::1]:8460",
+		"https://localhost:8460",
+		"http://wails.localhost",
+	} {
+		req := httptest.NewRequest(http.MethodPost, "http://localhost:8460/api/v1/workspaces", nil)
+		if origin != "" {
+			req.Header.Set("Origin", origin)
+		}
+		rec := httptest.NewRecorder()
+		guard.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("Origin %q: expected 200, got %d", origin, rec.Code)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/nebari-dev/nebi/internal/executor"
 	"github.com/nebari-dev/nebi/internal/logger"
 	"github.com/nebari-dev/nebi/internal/logstream"
+	"github.com/nebari-dev/nebi/internal/netguard"
 	"github.com/nebari-dev/nebi/internal/queue"
 	"github.com/nebari-dev/nebi/internal/rbac"
 	"github.com/nebari-dev/nebi/internal/service"
@@ -64,6 +65,7 @@ func Run(ctx context.Context, cfg Config) error {
 	if cfg.Port != 0 {
 		appCfg.Server.Port = cfg.Port
 	}
+	appCfg.Server.Host = resolveBindHost(appCfg.IsLocalMode(), appCfg.Server.Host)
 
 	// Initialize logger
 	logger.Init(appCfg.Log.Format, appCfg.Log.Level)
@@ -186,10 +188,22 @@ func Run(ctx context.Context, cfg Config) error {
 		var valkeyClientInterface interface{} = valkeyClient
 		router := api.NewRouter(appCfg, database, jobQueue, exec, broker, valkeyClientInterface, slog.Default())
 
+		var handler http.Handler = router
+		if appCfg.IsLocalMode() {
+			// Local mode is a single-user, on-device setup: scope the
+			// listener to clients on the local machine.
+			allowAnyHost := !netguard.IsLoopbackHost(appCfg.Server.Host)
+			if allowAnyHost {
+				slog.Warn("Local mode is bound to a non-loopback interface; it is intended for local use only",
+					"host", appCfg.Server.Host)
+			}
+			handler = netguard.Middleware(router, allowAnyHost)
+		}
+
 		addr := listenAddress(appCfg.Server.Host, appCfg.Server.Port)
 		srv = &http.Server{
 			Addr:    addr,
-			Handler: router,
+			Handler: handler,
 		}
 
 		go func() {
@@ -226,6 +240,18 @@ func Run(ctx context.Context, cfg Config) error {
 
 	slog.Info("Nebi exited")
 	return nil
+}
+
+// resolveBindHost returns the effective bind host. Local mode is a
+// single-user, on-device setup, so when no host is configured it binds
+// loopback only; binding more widely requires an explicit host (config,
+// env, or flag).
+func resolveBindHost(localMode bool, host string) string {
+	host = strings.TrimSpace(host)
+	if localMode && host == "" {
+		return "127.0.0.1"
+	}
+	return host
 }
 
 func listenAddress(host string, port int) string {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2,6 +2,30 @@ package server
 
 import "testing"
 
+func TestResolveBindHost(t *testing.T) {
+	tests := []struct {
+		name      string
+		localMode bool
+		host      string
+		want      string
+	}{
+		{name: "local mode defaults to loopback", localMode: true, host: "", want: "127.0.0.1"},
+		{name: "local mode whitespace defaults to loopback", localMode: true, host: "  ", want: "127.0.0.1"},
+		{name: "local mode explicit host respected", localMode: true, host: "0.0.0.0", want: "0.0.0.0"},
+		{name: "team mode keeps all-interface default", localMode: false, host: "", want: ""},
+		{name: "team mode explicit host respected", localMode: false, host: "10.0.0.5", want: "10.0.0.5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveBindHost(tt.localMode, tt.host)
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
 func TestListenAddress(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Local/desktop mode is a single-user, on-device setup, but the API listener bound all network interfaces by default and sent wildcard CORS. This scopes it to the local machine.

- bind `127.0.0.1` by default in local mode (desktop app and `nebi serve`)
- only accept requests with a loopback `Host` header and a local `Origin` header
- echo local UI origins for CORS instead of a wildcard

Team mode behavior is unchanged. Setting a non-loopback bind host in local mode still works but logs a warning.

Closes #442