### PR TITLE
fix(netguard): allow operator-configured origins in local mode

### DIFF
--- a/app.go
+++ b/app.go
@@ -211,7 +211,7 @@ func (a *App) startEmbeddedServer(cfg *config.Config, database *gorm.DB) {
 	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(cfg.Server.Port))
 	a.server = &http.Server{
 		Addr:    addr,
-		Handler: netguard.Middleware(router, false),
+		Handler: netguard.Middleware(router, false, nil),
 	}
 
 	logToFile(fmt.Sprintf("startEmbeddedServer: starting server on %s", addr))

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -4,6 +4,12 @@
 server:
   port: 8460
   mode: development  # or "production"
+  # Local mode only accepts requests with loopback Host/Origin headers.
+  # When nebi is served through a reverse proxy on a public hostname
+  # (e.g. JupyterHub's jupyter-server-proxy), list that origin here so
+  # browser CORS-mode requests (the SPA's crossorigin asset bundle) pass.
+  # Comma-separated. Env: NEBI_SERVER_ALLOWED_ORIGINS
+  # allowed_origins: "https://hub.example.com"
 
 database:
   driver: sqlite  # or "postgres"

--- a/internal/api/cors_test.go
+++ b/internal/api/cors_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func corsTestRouter(localMode bool) *gin.Engine {
+func corsTestRouter(localMode bool, allowedOrigins ...string) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	r.Use(corsMiddleware(localMode))
+	r.Use(corsMiddleware(localMode, allowedOrigins))
 	r.GET("/ping", func(c *gin.Context) { c.String(http.StatusOK, "pong") })
 	return r
 }
@@ -71,5 +71,19 @@ func TestCORSTeamModeKeepsWildcard(t *testing.T) {
 	rec := doCORSRequest(t, r, "https://anywhere.example.com")
 	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
 		t.Errorf("team mode: expected wildcard Access-Control-Allow-Origin, got %q", got)
+	}
+}
+
+func TestCORSLocalModeEchoesConfiguredOrigins(t *testing.T) {
+	r := corsTestRouter(true, "https://hub.example.com")
+
+	rec := doCORSRequest(t, r, "https://hub.example.com")
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://hub.example.com" {
+		t.Errorf("expected configured origin echoed, got %q", got)
+	}
+
+	rec = doCORSRequest(t, r, "https://evil.example.com")
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("expected no Access-Control-Allow-Origin for unlisted origin, got %q", got)
 	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -63,7 +63,7 @@ func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Exe
 	// Middleware
 	router.Use(gin.Recovery())
 	router.Use(loggingMiddleware())
-	router.Use(corsMiddleware(localMode))
+	router.Use(corsMiddleware(localMode, cfg.Server.AllowedOriginsList()))
 
 	// Initialize authenticator based on mode
 	var authenticator auth.Authenticator
