### PR TITLE
fix: hide the Admin menu and lock /admin routes in local mode

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,0 +1,63 @@
+import { HttpResponse, http } from 'msw';
+import { Route, Routes } from 'react-router-dom';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AdminRoute } from './App';
+import { useModeStore } from './store/modeStore';
+import { server } from './test/handlers';
+import { renderWithProviders, screen } from './test/utils';
+
+const renderAdminRoutes = () =>
+  renderWithProviders(
+    <Routes>
+      <Route path="/workspaces" element={<div>workspaces page</div>} />
+      <Route element={<AdminRoute />}>
+        <Route path="/admin" element={<div>admin dashboard</div>} />
+      </Route>
+    </Routes>,
+    { initialEntries: ['/admin'] },
+  );
+
+describe('AdminRoute', () => {
+  afterEach(() => {
+    useModeStore.setState({ mode: null, features: {}, loading: true });
+  });
+
+  it('redirects away from /admin in local mode without probing the admin API', async () => {
+    useModeStore.setState({ mode: 'local', features: {}, loading: false });
+    let probed = false;
+    server.use(
+      http.get('/api/v1/admin/users', () => {
+        probed = true;
+        return HttpResponse.json([]);
+      }),
+    );
+
+    renderAdminRoutes();
+
+    expect(await screen.findByText('workspaces page')).toBeInTheDocument();
+    expect(screen.queryByText('admin dashboard')).not.toBeInTheDocument();
+    expect(probed).toBe(false);
+  });
+
+  it('renders admin routes for admins in team mode', async () => {
+    useModeStore.setState({ mode: 'team', features: {}, loading: false });
+
+    renderAdminRoutes();
+
+    expect(await screen.findByText('admin dashboard')).toBeInTheDocument();
+  });
+
+  it('redirects non-admins to workspaces in team mode', async () => {
+    useModeStore.setState({ mode: 'team', features: {}, loading: false });
+    server.use(
+      http.get('/api/v1/admin/users', () =>
+        HttpResponse.json({ error: 'Forbidden' }, { status: 403 }),
+      ),
+    );
+
+    renderAdminRoutes();
+
+    expect(await screen.findByText('workspaces page')).toBeInTheDocument();
+    expect(screen.queryByText('admin dashboard')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { Loader2 } from 'lucide-react';
 import type { ReactElement } from 'react';
 import { useEffect } from 'react';
@@ -9,9 +9,9 @@ import {
   Route,
   Routes,
 } from 'react-router-dom';
-import { adminApi } from './api/admin';
 import { AdminLayout } from './components/layout/AdminLayout';
 import { Layout } from './components/layout/Layout';
+import { useIsAdmin } from './hooks/useAdmin';
 import { useThemePreference } from './hooks/useThemePreference';
 import { getBasePath } from './lib/basePath';
 import { queryClient } from './lib/queryClient';
@@ -58,19 +58,16 @@ const PrivateRoute = ({ children }: { children: ReactElement }) => {
   return isAuthenticated ? children : <Navigate to="/login" />;
 };
 
-const AdminRoute = () => {
-  const { data: isAdmin, isLoading } = useQuery({
-    queryKey: ['user', 'is_admin'],
-    queryFn: async () => {
-      try {
-        await adminApi.getUsers();
-        return true;
-      } catch {
-        return false;
-      }
-    },
-    retry: false,
-  });
+// Exported for tests. Admin is a team-mode surface: local mode has no auth or
+// roles, so /admin/* redirects away without ever probing the admin API (the
+// useIsAdmin query is disabled there).
+export const AdminRoute = () => {
+  const isLocalMode = useModeStore((state) => state.isLocalMode());
+  const { data: isAdmin, isLoading } = useIsAdmin();
+
+  if (isLocalMode) {
+    return <Navigate to="/workspaces" replace />;
+  }
 
   if (isLoading) {
     return (

--- a/frontend/src/components/layout/Layout.test.tsx
+++ b/frontend/src/components/layout/Layout.test.tsx
@@ -1,0 +1,60 @@
+import { HttpResponse, http } from 'msw';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useAuthStore } from '@/store/authStore';
+import { useModeStore } from '@/store/modeStore';
+import { mockUser, server } from '@/test/handlers';
+import { renderWithProviders, screen } from '@/test/utils';
+import { Layout } from './Layout';
+
+const renderLayout = () =>
+  renderWithProviders(
+    <Layout themeMode="system" isDarkMode={false} onThemeChange={vi.fn()} />,
+  );
+
+const useDisconnectedRemoteServer = () =>
+  server.use(
+    http.get('/api/v1/remote/server', () =>
+      HttpResponse.json({ url: '', username: '', status: 'disconnected' }),
+    ),
+  );
+
+describe('Layout', () => {
+  afterEach(() => {
+    useModeStore.setState({ mode: null, features: {}, loading: true });
+    useAuthStore.setState({ token: null, user: null });
+  });
+
+  it('hides the Admin button and profile menu in local mode', async () => {
+    useModeStore.setState({ mode: 'local', features: {}, loading: false });
+    // Even with a stale user in the auth store, local mode shows neither.
+    useAuthStore.setState({ token: 'test-token', user: mockUser });
+    useDisconnectedRemoteServer();
+
+    renderLayout();
+
+    // Wait for the version footer so the header has fully settled.
+    expect(await screen.findByText('v0.0.1')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /admin/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /testuser/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the Admin button and profile menu for admins in team mode', async () => {
+    useModeStore.setState({ mode: 'team', features: {}, loading: false });
+    useAuthStore.setState({ token: 'test-token', user: mockUser });
+    useDisconnectedRemoteServer();
+
+    renderLayout();
+
+    // The default /admin/users handler succeeds, so useIsAdmin resolves true.
+    expect(
+      await screen.findByRole('button', { name: /admin/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /testuser/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -171,7 +171,7 @@ export const Layout = ({
                   </button>
                 </div>
               )}
-              {isAdmin && (
+              {!isLocalMode && isAdmin && (
                 <NavLink to="/admin">
                   {({ isActive }) => (
                     <Button

--- a/frontend/src/hooks/useAdmin.test.ts
+++ b/frontend/src/hooks/useAdmin.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { HttpResponse, http } from 'msw';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useModeStore } from '@/store/modeStore';
 import {
   mockAdminUser,
   mockCollaborator,
@@ -27,6 +28,19 @@ import {
 } from './useAdmin';
 
 describe('useIsAdmin', () => {
+  afterEach(() => {
+    useModeStore.setState({ mode: null, features: {}, loading: true });
+  });
+
+  it('does not probe the admin API in local mode and resolves as not-admin', () => {
+    useModeStore.setState({ mode: 'local', features: {}, loading: false });
+    const { result } = renderHook(() => useIsAdmin(), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(result.current.data).toBeUndefined();
+  });
+
   it('returns true when admin endpoint succeeds', async () => {
     const { result } = renderHook(() => useIsAdmin(), {
       wrapper: createWrapper(),

--- a/frontend/src/hooks/useAdmin.ts
+++ b/frontend/src/hooks/useAdmin.ts
@@ -1,13 +1,17 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { adminApi } from '@/api/admin';
+import { useModeStore } from '@/store/modeStore';
 import type {
   CreateUserRequest,
   FederatedIdentityReviewStatusFilter,
   ShareWorkspaceRequest,
 } from '@/types/models';
 
-// Check if current user is admin
+// Check if current user is admin. Local mode bypasses auth entirely, so there
+// is no admin role to probe for — the query stays disabled there and the
+// undefined data reads as not-admin.
 export const useIsAdmin = () => {
+  const isLocalMode = useModeStore((s) => s.isLocalMode());
   return useQuery({
     queryKey: ['user', 'is_admin'],
     queryFn: async () => {
@@ -19,6 +23,7 @@ export const useIsAdmin = () => {
       }
     },
     retry: false,
+    enabled: !isLocalMode,
   });
 };
 


### PR DESCRIPTION
## Summary

Local mode bypasses auth entirely, so the admin dashboard has nothing to manage there. This hides the admin surface in local mode:

- The `Admin` nav button in `Layout.tsx` renders only when `!isLocalMode && isAdmin`
- `useIsAdmin()` sets `enabled: !isLocalMode`, so the `adminApi.getUsers()` probe never fires in local mode and the hook resolves as not-admin — no wasted round trip on every local-mode app load
- `AdminRoute` redirects `/admin/*` to `/workspaces` in local mode, and now reuses `useIsAdmin()` instead of duplicating the inline `is_admin` query (so it inherits the local-mode disable)

## Tests

- New `Layout.test.tsx`: local mode shows neither the Admin button nor the profile-menu trigger, even with a stale user in the auth store (regression guard for the already-hidden `ProfileMenu`); team mode with an admin shows both
- New `App.test.tsx`: `AdminRoute` redirects in local mode without hitting the admin API (asserted via an msw spy), renders admin routes for team-mode admins, and redirects team-mode non-admins
- `useAdmin.test.ts`: the `is_admin` query stays idle and resolves as not-admin in local mode

Full suite passes (239 tests / 34 files), `tsc -b` clean, `biome check` clean with no new warnings.

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)