### PR TITLE
prevent package names from being parsed as pixi flags

### DIFF
--- a/internal/pkgmgr/pixi/pixi.go
+++ b/internal/pkgmgr/pixi/pixi.go
@@ -195,13 +195,16 @@ func (p *PixiManager) Install(ctx context.Context, opts pkgmgr.InstallOptions) e
 	if len(opts.Packages) == 0 {
 		return fmt.Errorf("at least one package is required")
 	}
+	if err := validatePackageArgs(opts.Packages); err != nil {
+		return err
+	}
 
 	// Build pixi add command with verbose flag for better logging
 	baseArgs := []string{"add", "-v"}
 	if opts.NoInstall {
 		baseArgs = append(baseArgs, "--no-install")
 	}
-	args := append(baseArgs, opts.Packages...)
+	args := append(append(baseArgs, "--"), opts.Packages...)
 
 	// Execute pixi add
 	cmd := exec.CommandContext(ctx, p.pixiPath, args...)
@@ -267,13 +270,16 @@ func (p *PixiManager) Remove(ctx context.Context, opts pkgmgr.RemoveOptions) err
 	if len(opts.Packages) == 0 {
 		return fmt.Errorf("at least one package is required")
 	}
+	if err := validatePackageArgs(opts.Packages); err != nil {
+		return err
+	}
 
 	// Build pixi remove command
 	baseArgs := []string{"remove", "-v"}
 	if opts.NoInstall {
 		baseArgs = append(baseArgs, "--no-install")
 	}
-	args := append(baseArgs, opts.Packages...)
+	args := append(append(baseArgs, "--"), opts.Packages...)
 
 	// Execute pixi remove
 	cmd := exec.CommandContext(ctx, p.pixiPath, args...)
@@ -398,7 +404,10 @@ func (p *PixiManager) Update(ctx context.Context, opts pkgmgr.UpdateOptions) err
 	// Build pixi update command
 	args := []string{"update"}
 	if len(opts.Packages) > 0 {
-		args = append(args, opts.Packages...)
+		if err := validatePackageArgs(opts.Packages); err != nil {
+			return err
+		}
+		args = append(append(args, "--"), opts.Packages...)
 	}
 
 	// Execute pixi update
@@ -413,6 +422,18 @@ func (p *PixiManager) Update(ctx context.Context, opts pkgmgr.UpdateOptions) err
 		return fmt.Errorf("pixi update failed: %w, stderr: %s", err, stderr.String())
 	}
 
+	return nil
+}
+
+func validatePackageArgs(packages []string) error {
+	for _, pkg := range packages {
+		if strings.TrimSpace(pkg) == "" {
+			return fmt.Errorf("package argument cannot be empty")
+		}
+		if strings.ContainsAny(pkg, "\x00\r\n") {
+			return fmt.Errorf("package argument %q contains unsupported control characters", pkg)
+		}
+	}
 	return nil
 }
 

--- a/internal/pkgmgr/pixi/pixi_test.go
+++ b/internal/pkgmgr/pixi/pixi_test.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/nebari-dev/nebi/internal/pkgmgr"
@@ -252,6 +255,156 @@ func TestRemove(t *testing.T) {
 			t.Errorf("Expected 'python' to be removed, but it's still in the list")
 		}
 	}
