### PR TITLE
fix: allow framing from self and configured origins

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -65,7 +65,7 @@ func NewRouter(cfg *config.Config, db *gorm.DB, q queue.Queue, exec executor.Exe
 	// Middleware
 	router.Use(gin.Recovery())
 	router.Use(loggingMiddleware())
-	router.Use(securityHeadersMiddleware(localMode))
+	router.Use(securityHeadersMiddleware(localMode, cfg.Server.AllowedOriginsList()))
 	router.Use(corsMiddleware(localMode, cfg.Server.AllowedOriginsList()))
 
 	// Initialize authenticator based on mode
@@ -544,7 +544,7 @@ const (
 	cspStyleNonceKey  = "cspStyleNonce"
 )
 
-func securityHeadersMiddleware(localMode bool) gin.HandlerFunc {
+func securityHeadersMiddleware(localMode bool, allowedOrigins []string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		scriptNonce, err := newCSPNonce()
 		if err != nil {
@@ -560,11 +560,14 @@ func securityHeadersMiddleware(localMode bool) gin.HandlerFunc {
 		c.Set(cspScriptNonceKey, scriptNonce)
 		c.Set(cspStyleNonceKey, styleNonce)
 		headers := c.Writer.Header()
-		headers.Set("Content-Security-Policy", contentSecurityPolicy(scriptNonce, styleNonce, localMode))
+		headers.Set("Content-Security-Policy", contentSecurityPolicy(scriptNonce, styleNonce, localMode, allowedOrigins))
 		headers.Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		headers.Set("Permissions-Policy", "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()")
 		headers.Set("X-Content-Type-Options", "nosniff")
-		headers.Set("X-Frame-Options", "DENY")
+		// Legacy fallback only: browsers that support CSP frame-ancestors
+		// ignore this header, and it cannot express the configured-origins
+		// allowlist, so SAMEORIGIN is the closest safe value.
+		headers.Set("X-Frame-Options", "SAMEORIGIN")
 		if isHTTPSRequest(c) {
 			headers.Set("Strict-Transport-Security", "max-age=31536000")
 		}
@@ -573,17 +576,25 @@ func securityHeadersMiddleware(localMode bool) gin.HandlerFunc {
 	}
 }
 
-func contentSecurityPolicy(scriptNonce string, styleNonce string, localMode bool) string {
+func contentSecurityPolicy(scriptNonce string, styleNonce string, localMode bool, allowedOrigins []string) string {
 	connectSrc := "connect-src 'self'"
 	if localMode {
 		connectSrc = "connect-src 'self' http://localhost:* http://127.0.0.1:* https://localhost:* https://127.0.0.1:*"
+	}
+
+	// 'self' covers reverse proxies that serve nebi and the framing page
+	// from one origin (e.g. jupyter-server-proxy under JupyterHub);
+	// server.allowed_origins covers frames served from a different origin.
+	frameAncestors := "frame-ancestors 'self'"
+	if len(allowedOrigins) > 0 {
+		frameAncestors += " " + strings.Join(allowedOrigins, " ")
 	}
 
 	directives := []string{
 		"default-src 'self'",
 		"base-uri 'none'",
 		"object-src 'none'",
-		"frame-ancestors 'none'",
+		frameAncestors,
 		"script-src 'self' 'nonce-" + scriptNonce + "'",
 		"style-src 'self' 'nonce-" + styleNonce + "'",
 		"style-src-elem 'self' 'nonce-" + styleNonce + "'",

--- a/internal/api/security_headers_test.go
+++ b/internal/api/security_headers_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func securityHeadersTestRouter(localMode bool) *gin.Engine {
+func securityHeadersTestRouter(localMode bool, allowedOrigins []string) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	r.Use(securityHeadersMiddleware(localMode))
+	r.Use(securityHeadersMiddleware(localMode, allowedOrigins))
 	r.GET("/ping", func(c *gin.Context) { c.String(http.StatusOK, "pong") })
 	return r
 }
@@ -27,7 +27,7 @@ func doSecurityHeadersRequest(t *testing.T, localMode bool, setup func(*http.Req
 		setup(req)
 	}
 	rec := httptest.NewRecorder()
-	securityHeadersTestRouter(localMode).ServeHTTP(rec, req)
+	securityHeadersTestRouter(localMode, nil).ServeHTTP(rec, req)
 	return rec
 }
 
@@ -40,7 +40,7 @@ func TestSecurityHeadersMiddlewareSetsBrowserHardeningHeaders(t *testing.T) {
 		"default-src 'self'",
 		"base-uri 'none'",
 		"object-src 'none'",
-		"frame-ancestors 'none'",
+		"frame-ancestors 'self'",
 		"style-src 'self'",
 		"style-src-attr 'none'",
 		"img-src 'self' data: blob:",
@@ -75,11 +75,26 @@ func TestSecurityHeadersMiddlewareSetsBrowserHardeningHeaders(t *testing.T) {
 	if got := headers.Get("X-Content-Type-Options"); got != "nosniff" {
 		t.Fatalf("expected X-Content-Type-Options nosniff, got %q", got)
 	}
-	if got := headers.Get("X-Frame-Options"); got != "DENY" {
-		t.Fatalf("expected X-Frame-Options DENY, got %q", got)
+	if got := headers.Get("X-Frame-Options"); got != "SAMEORIGIN" {
+		t.Fatalf("expected X-Frame-Options SAMEORIGIN, got %q", got)
 	}
 	if got := headers.Get("Strict-Transport-Security"); got != "" {
 		t.Fatalf("plain HTTP response must not set HSTS, got %q", got)
+	}
+}
+
+func TestSecurityHeadersMiddlewareAllowsConfiguredFrameAncestors(t *testing.T) {
+	origins := []string{"https://hub.example.com", "https://other.example.com"}
+	for _, localMode := range []bool{true, false} {
+		req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+		rec := httptest.NewRecorder()
+		securityHeadersTestRouter(localMode, origins).ServeHTTP(rec, req)
+
+		csp := rec.Header().Get("Content-Security-Policy")
+		want := "frame-ancestors 'self' https://hub.example.com https://other.example.com"
+		if !strings.Contains(csp, want) {
+			t.Fatalf("localMode=%v: expected CSP to include %q, got %q", localMode, want, csp)
+		}
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,7 +32,7 @@ type ServerConfig struct {
 	Port           int    `mapstructure:"port"`
 	Mode           string `mapstructure:"mode"`            // "development" or "production"
 	BasePath       string `mapstructure:"base_path"`       // URL path prefix (e.g. "/nebi")
-	AllowedOrigins string `mapstructure:"allowed_origins"` // comma-separated non-loopback origins accepted in local mode (e.g. "https://hub.example.com" when proxied by JupyterHub)
+	AllowedOrigins string `mapstructure:"allowed_origins"` // comma-separated non-loopback origins accepted in local mode and allowed as CSP frame-ancestors in all modes (e.g. "https://hub.example.com" when proxied by JupyterHub)
 }
 
 // AllowedOriginsList returns server.allowed_origins split on commas, with


### PR DESCRIPTION
## Problem

https://github.com/nebari-dev/nebi/pull/488 added `frame-ancestors 'none'` and `X-Frame-Options: DENY` to every response. This breaks nebi when it is embedded in JupyterLab via jupyter-server-proxy / jhub-apps: the browser refuses to render nebi inside the iframe ("hub.example.com refused to connect", console shows the frame-ancestors CSP violation).

`frame-ancestors 'none'` forbids even same-origin framing, which is exactly the jupyter-server-proxy topology: nebi and the framing JupyterLab page are served from the same hub origin.

## Fix

- `frame-ancestors 'self'` plus any operator-configured `server.allowed_origins` (the knob added in https://github.com/nebari-dev/nebi/pull/490 for exactly this proxy deployment shape, which the security-headers middleware was not consulting).
- `X-Frame-Options: SAMEORIGIN` instead of `DENY`. This header is a legacy fallback only: every browser that supports CSP `frame-ancestors` ignores it when that directive is present, and it cannot express an allowlist.

Clickjacking protection is preserved: arbitrary sites still cannot frame nebi, only same-origin pages and explicitly configured origins can.

## Testing

- New `TestSecurityHeadersMiddlewareAllowsConfiguredFrameAncestors` covering local and team mode (written first, watched fail against the old middleware).
- Updated existing hardening test expectations.
- Verified against a Nebari deployment where the pre-#488 image frames fine in JupyterLab and the post-#488 image is blocked.