### PR TITLE
fix: repositories table UX on the registry browse view

### DIFF
--- a/frontend/src/pages/Registries.test.tsx
+++ b/frontend/src/pages/Registries.test.tsx
@@ -1,0 +1,115 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '@/test/utils';
+import type { OCIRegistry, RegistryTag } from '@/types';
+import { RegistryRepositories } from './Registries';
+
+const registry: OCIRegistry = {
+  id: 'reg-1',
+  name: 'Test Registry',
+  url: 'registry.example.com',
+  username: '',
+  has_api_token: false,
+  is_default: true,
+  namespace: 'envs',
+  config_managed: false,
+  restricted: false,
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+let mockTags: RegistryTag[] = [];
+
+vi.mock('@/hooks/useRegistries', () => ({
+  usePublicRegistries: () => ({ data: [registry], isLoading: false }),
+  useRegistryRepositories: () => ({
+    data: { repositories: [{ name: 'team/app', is_public: true }] },
+    isLoading: false,
+  }),
+  useRepositoryTags: () => ({
+    data: { tags: mockTags },
+    isLoading: false,
+  }),
+  useImportEnvironment: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+const renderPage = () =>
+  renderWithProviders(
+    <Routes>
+      <Route
+        path="/registries/:registryId"
+        element={<RegistryRepositories />}
+      />
+    </Routes>,
+    { initialEntries: ['/registries/reg-1'] },
+  );
+
+describe('RegistryRepositories', () => {
+  beforeEach(() => {
+    mockTags = [];
+  });
+
+  it('defaults the tag select to latest when the repository has one', () => {
+    mockTags = [{ name: 'v1' }, { name: 'latest' }, { name: 'v2' }];
+    renderPage();
+
+    const select = screen.getByLabelText<HTMLSelectElement>(
+      'Select tag for team/app',
+    );
+    expect(select.value).toBe('latest');
+  });
+
+  it('falls back to the first tag when there is no latest tag', () => {
+    mockTags = [{ name: 'v1' }, { name: 'v2' }];
+    renderPage();
+
+    const select = screen.getByLabelText<HTMLSelectElement>(
+      'Select tag for team/app',
+    );
+    expect(select.value).toBe('v1');
+  });
+
+  it('uses the default tag in the command preview and prefilled workspace name', async () => {
+    mockTags = [{ name: 'v1' }, { name: 'latest' }];
+    const user = userEvent.setup();
+    renderPage();
+
+    expect(screen.getByText(/team\/app:latest/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /import/i }));
+    expect(screen.getByLabelText('Workspace Name')).toHaveValue('app-latest');
+  });
+
+  it('toggles the import panel from the row trigger', async () => {
+    mockTags = [{ name: 'latest' }];
+    const user = userEvent.setup();
+    renderPage();
+
+    const trigger = screen.getByRole('button', { name: /import/i });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(trigger);
+    expect(screen.getByLabelText('Workspace Name')).toBeInTheDocument();
+    const closeTrigger = screen.getByRole('button', { name: /close/i });
+    expect(closeTrigger).toHaveAttribute('aria-expanded', 'true');
+
+    await user.click(closeTrigger);
+    expect(screen.queryByLabelText('Workspace Name')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /import/i })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
+
+  it('renders only one Import button while the panel is expanded', async () => {
+    mockTags = [{ name: 'latest' }];
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /import/i }));
+
+    const importButtons = screen.getAllByRole('button', { name: /import/i });
+    expect(importButtons).toHaveLength(1);
+  });
+});

--- a/frontend/src/pages/Registries.tsx
+++ b/frontend/src/pages/Registries.tsx
@@ -2,6 +2,7 @@ import {
   ArrowLeft,
   Check,
   ChevronRight,
+  ChevronUp,
   Copy,
   Download,
   Globe,
@@ -27,6 +28,7 @@ import {
 } from '@/hooks/useRegistries';
 import { useRemoteRegistries, useRemoteView } from '@/hooks/useRemote';
 import { buildImportCommand } from '@/lib/registry';
+import { cn } from '@/lib/utils';
 
 export const Registries = () => {
   const navigate = useNavigate();
@@ -185,7 +187,9 @@ const RepositoryRow = ({
   const importNameId = useId();
 
   const tags = tagData?.tags || [];
-  const effectiveTag = selectedTag || tags[0]?.name || '';
+  const defaultTag =
+    tags.find((tag) => tag.name === 'latest')?.name || tags[0]?.name || '';
+  const effectiveTag = selectedTag || defaultTag;
 
   const handleCopyImportCmd = async () => {
     if (!registry || !effectiveTag) return;
@@ -195,7 +199,11 @@ const RepositoryRow = ({
     setTimeout(() => setCopiedTag(null), 2000);
   };
 
-  const handleOpenImport = () => {
+  const handleToggleImport = () => {
+    if (showImport) {
+      setShowImport(false);
+      return;
+    }
     if (!effectiveTag) return;
     const repoBaseName = repoName.split('/').pop() || repoName;
     setImportName(`${repoBaseName}-${effectiveTag}`);
@@ -227,7 +235,12 @@ const RepositoryRow = ({
 
   return (
     <>
-      <tr className="border-b last:border-0 hover:bg-muted/50">
+      <tr
+        className={cn(
+          'hover:bg-muted/50',
+          !showImport && 'border-b last:border-0',
+        )}
+      >
         <td className="p-4 font-mono text-sm">{repoName}</td>
         {showVisibility && (
           <td className="p-4">
@@ -294,18 +307,33 @@ const RepositoryRow = ({
           <div className="flex items-center justify-end gap-2">
             <Button
               size="sm"
-              onClick={handleOpenImport}
-              disabled={!effectiveTag || tagsLoading}
-              title="Import this environment into a new workspace"
+              variant={showImport ? 'outline' : 'default'}
+              onClick={handleToggleImport}
+              disabled={!showImport && (!effectiveTag || tagsLoading)}
+              aria-expanded={showImport}
+              title={
+                showImport
+                  ? 'Close the import panel'
+                  : 'Import this environment into a new workspace'
+              }
             >
-              <Download className="mr-2 h-4 w-4" />
-              Import
+              {showImport ? (
+                <>
+                  <ChevronUp className="mr-2 h-4 w-4" />
+                  Close
+                </>
+              ) : (
+                <>
+                  <Download className="mr-2 h-4 w-4" />
+                  Import
+                </>
+              )}
             </Button>
           </div>
         </td>
       </tr>
       {showImport && registry && (
-        <tr>
+        <tr className="border-b last:border-0">
           <td colSpan={colSpan} className="p-4 bg-muted/30">
             <div className="space-y-4">
               {error && (


### PR DESCRIPTION
## Summary

Fixes the four UX defects in the repositories table on the registry browse view (`/registries/:id`) described in #525:

- **Tag defaults to `latest`** — the `Tag` select now prefers the tag named `latest` when the repository has one, falling back to the previous first-returned-tag behavior otherwise. The `Command` preview and prefilled workspace name (`${repoBaseName}-${effectiveTag}`) follow the new default automatically.
- **Row trigger toggles the import panel** — clicking `Import` on an expanded row now collapses the panel instead of being a no-op; clicking again re-expands it (`Cancel` still works).
- **Only one Import action while expanded** — the row button becomes an outline `Close` button with a ChevronUp icon while the panel is open and carries `aria-expanded`, so the panel's submit is the only visible `Import`.
- **Expanded panel border** — the panel `<tr>` carries `border-b last:border-0`, and the repository row drops its own bottom border while expanded, so the panel reads as part of its row and separates cleanly from the next repository.

## Tests

Adds `frontend/src/pages/Registries.test.tsx` covering default tag selection with and without a `latest` tag, the default flowing into the command preview and prefilled workspace name, expand/collapse toggling with `aria-expanded` assertions, and exactly one `Import` button while expanded.

- `vitest run`: 238 tests across 33 files pass
- `vite build` succeeds
- Biome clean on the changed files (remaining `biome check` warnings are pre-existing `biome.json` schema-version complaints also present on `main`)

Closes #525

## Before
<img width="1395" height="769" alt="Screenshot 2026-08-25 at 4 43 32 PM" src="https://github.com/user-attachments/assets/b14a9372-bb1e-4f90-85b6-54bc9eaf1a24" />

## After
<img width="1434" height="889" alt="Screenshot 2026-08-25 at 4 44 05 PM" src="https://github.com/user-attachments/assets/594d3bc1-1662-4dbf-9135-09da24a885bc" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)