### PR TITLE
security: bump Go toolchain to 1.26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN npm run build
 # Stage 2: Build Go binary
 # Pinned by exact version + digest; keep in sync with the toolchain directive
 # in go.mod (scripts/check-go-toolchain.sh gates supported lines in CI).
-FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS backend-builder
+FROM golang:1.26.6-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS backend-builder
 WORKDIR /app
 
 # Copy go mod files and download dependencies (cached layer)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nebari-dev/nebi
 
 go 1.25.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.6.1


### PR DESCRIPTION
## Summary

Unblocks CI on `main` and every open PR. `main` is currently red at `0bfadea` across CI, Build and Push Docker Image, and Desktop App, all from one cause: the toolchain pinned by https://github.com/nebari-dev/nebi/pull/491 is `go1.26.5`, which has 8 known-fixed standard library vulnerabilities. They trip the govulncheck gates (Backend / Security, the Desktop `Build` matrix, Build CLI Binaries) and the Trivy image scan.

All 8 are fixed in `go1.26.6`:

| Advisory | CVE | Component |
|---|---|---|
| GO-2026-6218 | CVE-2026-56860 | `net/url` quadratic path parsing DoS |
| GO-2026-6091 | CVE-2026-56858 | `html/template` XSS via pathological input |
| GO-2026-6090 | CVE-2026-56862 | `crypto/tls` indefinite KeyUpdate DoS |
| GO-2026-6089 | CVE-2026-56853 | `net/http` unencrypted HTTP/2 DoS |
| GO-2026-6088 | CVE-2026-56859 | `encoding/xml` decode recursion DoS |
| GO-2026-5972 | CVE-2026-33818 | `encoding/asn1` Unmarshal recursion DoS |
| GO-2026-5942 | CVE-2026-46600 | `x/net/dns/dnsmessage` SVCB/HTTPS RR parse panic |
| GO-2026-5026 | CVE-2026-39821 | `x/net/idna` ASCII-only Punycode label handling |

## Changes

Two lines, kept in sync as `scripts/check-go-toolchain.sh` requires:

- `go.mod`: `toolchain go1.26.5` -> `go1.26.6`. Every workflow resolves Go via `go-version-file: go.mod`, so this covers all the govulncheck jobs.
- `Dockerfile`: builder image -> `golang:1.26.6-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83`, covering the Trivy image scan.

No source changes. Split out of https://github.com/nebari-dev/nebi/pull/506, where the same commit already passed all 11 checks, so it can merge ahead of that PR's review.

## Verification

- Registry config blob for the pinned digest reports `GOLANG_VERSION=1.26.6`, confirmed rather than trusting the tag.
- `scripts/check-go-toolchain.sh --strict` passes.
- `govulncheck@v1.6.0` (the version CI uses) over `./cmd/... ./internal/...`: **no vulnerabilities found**. The residual "3 vulnerabilities in modules you require" is unchanged from before this PR and uncalled, so it does not gate.

## Note for other open PRs

PR CI checks out `refs/pull/N/merge`, so open PRs pick this up automatically on their next run once it lands. No one needs to merge `main` into their branch for the fix to apply. One caveat: re-running an *existing* workflow run replays the original merge SHA and will not pick it up, so a fresh trigger (any push, or a rebase/merge of `main`) is needed for a PR you want green immediately.

## Follow-up

This will recur on every Go patch release, and it lands on whatever PRs happen to be open rather than the one that caused it. The non-strict toolchain check only warns on a stale patch, so the visible failure is govulncheck rather than the clear "update the toolchain directive" message. A scheduled `--strict` run that opens a bump PR would close that gap. Not included here to keep this PR minimal and fast to merge.