### PR TITLE
fix: normalize the Actions column on the workspaces table

### DIFF
--- a/frontend/src/components/workspace/InstallControls.test.tsx
+++ b/frontend/src/components/workspace/InstallControls.test.tsx
@@ -12,31 +12,28 @@ describe('InstallControls', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('shows an Install button when not installed', () => {
+  it('shows a labeled Install button when not installed', () => {
     renderWithProviders(
       <InstallControls workspaceId="ws-1" installStatus="not_installed" />,
     );
-    expect(
-      screen.getByRole('button', { name: /install/i }),
-    ).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: /install/i });
+    expect(button).toHaveTextContent('Install');
   });
 
-  it('shows an Install button after a failed install', () => {
+  it('shows a labeled Retry Install button after a failed install', () => {
     renderWithProviders(
       <InstallControls workspaceId="ws-1" installStatus="install_failed" />,
     );
-    expect(
-      screen.getByRole('button', { name: /install/i }),
-    ).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: /install/i });
+    expect(button).toHaveTextContent('Retry Install');
   });
 
-  it('shows an Uninstall button when installed', () => {
+  it('shows a labeled Uninstall button when installed', () => {
     renderWithProviders(
       <InstallControls workspaceId="ws-1" installStatus="installed" />,
     );
-    expect(
-      screen.getByRole('button', { name: /uninstall/i }),
-    ).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: /uninstall/i });
+    expect(button).toHaveTextContent('Uninstall');
   });
 
   it('shows a disabled progress indicator while installing', () => {
@@ -45,6 +42,7 @@ describe('InstallControls', () => {
     );
     const button = screen.getByRole('button', { name: /installing/i });
     expect(button).toBeDisabled();
+    expect(button).toHaveTextContent('Installing...');
   });
 
   it('calls onStarted with the queued job after clicking Install', async () => {
@@ -126,6 +124,110 @@ describe('InstallControls', () => {
     (await screen.findByRole('button', { name: 'Uninstall' })).click();
     await waitFor(() => expect(onStarted).toHaveBeenCalled());
     expect(onStarted.mock.calls[0][0]).toMatchObject({ id: 'job-2' });
+  });
+
+  describe('icon appearance (table rows)', () => {
+    it('renders an icon-only install button with an aria-label and title', () => {
+      renderWithProviders(
+        <InstallControls
+          workspaceId="ws-1"
+          installStatus="not_installed"
+          appearance="icon"
+        />,
+      );
+      const button = screen.getByRole('button', {
+        name: 'Install environment',
+      });
+      expect(button).toHaveTextContent('');
+      expect(button).toHaveAttribute(
+        'title',
+        'Download and install packages from the lockfile',
+      );
+    });
+
+    it('renders an icon-only uninstall button with an aria-label and title', () => {
+      renderWithProviders(
+        <InstallControls
+          workspaceId="ws-1"
+          installStatus="installed"
+          appearance="icon"
+        />,
+      );
+      const button = screen.getByRole('button', {
+        name: 'Uninstall environment',
+      });
+      expect(button).toHaveTextContent('');
+      expect(button).toHaveAttribute('title');
+    });
+
+    it('keeps the pending state distinguishable while installing', () => {
+      renderWithProviders(
+        <InstallControls
+          workspaceId="ws-1"
+          installStatus="installing"
+          appearance="icon"
+        />,
+      );
+      const button = screen.getByRole('button', { name: 'Installing...' });
+      expect(button).toBeDisabled();
+      expect(button).toHaveAttribute('title', 'Installing...');
+    });
+
+    it('keeps the pending state distinguishable while uninstalling', () => {
+      renderWithProviders(
+        <InstallControls
+          workspaceId="ws-1"
+          installStatus="uninstalling"
+          appearance="icon"
+        />,
+      );
+      const button = screen.getByRole('button', { name: 'Uninstalling...' });
+      expect(button).toBeDisabled();
+    });
+
+    it('still asks for confirmation before uninstalling', async () => {
+      renderWithProviders(
+        <InstallControls
+          workspaceId="ws-1"
+          installStatus="installed"
+          appearance="icon"
+        />,
+      );
+      screen.getByRole('button', { name: 'Uninstall environment' }).click();
+      expect(
+        await screen.findByRole('alertdialog', { name: /uninstall/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('stops click propagation so the row does not navigate', async () => {
+      server.use(
+        http.post('/api/v1/workspaces/ws-1/install', () =>
+          HttpResponse.json(
+            {
+              id: 'job-1',
+              workspace_id: 'ws-1',
+              type: 'env_install',
+              status: 'pending',
+            },
+            { status: 202 },
+          ),
+        ),
+      );
+      const onRowClick = vi.fn();
+      renderWithProviders(
+        // biome-ignore lint/a11y/useKeyWithClickEvents: test-only click capture stand-in for the table row
+        // biome-ignore lint/a11y/noStaticElementInteractions: test-only click capture stand-in for the table row
+        <div onClick={onRowClick}>
+          <InstallControls
+            workspaceId="ws-1"
+            installStatus="not_installed"
+            appearance="icon"
+          />
+        </div>,
+      );
+      screen.getByRole('button', { name: 'Install environment' }).click();
+      expect(onRowClick).not.toHaveBeenCalled();
+    });
   });
 
   it('does not uninstall when the confirmation is cancelled', async () => {

--- a/frontend/src/components/workspace/InstallControls.tsx
+++ b/frontend/src/components/workspace/InstallControls.tsx
@@ -1,4 +1,4 @@
-import { HardDriveDownload, Loader2, Trash2 } from 'lucide-react';
+import { HardDriveDownload, Loader2, PackageMinus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
@@ -11,6 +11,9 @@ import type { InstallStatus, Job } from '@/types';
 interface InstallControlsProps {
   workspaceId: string;
   installStatus?: InstallStatus;
+  // 'labeled' renders outline buttons with icon + text (detail page header);
+  // 'icon' renders ghost icon-only buttons matching other table row actions.
+  appearance?: 'labeled' | 'icon';
   // Called with the queued job right after an install or uninstall is
   // accepted, so callers can jump to the job's logs.
   onStarted?: (job: Job) => void;
@@ -21,6 +24,7 @@ interface InstallControlsProps {
 export const InstallControls = ({
   workspaceId,
   installStatus,
+  appearance = 'labeled',
   onStarted,
 }: InstallControlsProps) => {
   const installMutation = useInstallWorkspace(workspaceId);
@@ -31,11 +35,25 @@ export const InstallControls = ({
 
   const stop = (e: React.MouseEvent) => e.stopPropagation();
 
+  const iconOnly = appearance === 'icon';
+  const variant = iconOnly ? ('ghost' as const) : ('outline' as const);
+  const size = iconOnly ? ('icon' as const) : ('sm' as const);
+  const iconClass = iconOnly ? 'h-4 w-4' : 'h-4 w-4 mr-1.5';
+
   if (installStatus === 'installing' || installStatus === 'uninstalling') {
+    const label =
+      installStatus === 'installing' ? 'Installing...' : 'Uninstalling...';
     return (
-      <Button variant="outline" size="sm" disabled onClick={stop}>
-        <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
-        {installStatus === 'installing' ? 'Installing...' : 'Uninstalling...'}
+      <Button
+        variant={variant}
+        size={size}
+        disabled
+        onClick={stop}
+        aria-label={label}
+        title={label}
+      >
+        <Loader2 className={`${iconClass} animate-spin`} />
+        {!iconOnly && label}
       </Button>
     );
   }
@@ -44,8 +62,8 @@ export const InstallControls = ({
     return (
       <>
         <Button
-          variant="outline"
-          size="sm"
+          variant={variant}
+          size={size}
           disabled={uninstallMutation.isPending}
           onClick={(e) => {
             stop(e);
@@ -54,8 +72,14 @@ export const InstallControls = ({
           aria-label="Uninstall environment"
           title="Remove the installed environment (.pixi/envs); pixi.toml and pixi.lock are kept"
         >
-          <Trash2 className="h-4 w-4 mr-1.5" />
-          Uninstall
+          {iconOnly ? (
+            <PackageMinus className={iconClass} />
+          ) : (
+            <>
+              <Trash2 className={iconClass} />
+              Uninstall
+            </>
+          )}
         </Button>
         <ConfirmDialog
           open={confirmingUninstall}
@@ -73,20 +97,26 @@ export const InstallControls = ({
   }
 
   // not_installed or install_failed
+  const installLabel =
+    installStatus === 'install_failed' ? 'Retry Install' : 'Install';
   return (
     <Button
-      variant="outline"
-      size="sm"
+      variant={variant}
+      size={size}
       disabled={installMutation.isPending}
       onClick={(e) => {
         stop(e);
         installMutation.mutate(undefined, { onSuccess: onStarted });
       }}
-      aria-label="Install environment"
+      aria-label={
+        installStatus === 'install_failed'
+          ? 'Retry environment install'
+          : 'Install environment'
+      }
       title="Download and install packages from the lockfile"
     >
-      <HardDriveDownload className="h-4 w-4 mr-1.5" />
-      {installStatus === 'install_failed' ? 'Retry Install' : 'Install'}
+      <HardDriveDownload className={iconClass} />
+      {!iconOnly && installLabel}
     </Button>
   );
 };

--- a/frontend/src/pages/Workspaces.tsx
+++ b/frontend/src/pages/Workspaces.tsx
@@ -457,6 +457,7 @@ export const Workspaces = () => {
                           <InstallControls
                             workspaceId={ws.id}
                             installStatus={ws.install_status}
+                            appearance="icon"
                             onStarted={(job) =>
                               setEnvJobNotice({
                                 wsId: ws.id,
@@ -470,8 +471,7 @@ export const Workspaces = () => {
                         {ws.location === 'local' && ws.source !== 'local' && (
                           <Button
                             variant="ghost"
-                            size="sm"
-                            className="gap-1.5"
+                            size="icon"
                             onClick={(e) => handleCopyPull(e, ws.name, ws.id)}
                             aria-label={`Copy pull command for ${ws.name}`}
                             title="Copy nebi pull command"
@@ -486,7 +486,7 @@ export const Workspaces = () => {
 
                         <Button
                           variant="ghost"
-                          size="sm"
+                          size="icon"
                           onClick={(e) => {
                             e.stopPropagation();
                             setConfirmDelete({
@@ -497,6 +497,7 @@ export const Workspaces = () => {
                           }}
                           disabled={isDeletePending}
                           aria-label={`Delete ${ws.name}`}
+                          title="Delete workspace"
                         >
                           <Trash2 className="h-4 w-4" />
                         </Button>


### PR DESCRIPTION
Closes #528

## Summary

Normalizes the three row actions in the workspaces table (install/uninstall, copy pull command, delete) to a single treatment: ghost icon-only buttons with `size="icon"`, each carrying both an `aria-label` and a `title`.

- `InstallControls` gains an `appearance` prop: `'labeled'` (default) keeps the current outline icon+text buttons, so the `WorkspaceDetail` header is visually unchanged; `'icon'` renders the new table treatment.
- In icon form, uninstall uses `PackageMinus` instead of `Trash2` so it doesn't read as a duplicate of the row's delete button.
- Pending `installing` / `uninstalling` states stay distinguishable as a disabled ghost icon button with a spinner, plus matching `aria-label`/`title` ("Installing..." / "Uninstalling...").
- The copy-pull button drops the dead `gap-1.5` class and moves from `size="sm"` to `size="icon"`; the delete button does the same and gains a `title`.
- All row action clicks still call `stopPropagation`, covered by a new test.

## Testing

- `InstallControls.test.tsx` updated: labeled-default assertions now check the visible text labels (covering the unchanged detail-page treatment), plus a new suite for the icon appearance (icon-only rendering with `aria-label` + `title`, both pending states, uninstall confirmation flow, click propagation).
- Full suite passes: 239 tests across 32 files, `tsc -b && vite build` succeeds, `biome check` clean (the two remaining infos are pre-existing `biome.json` schema-version notices).

## Before
<img width="1396" height="771" alt="Screenshot 2026-08-25 at 4 33 36 PM" src="https://github.com/user-attachments/assets/c9261653-7e84-45cc-b19c-84292ab38ae7" />

## After
<img width="1437" height="840" alt="Screenshot 2026-08-25 at 4 29 57 PM" src="https://github.com/user-attachments/assets/b7e67f0d-33ff-4ef8-9773-8c859d013aac" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)