@@ -537,15 +537,18 @@ func loggingMiddleware() gin.HandlerFunc {
 //
 // In local mode the API is used only by local UIs, so instead of a wildcard
 // the allowed origin is echoed only for those: loopback http(s) origins (the
-// SPA served by this process, the Vite dev server) and the desktop webview
-// ("wails://..." on macOS/Linux, opaque "null" origins some webviews produce).
-// Those webview requests arrive through the in-process Wails handler, never
-// the network listener (see netguard.Middleware).
-func corsMiddleware(localMode bool) gin.HandlerFunc {
+// SPA served by this process, the Vite dev server), the desktop webview
+// ("wails://..." on macOS/Linux, opaque "null" origins some webviews produce),
+// and any operator-configured server.allowed_origins (a reverse proxy such as
+// jupyter-server-proxy, whose public origin browsers send on CORS-mode
+// requests like Vite's crossorigin module bundles). Webview requests arrive
+// through the in-process Wails handler, never the network listener (see
+// netguard.Middleware, which enforces the same origin rules on requests).
+func corsMiddleware(localMode bool, allowedOrigins []string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if localMode {
 			origin := c.Request.Header.Get("Origin")
-			if netguard.IsLoopbackOrigin(origin) || strings.HasPrefix(origin, "wails://") || origin == "null" {
+			if netguard.IsLoopbackOrigin(origin) || netguard.OriginAllowed(origin, allowedOrigins) || strings.HasPrefix(origin, "wails://") || origin == "null" {
 				c.Writer.Header().Set("Access-Control-Allow-Origin", origin)
 				c.Writer.Header().Set("Vary", "Origin")
 			}

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -24,7 +24,7 @@ import (
 // skipped) backed by an on-disk SQLite database, the in-memory queue, and the
 // local executor. Driving the actual router exercises the real CORS middleware
 // wiring and the real embedded-SPA static handler, not a hand-built stand-in.
-func buildTestRouter(t *testing.T, basePath string) http.Handler {
+func buildTestRouter(t *testing.T, basePath string, mutate ...func(*config.Config)) http.Handler {
 	t.Helper()
 
 	cfg := &config.Config{Mode: "local"}
@@ -32,6 +32,9 @@ func buildTestRouter(t *testing.T, basePath string) http.Handler {
 	cfg.Auth.JWTSecret = "test-secret-for-router-test"
 	cfg.Database.Driver = "sqlite"
 	cfg.Database.DSN = filepath.Join(t.TempDir(), "router-test.db")
+	for _, m := range mutate {
+		m(cfg)
+	}
 
 	database, err := db.New(cfg.Database)
 	if err != nil {
@@ -205,5 +208,32 @@ func TestLegacyCLILoginRoutesRemoved(t *testing.T) {
 		if w.Code != http.StatusNotFound {
 			t.Fatalf("%s %s: expected 404 (route removed), got %d", tc.method, tc.path, w.Code)
 		}
+	}
+}
+
+// TestCORSAllowsConfiguredOrigin drives the real router with an
+// operator-configured non-loopback origin (server.allowed_origins) and
+// asserts the CORS layer echoes it. Browsers require a matching
+// Access-Control-Allow-Origin for the SPA's crossorigin module bundle when
+// nebi is served behind a reverse proxy such as jupyter-server-proxy.
+func TestCORSAllowsConfiguredOrigin(t *testing.T) {
+	router := buildTestRouter(t, "", func(cfg *config.Config) {
+		cfg.Server.AllowedOrigins = "https://hub.example.com"
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
+	req.Header.Set("Origin", "https://hub.example.com")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://hub.example.com" {
+		t.Errorf("expected configured origin echoed in Access-Control-Allow-Origin, got %q", got)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("expected no Access-Control-Allow-Origin for unlisted origin, got %q", got)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,10 +27,26 @@ func (c *Config) IsLocalMode() bool {
 // ServerConfig holds HTTP server configuration
 // Host may be empty to allow "all interfaces" bind behavior.
 type ServerConfig struct {
-	Host     string `mapstructure:"host"` // Bind host/IP (e.g. "127.0.0.1", "0.0.0.0")
-	Port     int    `mapstructure:"port"`
-	Mode     string `mapstructure:"mode"`      // "development" or "production"
-	BasePath string `mapstructure:"base_path"` // URL path prefix (e.g. "/nebi")
+	Host           string `mapstructure:"host"` // Bind host/IP (e.g. "127.0.0.1", "0.0.0.0")
+	Port           int    `mapstructure:"port"`
+	Mode           string `mapstructure:"mode"`            // "development" or "production"
+	BasePath       string `mapstructure:"base_path"`       // URL path prefix (e.g. "/nebi")
+	AllowedOrigins string `mapstructure:"allowed_origins"` // comma-separated non-loopback origins accepted in local mode (e.g. "https://hub.example.com" when proxied by JupyterHub)
+}
+
+// AllowedOriginsList returns server.allowed_origins split on commas, with
+// whitespace trimmed and empty entries dropped.
+func (c *ServerConfig) AllowedOriginsList() []string {
+	if strings.TrimSpace(c.AllowedOrigins) == "" {
+		return nil
+	}
+	var out []string
+	for _, o := range strings.Split(c.AllowedOrigins, ",") {
+		if o = strings.TrimSpace(o); o != "" {
+			out = append(out, o)
+		}
+	}
+	return out
 }
 
 // DatabaseConfig holds database configuration
@@ -90,6 +106,7 @@ func Load() (*Config, error) {
 	v.SetDefault("server.port", 8460)
 	v.SetDefault("server.mode", "development")
 	v.SetDefault("server.base_path", "")
+	v.SetDefault("server.allowed_origins", "")
 	v.SetDefault("database.driver", "sqlite")
 	v.SetDefault("database.dsn", "./nebi.db")
 	v.SetDefault("database.max_idle_conns", 10)
@@ -141,6 +158,7 @@ func Load() (*Config, error) {
 	_ = v.BindEnv("server.port", "NEBI_SERVER_PORT")
 	_ = v.BindEnv("server.mode", "NEBI_SERVER_MODE")
 	_ = v.BindEnv("server.base_path", "NEBI_SERVER_BASE_PATH")
+	_ = v.BindEnv("server.allowed_origins", "NEBI_SERVER_ALLOWED_ORIGINS")
 	_ = v.BindEnv("database.driver", "NEBI_DATABASE_DRIVER")
 	_ = v.BindEnv("database.dsn", "NEBI_DATABASE_DSN")
 	_ = v.BindEnv("auth.type", "NEBI_AUTH_TYPE")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -71,3 +71,26 @@ func TestLoad_LocalMode_AllowsDefaultJWTSecret(t *testing.T) {
 		t.Fatalf("unexpected error in local mode: %v", err)
 	}
 }
+
+func TestLoad_Server_AllowedOrigins(t *testing.T) {
+	isolate(t)
+	t.Setenv("NEBI_MODE", "local")
+	t.Setenv("NEBI_SERVER_ALLOWED_ORIGINS", "https://hub.example.com, https://other.example.com ,")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := cfg.Server.AllowedOriginsList()
+	want := []string{"https://hub.example.com", "https://other.example.com"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("expected %v, got %v", want, got)
+	}
+}
+
+func TestAllowedOriginsList_Empty(t *testing.T) {
+	c := ServerConfig{AllowedOrigins: "  "}
+	if got := c.AllowedOriginsList(); got != nil {
+		t.Errorf("expected nil for blank value, got %v", got)
+	}
+}

--- a/internal/netguard/guard.go
+++ b/internal/netguard/guard.go
@@ -17,20 +17,45 @@ import (
 //     127.0.0.1, ::1). Set allowAnyHost when the operator explicitly bound a
 //     non-loopback interface and therefore expects non-loopback Host values.
 //
-//   - The Origin header, when present, must be a loopback http(s) origin.
-//     Requests without an Origin (CLI, curl, same-origin GET) pass through.
-func Middleware(next http.Handler, allowAnyHost bool) http.Handler {
+//   - The Origin header, when present, must be a loopback http(s) origin or
+//     one of allowedOrigins (operator-configured via server.allowed_origins /
+//     NEBI_SERVER_ALLOWED_ORIGINS, e.g. the public hostname of a reverse
+//     proxy such as JupyterHub's jupyter-server-proxy — browsers send the
+//     proxy's origin on CORS-mode subresource requests like Vite's
+//     crossorigin module bundles). Requests without an Origin (CLI, curl,
+//     same-origin GET) pass through.
+func Middleware(next http.Handler, allowAnyHost bool, allowedOrigins []string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !allowAnyHost && !isLoopbackHostPort(r.Host) {
 			http.Error(w, "Forbidden: local mode only accepts requests addressed to a local host", http.StatusForbidden)
 			return
 		}
-		if origin := r.Header.Get("Origin"); origin != "" && !IsLoopbackOrigin(origin) {
+		if origin := r.Header.Get("Origin"); origin != "" && !IsLoopbackOrigin(origin) && !OriginAllowed(origin, allowedOrigins) {
 			http.Error(w, "Forbidden: local mode only accepts requests from a local origin", http.StatusForbidden)
 			return
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// OriginAllowed reports whether origin matches one of allowed, compared
+// case-insensitively and ignoring surrounding whitespace and trailing
+// slashes (tolerating hand-typed env var values).
+func OriginAllowed(origin string, allowed []string) bool {
+	norm := normalizeOrigin(origin)
+	if norm == "" {
+		return false
+	}
+	for _, a := range allowed {
+		if normalizeOrigin(a) == norm {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeOrigin(origin string) string {
+	return strings.ToLower(strings.TrimRight(strings.TrimSpace(origin), "/"))
 }
 
 // IsLoopbackOrigin reports whether an Origin header value is an http(s)

--- a/internal/netguard/guard_test.go
+++ b/internal/netguard/guard_test.go
@@ -15,7 +15,7 @@ func okHandler() http.Handler {
 }
 
 func TestMiddlewareAllowsLoopbackHosts(t *testing.T) {
-	guard := netguard.Middleware(okHandler(), false)
+	guard := netguard.Middleware(okHandler(), false, nil)
 
 	for _, host := range []string{
 		"localhost:8460",
@@ -37,7 +37,7 @@ func TestMiddlewareAllowsLoopbackHosts(t *testing.T) {
 }
 
 func TestMiddlewareRejectsNonLoopbackHost(t *testing.T) {
-	guard := netguard.Middleware(okHandler(), false)
+	guard := netguard.Middleware(okHandler(), false, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "http://evil.example.com:8460/api/v1/workspaces", nil)
 	rec := httptest.NewRecorder()
@@ -49,7 +49,7 @@ func TestMiddlewareRejectsNonLoopbackHost(t *testing.T) {
 }
 
 func TestMiddlewareRejectsNonLocalOrigins(t *testing.T) {
-	guard := netguard.Middleware(okHandler(), false)
+	guard := netguard.Middleware(okHandler(), false, nil)
 
 	for _, origin := range []string{
 		"https://evil.example.com",
@@ -69,7 +69,7 @@ func TestMiddlewareRejectsNonLocalOrigins(t *testing.T) {
 }
 
 func TestMiddlewareAllowAnyHostStillRejectsNonLocalOrigins(t *testing.T) {
-	guard := netguard.Middleware(okHandler(), true)
+	guard := netguard.Middleware(okHandler(), true, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "http://192.0.2.10:8460/api/v1/health", nil)
 	rec := httptest.NewRecorder()
@@ -87,8 +87,59 @@ func TestMiddlewareAllowAnyHostStillRejectsNonLocalOrigins(t *testing.T) {
 	}
 }
 
+func TestMiddlewareAllowsConfiguredOrigins(t *testing.T) {
+	guard := netguard.Middleware(okHandler(), false, []string{"https://hub.example.com", "https://other.example.com:8443"})
+
+	for _, origin := range []string{
+		"https://hub.example.com",
+		"HTTPS://HUB.EXAMPLE.COM", // case-insensitive
+		"https://other.example.com:8443",
+	} {
+		req := httptest.NewRequest(http.MethodGet, "http://localhost:8460/assets/index.js", nil)
+		req.Header.Set("Origin", origin)
+		rec := httptest.NewRecorder()
+		guard.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("Origin %q: expected 200, got %d", origin, rec.Code)
+		}
+	}
+}
+
+func TestMiddlewareConfiguredOriginsDoNotOpenOtherOrigins(t *testing.T) {
+	guard := netguard.Middleware(okHandler(), false, []string{"https://hub.example.com"})
+
+	for _, origin := range []string{
+		"https://evil.example.com",
+		"https://hub.example.com.evil.com",
+		"http://hub.example.com", // scheme must match too
+	} {
+		req := httptest.NewRequest(http.MethodGet, "http://localhost:8460/assets/index.js", nil)
+		req.Header.Set("Origin", origin)
+		rec := httptest.NewRecorder()
+		guard.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("Origin %q: expected 403, got %d", origin, rec.Code)
+		}
+	}
+}
+
+func TestOriginAllowed(t *testing.T) {
+	allowed := []string{" https://hub.example.com/ "} // tolerates stray whitespace/slash from env vars
+	if !netguard.OriginAllowed("https://hub.example.com", allowed) {
+		t.Error("expected normalized match to be allowed")
+	}
+	if netguard.OriginAllowed("", allowed) {
+		t.Error("empty origin must not match")
+	}
+	if netguard.OriginAllowed("https://hub.example.com", nil) {
+		t.Error("nil allowlist must not match")
+	}
+}
+
 func TestMiddlewareAllowsLoopbackAndAbsentOrigins(t *testing.T) {
-	guard := netguard.Middleware(okHandler(), false)
+	guard := netguard.Middleware(okHandler(), false, nil)
 
 	for _, origin := range []string{
 		"", // CLI / same-origin GET: no Origin header

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -197,7 +197,7 @@ func Run(ctx context.Context, cfg Config) error {
 				slog.Warn("Local mode is bound to a non-loopback interface; it is intended for local use only",
 					"host", appCfg.Server.Host)
 			}
-			handler = netguard.Middleware(router, allowAnyHost)
+			handler = netguard.Middleware(router, allowAnyHost, appCfg.Server.AllowedOriginsList())
 		}
 
 		addr := listenAddress(appCfg.Server.Host, appCfg.Server.Port)


### PR DESCRIPTION
Fixes https://github.com/nebari-dev/nebi/issues/489

## Summary

Local mode rejects any request whose `Origin` header is not a loopback origin (netguard, since https://github.com/nebari-dev/nebi/pull/459). When nebi is served through a reverse proxy on a public hostname, the JupyterHub data-science-pack being the shipping example, browsers send the proxy's origin on CORS-mode subresource requests: Vite emits the SPA bundle as `<script type="module" crossorigin>` / `<link crossorigin>`. Every JS/CSS asset request therefore returned 403 and clicking the Nebi tile rendered a blank page, while the page navigation itself (no Origin header) and curl-based smoke tests passed.

This adds `server.allowed_origins` (`NEBI_SERVER_ALLOWED_ORIGINS`), a comma-separated allowlist of additional origins honored in two places, both of which are required for the browser to load the SPA:

- `netguard.Middleware` accepts listed origins alongside loopback ones (request-side 403 fix)
- `corsMiddleware` echoes listed origins in `Access-Control-Allow-Origin` (response side; `crossorigin` fetches fail in the browser without it even on a 200)

Matching is case-insensitive and tolerates surrounding whitespace and trailing slashes. Default is empty, so behavior is unchanged unless the operator opts in. The desktop app path (`app.go`) passes no extra origins.

Companion change: nebari-dev/data-science-pack will inject `NEBI_SERVER_ALLOWED_ORIGINS=https://<hub-host>` into user pods via the spawner (PR to follow on https://github.com/nebari-dev/data-science-pack/pull/202).

## Test plan

- [x] netguard unit tests: configured origins accepted (incl. case-insensitivity), unlisted/scheme-mismatched origins still 403, loopback and absent-Origin behavior unchanged, allowlist does not bypass the Host check
- [x] CORS tests: configured origin echoed with Vary: Origin, unlisted origin gets no ACAO, local mode still never wildcards, team mode unchanged
- [x] Config tests: env var parsing, whitespace/empty handling
- [x] Router-level test driving the real router with `server.allowed_origins` set
- [x] `go test ./internal/...` all green
- [x] Reproduced the original failure on a live JupyterHub cluster (`curl -H "Origin: https://hub..." -> 403` with the exact 64-byte netguard body observed at the Envoy gateway) confirming the diagnosis this fix targets