+}
+
+func TestPackageCommandsSeparateUserArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(context.Context, *PixiManager, string) error
+		want []string
+	}{
+		{
+			name: "install",
+			run: func(ctx context.Context, pm *PixiManager, envPath string) error {
+				return pm.Install(ctx, pkgmgr.InstallOptions{
+					EnvPath:  envPath,
+					Packages: []string{"--config", "python=3.11"},
+				})
+			},
+			want: []string{"add", "-v", "--", "--config", "python=3.11"},
+		},
+		{
+			name: "install no-install",
+			run: func(ctx context.Context, pm *PixiManager, envPath string) error {
+				return pm.Install(ctx, pkgmgr.InstallOptions{
+					EnvPath:   envPath,
+					Packages:  []string{"--config", "python=3.11"},
+					NoInstall: true,
+				})
+			},
+			want: []string{"add", "-v", "--no-install", "--", "--config", "python=3.11"},
+		},
+		{
+			name: "remove",
+			run: func(ctx context.Context, pm *PixiManager, envPath string) error {
+				return pm.Remove(ctx, pkgmgr.RemoveOptions{
+					EnvPath:  envPath,
+					Packages: []string{"--manifest-path", "python"},
+				})
+			},
+			want: []string{"remove", "-v", "--", "--manifest-path", "python"},
+		},
+		{
+			name: "remove no-install",
+			run: func(ctx context.Context, pm *PixiManager, envPath string) error {
+				return pm.Remove(ctx, pkgmgr.RemoveOptions{
+					EnvPath:   envPath,
+					Packages:  []string{"--manifest-path", "python"},
+					NoInstall: true,
+				})
+			},
+			want: []string{"remove", "-v", "--no-install", "--", "--manifest-path", "python"},
+		},
+		{
+			name: "update",
+			run: func(ctx context.Context, pm *PixiManager, envPath string) error {
+				return pm.Update(ctx, pkgmgr.UpdateOptions{
+					EnvPath:  envPath,
+					Packages: []string{"--frozen", "python"},
+				})
+			},
+			want: []string{"update", "--", "--frozen", "python"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm, argsPath, envPath := newRecordingPixi(t)
+
+			if err := tt.run(context.Background(), pm, envPath); err != nil {
+				t.Fatalf("command failed: %v", err)
+			}
+
+			got := readRecordedArgs(t, argsPath)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("recorded args = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidatePackageArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{name: "valid package spec", args: []string{"python=3.11"}},
+		{name: "valid option-like package", args: []string{"--config"}},
+		{name: "empty string", args: []string{""}, wantErr: true},
+		{name: "whitespace only", args: []string{" \t "}, wantErr: true},
+		{name: "nul byte", args: []string{"python\x00numpy"}, wantErr: true},
+		{name: "newline", args: []string{"python\nnumpy"}, wantErr: true},
+		{name: "carriage return", args: []string{"python\rnumpy"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePackageArgs(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validatePackageArgs() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func newRecordingPixi(t *testing.T) (*PixiManager, string, string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("recording pixi test uses a POSIX shell script")
+	}
+
+	tmpDir := t.TempDir()
+	pixiPath := filepath.Join(tmpDir, "pixi")
+	script := `#!/bin/sh
+for arg in "$@"; do
+  printf '%s\n' "$arg" >> "$0.args"
+done
+if [ "${1:-}" = "--version" ]; then
+  exit 0
+fi
+exit 0
+`
+	if err := os.WriteFile(pixiPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake pixi: %v", err)
+	}
+
+	pm, err := NewWithPath(pixiPath)
+	if err != nil {
+		t.Fatalf("create PixiManager with fake pixi: %v", err)
+	}
+
+	argsPath := pixiPath + ".args"
+	if err := os.WriteFile(argsPath, nil, 0644); err != nil {
+		t.Fatalf("clear recorded args: %v", err)
+	}
+
+	return pm, argsPath, tmpDir
+}
+
+func readRecordedArgs(t *testing.T, argsPath string) []string {
+	t.Helper()
+
+	content, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read recorded args: %v", err)
+	}
+
+	args := strings.Split(strings.TrimSuffix(string(content), "\n"), "\n")
+	if len(args) == 1 && args[0] == "" {
+		return nil
+	}
+	return args
 }
 
 func TestExtractWorkspaceName(t *testing.T) {


### PR DESCRIPTION
## Reference Issues or PRs

Part of #445 

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [x] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

This PR fixes the package argument injection portion of #445. Caller-provided package names are now validated before execution and passed to `pixi add`, `pixi remove`, and `pixi update` after a `--` separator, so option-like values such as `--config` are treated as positional package arguments rather than Pixi CLI flags. The change preserves the existing `--no-install` behavior used for workspace package edits, and adds tests that record the exact Pixi argv for `add`/`remove`/`update` plus validation coverage for empty and control-character package arguments.

The remaining chart/deployment hardening items from #445 do not belong in this repo anymore because the old in-repo Helm chart was removed by [nebari-dev/nebi#457](https://github.com/nebari-dev/nebi/pull/457).Note note on [nebari-dev/nebi#450](https://github.com/nebari-dev/nebi/issues/450#issuecomment-4974044471) points to [nebari-dev/nebi-pack](https://github.com/nebari-dev/nebi-pack) as the active deployment chart. Follow-up fixes for ServiceAccount token automount, pod/container security contexts, NetworkPolicy, imagePullSecrets, and chart pod hardening should be made in `nebi-pack`.
