### PR TITLE
Reject query-string auth tokens for protected routes

### DIFF
--- a/frontend/src/hooks/useJobLogStream.test.ts
+++ b/frontend/src/hooks/useJobLogStream.test.ts
@@ -1,102 +1,100 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAuthStore } from '@/store/authStore';
 import { mockUser } from '@/test/handlers';
 import { useJobLogStream } from './useJobLogStream';
 
-// Minimal EventSource mock
-class MockEventSource {
-  static instances: MockEventSource[] = [];
-  onopen: (() => void) | null = null;
-  onmessage: ((e: MessageEvent) => void) | null = null;
-  onerror: ((e: Event) => void) | null = null;
-  private listeners: Record<string, EventListener> = {};
-  readyState = 1;
+const encoder = new TextEncoder();
 
-  constructor(public url: string) {
-    MockEventSource.instances.push(this);
-  }
-
-  addEventListener(type: string, listener: EventListener) {
-    this.listeners[type] = listener;
-  }
-
-  dispatchCustomEvent(type: string, data?: string) {
-    const event = new MessageEvent(type, { data });
-    this.listeners[type]?.(event as unknown as Event);
-  }
-
-  close = vi.fn();
-}
-
-let originalEventSource: typeof EventSource;
-
-beforeEach(() => {
-  MockEventSource.instances = [];
-  originalEventSource = globalThis.EventSource;
-  (globalThis as unknown as Record<string, unknown>).EventSource =
-    MockEventSource;
-  vi.spyOn(console, 'log').mockImplementation(() => {});
-  vi.spyOn(console, 'error').mockImplementation(() => {});
-  act(() => {
-    useAuthStore.setState({ token: 'test-token', user: mockUser });
+const streamResponse = (body: string, init: ResponseInit = {}) => {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(body));
+      controller.close();
+    },
   });
-});
-
-afterEach(() => {
-  (globalThis as unknown as Record<string, unknown>).EventSource =
-    originalEventSource;
-  act(() => {
-    useAuthStore.setState({ token: null, user: null });
+  return new Response(stream, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+    ...init,
   });
-  vi.restoreAllMocks();
-});
+};
 
 describe('useJobLogStream', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(() => new Promise<Response>(() => {}));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    act(() => {
+      useAuthStore.setState({ token: 'test-token', user: mockUser });
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    act(() => {
+      useAuthStore.setState({ token: null, user: null });
+    });
+    vi.restoreAllMocks();
+  });
+
   it('does not open a stream for a completed job', () => {
     renderHook(() => useJobLogStream('job-1', 'completed'));
-    expect(MockEventSource.instances).toHaveLength(0);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('does not open a stream for a failed job', () => {
     renderHook(() => useJobLogStream('job-1', 'failed'));
-    expect(MockEventSource.instances).toHaveLength(0);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('opens an EventSource for a running job', () => {
+  it('opens a fetch stream for a running job', async () => {
     renderHook(() => useJobLogStream('job-1', 'running'));
-    expect(MockEventSource.instances).toHaveLength(1);
-    expect(MockEventSource.instances[0].url).toContain(
-      '/jobs/job-1/logs/stream',
-    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock.mock.calls[0][0]).toContain('/jobs/job-1/logs/stream');
   });
 
-  it('opens an EventSource for a pending job', () => {
+  it('opens a fetch stream for a pending job', async () => {
     renderHook(() => useJobLogStream('job-1', 'pending'));
-    expect(MockEventSource.instances).toHaveLength(1);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
   });
 
-  it('includes the auth token in the stream URL', () => {
+  it('sends the auth token in a header instead of the stream URL', async () => {
     renderHook(() => useJobLogStream('job-1', 'running'));
-    expect(MockEventSource.instances[0].url).toContain('token=test-token');
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(url).not.toContain('token=');
+    expect(options.headers).toMatchObject({
+      Accept: 'text/event-stream',
+      Authorization: 'Bearer test-token',
+    });
   });
 
-  it('appends incoming messages to logs', () => {
+  it('appends incoming messages to logs', async () => {
+    fetchMock.mockResolvedValueOnce(
+      streamResponse('data: line 1\n\ndata: line 2\n\n'),
+    );
+
     const { result } = renderHook(() => useJobLogStream('job-1', 'running'));
 
-    act(() => {
-      MockEventSource.instances[0].onmessage?.(
-        new MessageEvent('message', { data: 'line 1' }),
-      );
-    });
-    act(() => {
-      MockEventSource.instances[0].onmessage?.(
-        new MessageEvent('message', { data: 'line 2' }),
-      );
-    });
-
-    expect(result.current.logs).toContain('line 1');
+    await waitFor(() => expect(result.current.logs).toContain('line 1'));
     expect(result.current.logs).toContain('line 2');
+  });
+
+  it('preserves multiline data fields', async () => {
+    fetchMock.mockResolvedValueOnce(
+      streamResponse('data: line 1\ndata: line 2\n\n'),
+    );
+
+    const { result } = renderHook(() => useJobLogStream('job-1', 'running'));
+
+    await waitFor(() => expect(result.current.logs).toBe('line 1\nline 2\n'));
   });
 
   it('initialises logs from the initialLogs prop', () => {
@@ -106,26 +104,34 @@ describe('useJobLogStream', () => {
     expect(result.current.logs).toBe('prior output\n');
   });
 
-  it('sets isStreaming to true for a running job', () => {
+  it('sets isStreaming to true for a running job', async () => {
     const { result } = renderHook(() => useJobLogStream('job-1', 'running'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     expect(result.current.isStreaming).toBe(true);
   });
 
-  it('sets isStreaming to false when done event fires', () => {
+  it('sets isStreaming to false when done event arrives', async () => {
+    fetchMock.mockResolvedValueOnce(
+      streamResponse('event: done\ndata: Job completed\n\n'),
+    );
+
     const { result } = renderHook(() => useJobLogStream('job-1', 'running'));
 
-    act(() => {
-      MockEventSource.instances[0].dispatchCustomEvent('done');
-    });
-
-    expect(result.current.isStreaming).toBe(false);
-    expect(MockEventSource.instances[0].close).toHaveBeenCalled();
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+    expect(result.current.logs).not.toContain('Job completed');
   });
 
-  it('closes the EventSource on unmount', () => {
+  it('aborts the fetch stream on unmount', async () => {
     const { unmount } = renderHook(() => useJobLogStream('job-1', 'running'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const options = fetchMock.mock.calls[0][1] as RequestInit;
+    const signal = options.signal as AbortSignal;
+
+    expect(signal.aborted).toBe(false);
     unmount();
-    expect(MockEventSource.instances[0].close).toHaveBeenCalled();
+    expect(signal.aborted).toBe(true);
   });
 
   it('does not open a stream when there is no auth token', () => {
@@ -133,6 +139,6 @@ describe('useJobLogStream', () => {
       useAuthStore.setState({ token: null, user: null });
     });
     renderHook(() => useJobLogStream('job-1', 'running'));
-    expect(MockEventSource.instances).toHaveLength(0);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/useJobLogStream.ts
+++ b/frontend/src/hooks/useJobLogStream.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { getApiBaseUrl } from '@/lib/basePath';
 import { useAuthStore } from '@/store/authStore';
 
@@ -11,11 +11,10 @@ export const useJobLogStream = (
 ) => {
   const [logs, setLogs] = useState<string>(initialLogs);
   const [isStreaming, setIsStreaming] = useState(false);
-  const eventSourceRef = useRef<EventSource | null>(null);
   const token = useAuthStore((state) => state.token);
 
   useEffect(() => {
-    // Only stream for running jobs
+    // Only stream for jobs that may still emit logs.
     if (jobStatus !== 'running' && jobStatus !== 'pending') {
       setIsStreaming(false);
       return;
@@ -23,50 +22,130 @@ export const useJobLogStream = (
 
     if (!token) {
       console.error('No auth token available for log streaming');
+      setIsStreaming(false);
       return;
     }
 
+    const abortController = new AbortController();
     setIsStreaming(true);
 
-    // Build the SSE URL using the same base as axios client
-    const url = `${API_BASE_URL}/jobs/${jobId}/logs/stream?token=${encodeURIComponent(token)}`;
-    console.log('Connecting to SSE stream:', url);
-
-    const eventSource = new EventSource(url);
-    eventSourceRef.current = eventSource;
-
-    eventSource.onopen = () => {
-      console.log('SSE connection opened for job:', jobId);
-    };
-
-    eventSource.onmessage = (event) => {
-      console.log('Received log data:', event.data);
-      // SSE strips newlines from data field, so we need to add them back
-      // The data already contains the text, we just ensure proper line breaks
+    const appendLogData = (data: string) => {
       setLogs((prev) => {
-        // If the data already has a newline at the end, don't add another
-        const hasNewline = event.data.endsWith('\n');
-        return prev + event.data + (hasNewline ? '' : '\n');
+        const hasNewline = data.endsWith('\n');
+        return prev + data + (hasNewline ? '' : '\n');
       });
     };
 
-    eventSource.addEventListener('done', (event) => {
-      console.log('SSE stream completed:', event);
-      setIsStreaming(false);
-      eventSource.close();
-    });
+    const streamLogs = async () => {
+      let buffer = '';
+      let eventName = '';
+      let dataLines: string[] = [];
 
-    eventSource.onerror = (error) => {
-      console.error('EventSource error:', error);
-      console.error('EventSource readyState:', eventSource.readyState);
-      setIsStreaming(false);
-      eventSource.close();
+      const resetEvent = () => {
+        eventName = '';
+        dataLines = [];
+      };
+
+      const finishEvent = () => {
+        const data = dataLines.join('\n');
+        if (eventName === 'done') {
+          return true;
+        }
+        if (eventName === 'error') {
+          console.error('SSE stream error:', data);
+          return true;
+        }
+        if (dataLines.length > 0) {
+          appendLogData(data);
+        }
+        resetEvent();
+        return false;
+      };
+
+      const processLine = (line: string) => {
+        if (line === '') {
+          return finishEvent();
+        }
+        if (line.startsWith('event:')) {
+          eventName = line.slice('event:'.length).trimStart();
+          return false;
+        }
+        if (line.startsWith('data:')) {
+          let data = line.slice('data:'.length);
+          if (data.startsWith(' ')) {
+            data = data.slice(1);
+          }
+          dataLines.push(data);
+        }
+        return false;
+      };
+
+      try {
+        const response = await fetch(
+          `${API_BASE_URL}/jobs/${jobId}/logs/stream`,
+          {
+            headers: {
+              Accept: 'text/event-stream',
+              Authorization: `Bearer ${token}`,
+            },
+            signal: abortController.signal,
+          },
+        );
+
+        if (!response.ok) {
+          throw new Error(`Log stream failed with status ${response.status}`);
+        }
+        if (!response.body) {
+          throw new Error('Log stream response body is not readable');
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) {
+            break;
+          }
+
+          buffer += decoder.decode(value, { stream: true });
+          let lineEnd = buffer.indexOf('\n');
+          while (lineEnd !== -1) {
+            let line = buffer.slice(0, lineEnd);
+            if (line.endsWith('\r')) {
+              line = line.slice(0, -1);
+            }
+            buffer = buffer.slice(lineEnd + 1);
+            if (processLine(line)) {
+              await reader.cancel();
+              return;
+            }
+            lineEnd = buffer.indexOf('\n');
+          }
+        }
+
+        buffer += decoder.decode();
+        if (buffer !== '') {
+          processLine(buffer);
+        }
+        if (dataLines.length > 0) {
+          finishEvent();
+        }
+      } catch (error) {
+        if (!abortController.signal.aborted) {
+          console.error('SSE stream error:', error);
+        }
+      } finally {
+        if (!abortController.signal.aborted) {
+          setIsStreaming(false);
+        }
+      }
     };
 
+    void streamLogs();
+
     return () => {
-      if (eventSourceRef.current) {
-        eventSourceRef.current.close();
-      }
+      abortController.abort();
     };
   }, [jobId, jobStatus, token]);
 

--- a/internal/api/handlers/job.go
+++ b/internal/api/handlers/job.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -28,6 +30,22 @@ func NewJobHandler(svc *service.JobService, broker *logstream.LogBroker, valkeyC
 		broker:       broker,
 		valkeyClient: client,
 	}
+}
+
+func writeSSEEvent(w io.Writer, event, data string) {
+	if event != "" {
+		fmt.Fprintf(w, "event: %s\n", event)
+	}
+
+	normalized := strings.NewReplacer("\r\n", "\n", "\r", "\n").Replace(data)
+	for _, line := range strings.Split(normalized, "\n") {
+		fmt.Fprintf(w, "data: %s\n", line)
+	}
+	fmt.Fprint(w, "\n")
+}
+
+func writeSSEData(w io.Writer, data string) {
+	writeSSEEvent(w, "", data)
 }
 
 // ListJobs godoc
@@ -74,7 +92,6 @@ func (h *JobHandler) GetJob(c *gin.Context) {
 // @Security BearerAuth
 // @Produce text/event-stream
 // @Param id path string true "Job ID"
-// @Param token query string false "Auth token (alternative to Bearer header for EventSource compatibility)"
 // @Success 200 {string} string "event stream"
 // @Failure 401 {object} ErrorResponse
 // @Failure 404 {object} ErrorResponse
@@ -103,16 +120,16 @@ func (h *JobHandler) StreamJobLogs(c *gin.Context) {
 	// If job is already completed or failed, send historical logs and close
 	if job.Status == models.JobStatusCompleted || job.Status == models.JobStatusFailed {
 		if job.Logs != "" {
-			fmt.Fprintf(c.Writer, "data: %s\n\n", job.Logs)
+			writeSSEData(c.Writer, job.Logs)
 		}
-		fmt.Fprintf(c.Writer, "event: done\ndata: Job already completed\n\n")
+		writeSSEEvent(c.Writer, "done", "Job already completed")
 		c.Writer.Flush()
 		return
 	}
 
 	// Send historical logs if any exist
 	if job.Logs != "" {
-		fmt.Fprintf(c.Writer, "data: %s\n\n", job.Logs)
+		writeSSEData(c.Writer, job.Logs)
 		c.Writer.Flush()
 	}
 
@@ -122,7 +139,7 @@ func (h *JobHandler) StreamJobLogs(c *gin.Context) {
 	} else if h.broker != nil {
 		h.streamLogsFromBroker(c, jobUUID)
 	} else {
-		fmt.Fprintf(c.Writer, "event: error\ndata: Log streaming not available\n\n")
+		writeSSEEvent(c.Writer, "error", "Log streaming not available")
 		c.Writer.Flush()
 	}
 }
@@ -137,21 +154,21 @@ func (h *JobHandler) streamLogsFromValkey(c *gin.Context, jobID uuid.UUID) {
 	err := h.valkeyClient.Receive(ctx, subscribeCmd, func(msg valkey.PubSubMessage) {
 		logLine := msg.Message
 
-		fmt.Fprintf(c.Writer, "data: %s\n\n", logLine)
+		writeSSEData(c.Writer, logLine)
 		if flusher, ok := c.Writer.(http.Flusher); ok {
 			flusher.Flush()
 		}
 
 		if logLine == "\n[COMPLETED] Job finished successfully\n" ||
 			(len(logLine) > 7 && logLine[:7] == "\n[ERROR]") {
-			fmt.Fprintf(c.Writer, "event: done\ndata: Job completed\n\n")
+			writeSSEEvent(c.Writer, "done", "Job completed")
 			c.Writer.Flush()
 		}
 	})
 
 	if err != nil {
 		if err.Error() != "context canceled" {
-			fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n", err.Error())
+			writeSSEEvent(c.Writer, "error", err.Error())
 			c.Writer.Flush()
 		}
 	}
@@ -169,12 +186,12 @@ func (h *JobHandler) streamLogsFromBroker(c *gin.Context, jobID uuid.UUID) {
 			return
 		case logLine, ok := <-logChan:
 			if !ok {
-				fmt.Fprintf(c.Writer, "event: done\ndata: Stream ended\n\n")
+				writeSSEEvent(c.Writer, "done", "Stream ended")
 				c.Writer.Flush()
 				return
 			}
 
-			fmt.Fprintf(c.Writer, "data: %s\n\n", logLine)
+			writeSSEData(c.Writer, logLine)
 			if flusher, ok := c.Writer.(http.Flusher); ok {
 				flusher.Flush()
 			}

--- a/internal/api/handlers/job_test.go
+++ b/internal/api/handlers/job_test.go
@@ -1,0 +1,28 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestWriteSSEEventFormatsMultilineData(t *testing.T) {
+	var out bytes.Buffer
+
+	writeSSEData(&out, "line one\nline two\n")
+
+	const want = "data: line one\ndata: line two\ndata: \n\n"
+	if got := out.String(); got != want {
+		t.Fatalf("unexpected SSE data frame:\nwant %q\ngot  %q", want, got)
+	}
+}
+
+func TestWriteSSEEventFormatsNamedEvent(t *testing.T) {
+	var out bytes.Buffer
+
+	writeSSEEvent(&out, "done", "Job completed")
+
+	const want = "event: done\ndata: Job completed\n\n"
+	if got := out.String(); got != want {
+		t.Fatalf("unexpected SSE event frame:\nwant %q\ngot  %q", want, got)
+	}
+}

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1,16 +1,22 @@
 package api
 
 import (
+	"bytes"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
+	"github.com/nebari-dev/nebi/internal/auth"
 	"github.com/nebari-dev/nebi/internal/config"
 	"github.com/nebari-dev/nebi/internal/db"
 	"github.com/nebari-dev/nebi/internal/executor"
+	"github.com/nebari-dev/nebi/internal/models"
 	"github.com/nebari-dev/nebi/internal/queue"
 )
 
@@ -44,6 +50,62 @@ func buildTestRouter(t *testing.T, basePath string) http.Handler {
 	return NewRouter(cfg, database, queue.NewMemoryQueue(16), exec, nil, nil, logger)
 }
 
+func buildTeamTestRouter(t *testing.T, logger *slog.Logger) (http.Handler, string) {
+	t.Helper()
+
+	const (
+		username  = "alice"
+		password  = "correct-horse-battery-staple"
+		jwtSecret = "test-secret-for-team-router-test"
+	)
+
+	cfg := &config.Config{Mode: "team"}
+	cfg.Auth.Type = "basic"
+	cfg.Auth.JWTSecret = jwtSecret
+	cfg.Database.Driver = "sqlite"
+	cfg.Database.DSN = filepath.Join(t.TempDir(), "team-router-test.db")
+
+	database, err := db.New(cfg.Database)
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+	if err := db.Migrate(database); err != nil {
+		t.Fatalf("db.Migrate: %v", err)
+	}
+
+	hash, err := auth.HashPassword(password)
+	if err != nil {
+		t.Fatalf("HashPassword: %v", err)
+	}
+	user := models.User{
+		Username:     username,
+		Email:        username + "@example.com",
+		PasswordHash: hash,
+	}
+	if err := database.Create(&user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	authenticator, err := auth.NewBasicAuthenticator(database, jwtSecret, nil)
+	if err != nil {
+		t.Fatalf("NewBasicAuthenticator: %v", err)
+	}
+	login, err := authenticator.Login(username, password)
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	exec, err := executor.NewLocalExecutor(cfg)
+	if err != nil {
+		t.Fatalf("NewLocalExecutor: %v", err)
+	}
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+
+	return NewRouter(cfg, database, queue.NewMemoryQueue(16), exec, nil, nil, logger), login.Token
+}
+
 func TestCORSMiddlewareNoInvalidCredentialedWildcard(t *testing.T) {
 	r := buildTestRouter(t, "")
 
@@ -70,6 +132,51 @@ func TestCORSMiddlewareNoInvalidCredentialedWildcard(t *testing.T) {
 		if acac != "" {
 			t.Fatalf("%s: expected no Access-Control-Allow-Credentials, got %q", path, acac)
 		}
+	}
+}
+
+func TestProtectedRoutesRejectQueryToken(t *testing.T) {
+	r, token := buildTeamTestRouter(t, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/me", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected bearer header to authenticate, got %d", w.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/auth/me?token="+url.QueryEscape(token), nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected query token to be rejected with 401, got %d", w.Code)
+	}
+}
+
+func TestLoggingMiddlewareOmitsQueryString(t *testing.T) {
+	var logs bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	defer slog.SetDefault(previous)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(loggingMiddleware())
+	r.GET("/api/v1/auth/me", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/me?token=secret-bearer-material", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	output := logs.String()
+	if !strings.Contains(output, "/api/v1/auth/me") {
+		t.Fatalf("expected log output to include request path, got %q", output)
+	}
+	if strings.Contains(output, "token") || strings.Contains(output, "secret-bearer-material") {
+		t.Fatalf("expected log output to omit query string, got %q", output)
 	}
 }
 

--- a/internal/auth/basic.go
+++ b/internal/auth/basic.go
@@ -157,7 +157,7 @@ func (a *BasicAuthenticator) validateToken(tokenString string) (*Claims, error) 
 }
 
 // Middleware returns a Gin middleware for authentication.
-// It checks (in order): Bearer token header, ?token= query param, IdToken cookie.
+// It checks (in order): Bearer token header, IdToken cookie.
 func (a *BasicAuthenticator) Middleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var tokenString string
@@ -173,9 +173,6 @@ func (a *BasicAuthenticator) Middleware() gin.HandlerFunc {
 				return
 			}
 			tokenString = parts[1]
-		} else {
-			// Fallback to query parameter (for EventSource/SSE compatibility)
-			tokenString = c.Query("token")
 		}
 
 		// If we have a Nebi JWT, validate it

--- a/internal/auth/basic_test.go
+++ b/internal/auth/basic_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -66,6 +67,34 @@ func TestBasicAuthenticator_LoginTokenIsAccepted(t *testing.T) {
 
 	if code := callWithToken(t, authr.Middleware(), resp.Token); code != http.StatusOK {
 		t.Fatalf("expected 200 for a token signed by Login, got %d", code)
+	}
+}
+
+func TestBasicAuthenticator_RejectsQueryToken(t *testing.T) {
+	db := setupTestDB(t)
+	newTestUser(t, db, "alice", "correct-horse-battery-staple")
+
+	authr, err := NewBasicAuthenticator(db, testJWTSecret, nil)
+	if err != nil {
+		t.Fatalf("NewBasicAuthenticator: %v", err)
+	}
+
+	resp, err := authr.Login("alice", "correct-horse-battery-staple")
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(authr.Middleware())
+	router.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodGet, "/?token="+url.QueryEscape(resp.Token), nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for token in query string, got %d", rec.Code)
 	}
 }
 

--- a/internal/swagger/docs.go
+++ b/internal/swagger/docs.go
@@ -1680,12 +1680,6 @@ const docTemplate = `{
                         "name": "id",
                         "in": "path",
                         "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Auth token (alternative to Bearer header for EventSource compatibility)",
-                        "name": "token",
-                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/internal/swagger/swagger.json
+++ b/internal/swagger/swagger.json
@@ -1674,12 +1674,6 @@
                         "name": "id",
                         "in": "path",
                         "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Auth token (alternative to Bearer header for EventSource compatibility)",
-                        "name": "token",
-                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/internal/swagger/swagger.yaml
+++ b/internal/swagger/swagger.yaml
@@ -1732,10 +1732,6 @@ paths:
         name: id
         required: true
         type: string
-      - description: Auth token (alternative to Bearer header for EventSource compatibility)
-        in: query
-        name: token
-        type: string
       produces:
       - text/event-stream
       responses:


### PR DESCRIPTION
## Reference Issues or PRs
Closes #449 

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [x] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

Removes JWT authentication via `?token=` from protected routes, switches job log streaming to bearer-header `fetch()` streaming, and updates Swagger accordingly. Adds router/logging regression coverage and normalizes SSE log output with a shared multiline-safe writer.
