### PR TITLE
chore: regenerate swagger docs, fail CI when they drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,18 @@ jobs:
       - name: Create stub frontend/dist for embed
         run: mkdir -p frontend/dist internal/web/dist && touch frontend/dist/.gitkeep internal/web/dist/.gitkeep
 
+      # The Release workflow regenerates these docs and GoReleaser refuses a
+      # dirty tree, so stale committed docs break releases. Catch the drift on
+      # the PR that causes it instead. Uses swag@latest to match release.yml.
+      - name: Check Swagger docs are up to date
+        run: |
+          go install github.com/swaggo/swag/cmd/swag@latest
+          swag init -g cmd/nebi/serve.go -o internal/swagger --packageName swagger
+          if ! git diff --exit-code internal/swagger/; then
+            echo "::error::internal/swagger is stale. Run: swag init -g cmd/nebi/serve.go -o internal/swagger --packageName swagger"
+            exit 1
+          fi
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@8564da7cb3c6866ed1da648ca8f00a258ef0c802 # v6.5.2
         with:

--- a/internal/swagger/docs.go
+++ b/internal/swagger/docs.go
@@ -936,6 +936,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/handlers.ErrorResponse"
                         }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
                     }
                 }
             },
@@ -965,6 +971,12 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/handlers.ErrorResponse"
                         }
@@ -4140,6 +4152,9 @@ const docTemplate = `{
         "service.RegistryResult": {
             "type": "object",
             "properties": {
+                "config_managed": {
+                    "type": "boolean"
+                },
                 "created_at": {
                     "type": "string"
                 },

--- a/internal/swagger/swagger.json
+++ b/internal/swagger/swagger.json
@@ -930,6 +930,12 @@
                         "schema": {
                             "$ref": "#/definitions/handlers.ErrorResponse"
                         }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
                     }
                 }
             },
@@ -959,6 +965,12 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/handlers.ErrorResponse"
                         }
@@ -4134,6 +4146,9 @@
         "service.RegistryResult": {
             "type": "object",
             "properties": {
+                "config_managed": {
+                    "type": "boolean"
+                },
                 "created_at": {
                     "type": "string"
                 },

--- a/internal/swagger/swagger.yaml
+++ b/internal/swagger/swagger.yaml
@@ -642,6 +642,8 @@ definitions:
     type: object
   service.RegistryResult:
     properties:
+      config_managed:
+        type: boolean
       created_at:
         type: string
       has_api_token:
@@ -1224,6 +1226,10 @@ paths:
           description: Not Found
           schema:
             $ref: '#/definitions/handlers.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Delete a registry
@@ -1282,6 +1288,10 @@ paths:
             $ref: '#/definitions/handlers.ErrorResponse'
         "404":
           description: Not Found
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/handlers.ErrorResponse'
       security:


### PR DESCRIPTION
## Problem

The v0.14 release failed (https://github.com/nebari-dev/nebi/actions/runs/31529225352): the Release workflow runs `swag init` before GoReleaser, GoReleaser refuses to release from a dirty tree, and the committed `internal/swagger/` docs were stale. The GitHub release ended up with only the Desktop App assets - no CLI/server binaries, which is what `install.sh`/`install.ps1` consume.

The docs were last regenerated in https://github.com/nebari-dev/nebi/pull/466, and https://github.com/nebari-dev/nebi/pull/477 changed the API surface (`config_managed` field on registries, new 409 responses) without regenerating. Nothing in PR CI catches this, so the failure only surfaces at release time - on whoever cuts the tag, not whoever caused the drift.

## Changes

- Regenerate `internal/swagger/{docs.go,swagger.json,swagger.yaml}` (`swag init -g cmd/nebi/serve.go -o internal/swagger --packageName swagger`). Pure additions from #477's API changes.
- Add a step to the Backend / Lint CI job that regenerates the docs and fails with instructions if `git diff` shows drift, so this is caught on the offending PR. Uses `swag@latest` to match what release.yml installs.

## After merge

The v0.14 tag needs to be re-cut from the fixed main (delete release + tag, re-tag) so the release gets its GoReleaser artifacts - or a v0.15 cut instead.