### PR TITLE
Make log broker overflow visible: bounded wait and drop marker

### DIFF
--- a/internal/api/handlers/job_stream_test.go
+++ b/internal/api/handlers/job_stream_test.go
@@ -1,0 +1,141 @@
+package handlers
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/nebari-dev/nebi/internal/logstream"
+)
+
+// parseSSE decodes an SSE byte stream the way a browser EventSource does:
+// consecutive "data:" lines are joined with "\n" into one message, and a
+// blank line terminates the message.
+func parseSSE(t *testing.T, body string) (messages []string, events []string) {
+	t.Helper()
+	var data []string
+	var event string
+	flush := func() {
+		if len(data) == 0 && event == "" {
+			return
+		}
+		messages = append(messages, strings.Join(data, "\n"))
+		events = append(events, event)
+		data, event = nil, ""
+	}
+	sc := bufio.NewScanner(strings.NewReader(body))
+	for sc.Scan() {
+		line := sc.Text()
+		switch {
+		case line == "":
+			flush()
+		case strings.HasPrefix(line, "data: "):
+			data = append(data, strings.TrimPrefix(line, "data: "))
+		case strings.HasPrefix(line, "event: "):
+			event = strings.TrimPrefix(line, "event: ")
+		default:
+			t.Fatalf("malformed SSE line (would be discarded by the client): %q", line)
+		}
+	}
+	flush()
+	return messages, events
+}
+
+// TestStreamLogsFromBrokerPreservesMultilineBurst reproduces the bug in
+// nebari-dev/nebi#419: pixi emits log chunks containing embedded newlines,
+// in bursts. Every line must reach the client with a data: prefix, and a
+// burst larger than the old 100-entry buffer must not drop lines.
+func TestStreamLogsFromBrokerPreservesMultilineBurst(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	broker := logstream.NewBroker()
+	jobID := uuid.New()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/jobs/"+jobID.String()+"/logs/stream", nil)
+
+	const burst = 1000
+	want := make([]string, 0, burst)
+	for i := 0; i < burst; i++ {
+		want = append(want, fmt.Sprintf("chunk %d line a\nchunk %d line b\r\n  chunk %d line c", i, i, i))
+	}
+
+	// Subscribe synchronously so Publish has a subscriber, then publish the
+	// whole burst before the consumer goroutine drains anything, which is
+	// the worst case for the broker's non-blocking send.
+	ch := broker.Subscribe(jobID)
+	for _, line := range want {
+		broker.Publish(jobID, line)
+	}
+	broker.Close(jobID)
+
+	// Drive the handler's per-line writer over the pre-filled channel.
+	for line := range ch {
+		writeSSEData(c.Writer, line)
+	}
+	writeSSEEvent(c.Writer, "done", "Stream ended")
+
+	messages, events := parseSSE(t, rec.Body.String())
+	if len(messages) != burst+1 {
+		t.Fatalf("got %d SSE messages, want %d log messages + 1 done event (lines dropped?)", len(messages), burst+1)
+	}
+	for i, w := range want {
+		wantNorm := strings.ReplaceAll(w, "\r\n", "\n")
+		if messages[i] != wantNorm {
+			t.Fatalf("message %d mismatch:\nwant %q\ngot  %q", i, wantNorm, messages[i])
+		}
+	}
+	if events[burst] != "done" {
+		t.Fatalf("last event = %q, want done", events[burst])
+	}
+}
+
+// TestStreamLogsFromBrokerEndToEnd runs the real handler loop against a
+// recorder with a producer publishing multiline chunks concurrently.
+func TestStreamLogsFromBrokerEndToEnd(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	broker := logstream.NewBroker()
+	h := &JobHandler{broker: broker}
+	jobID := uuid.New()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/jobs/"+jobID.String()+"/logs/stream", nil)
+
+	const n = 500
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.streamLogsFromBroker(c, jobID)
+	}()
+
+	// Wait for the handler to subscribe before publishing.
+	for !broker.HasSubscribers(jobID) {
+		runtime.Gosched()
+	}
+	for i := 0; i < n; i++ {
+		broker.Publish(jobID, fmt.Sprintf("Installing package %d\n  - dependency resolved", i))
+	}
+	broker.Close(jobID)
+	<-done
+
+	messages, events := parseSSE(t, rec.Body.String())
+	if len(messages) != n+1 {
+		t.Fatalf("got %d SSE messages, want %d + done", len(messages), n+1)
+	}
+	for i := 0; i < n; i++ {
+		want := fmt.Sprintf("Installing package %d\n  - dependency resolved", i)
+		if messages[i] != want {
+			t.Fatalf("message %d:\nwant %q\ngot  %q", i, want, messages[i])
+		}
+	}
+	if events[n] != "done" {
+		t.Fatalf("final event = %q, want done", events[n])
+	}
+}

--- a/internal/logstream/broker.go
+++ b/internal/logstream/broker.go
@@ -3,7 +3,6 @@ package logstream
 import (
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/google/uuid"
 )
@@ -13,11 +12,6 @@ const (
 	// pixi emits output in bursts of many lines; a small buffer caused lines
 	// to be dropped before the SSE writer could drain them.
 	subscriberBufferSize = 4096
-
-	// defaultSendTimeout bounds how long Publish waits for a slow subscriber
-	// before dropping a line. Publish runs synchronously in the job's stdout
-	// writer, so this must stay short to avoid stalling the job itself.
-	defaultSendTimeout = 100 * time.Millisecond
 )
 
 // subscriber holds a subscriber's channel and how many lines have been
@@ -32,14 +26,12 @@ type subscriber struct {
 type LogBroker struct {
 	subscribers map[uuid.UUID]map[chan string]*subscriber // jobID -> set of subscribers
 	mu          sync.RWMutex
-	sendTimeout time.Duration
 }
 
 // NewBroker creates a new log broker
 func NewBroker() *LogBroker {
 	return &LogBroker{
 		subscribers: make(map[uuid.UUID]map[chan string]*subscriber),
-		sendTimeout: defaultSendTimeout,
 	}
 }
 
@@ -78,14 +70,13 @@ func (b *LogBroker) Unsubscribe(jobID uuid.UUID, ch chan string) {
 
 // Publish sends a log line to all subscribers of a job.
 //
-// If a subscriber's buffer is full, Publish waits up to sendTimeout for it
-// to drain. If it still cannot deliver, the line is dropped for that
-// subscriber and counted; the next successful delivery to that subscriber
-// is preceded by a marker line reporting how many lines were lost, so the
-// gap is visible to the client instead of silent.
+// Publish never blocks. If a subscriber's buffer is full, the line is
+// dropped for that subscriber and counted; the next successful delivery to
+// that subscriber is preceded by a marker line reporting how many lines
+// were lost, so the gap is visible to the client instead of silent. Publish
+// runs synchronously in the job's stdout writer, so a subscriber that has
+// fallen subscriberBufferSize lines behind is not worth stalling the job for.
 func (b *LogBroker) Publish(jobID uuid.UUID, line string) {
-	// Holding the read lock for the bounded wait delays Unsubscribe/Close by
-	// at most sendTimeout per subscriber, which is acceptable.
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
@@ -107,33 +98,25 @@ func (b *LogBroker) publishTo(sub *subscriber, line string) {
 
 	if sub.dropped > 0 {
 		marker := fmt.Sprintf("\n[nebi] %d log lines dropped because the client could not keep up; refresh to see the full log\n", sub.dropped)
-		if !b.send(sub.ch, marker) {
+		if !trySend(sub.ch, marker) {
 			// Still no room; drop this line too and keep the counter growing.
 			sub.dropped++
 			return
 		}
 		sub.dropped = 0
 	}
-	if !b.send(sub.ch, line) {
+	if !trySend(sub.ch, line) {
 		sub.dropped++
 	}
 }
 
-// send attempts a non-blocking send, then waits up to sendTimeout. It
-// returns false if the line could not be delivered.
-func (b *LogBroker) send(ch chan string, line string) bool {
+// trySend attempts a non-blocking send and returns false if the channel
+// buffer is full.
+func trySend(ch chan string, line string) bool {
 	select {
 	case ch <- line:
 		return true
 	default:
-	}
-
-	timer := time.NewTimer(b.sendTimeout)
-	defer timer.Stop()
-	select {
-	case ch <- line:
-		return true
-	case <-timer.C:
 		return false
 	}
 }

--- a/internal/logstream/broker.go
+++ b/internal/logstream/broker.go
@@ -1,21 +1,45 @@
 package logstream
 
 import (
+	"fmt"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 )
 
+const (
+	// subscriberBufferSize is the number of log lines buffered per subscriber.
+	// pixi emits output in bursts of many lines; a small buffer caused lines
+	// to be dropped before the SSE writer could drain them.
+	subscriberBufferSize = 4096
+
+	// defaultSendTimeout bounds how long Publish waits for a slow subscriber
+	// before dropping a line. Publish runs synchronously in the job's stdout
+	// writer, so this must stay short to avoid stalling the job itself.
+	defaultSendTimeout = 100 * time.Millisecond
+)
+
+// subscriber holds a subscriber's channel and how many lines have been
+// dropped for it since the last delivered drop marker.
+type subscriber struct {
+	ch      chan string
+	mu      sync.Mutex // serializes Publish per subscriber so marker + line ordering and dropped are consistent
+	dropped int
+}
+
 // LogBroker manages log streams for jobs
 type LogBroker struct {
-	subscribers map[uuid.UUID]map[chan string]bool // jobID -> set of subscriber channels
+	subscribers map[uuid.UUID]map[chan string]*subscriber // jobID -> set of subscribers
 	mu          sync.RWMutex
+	sendTimeout time.Duration
 }
 
 // NewBroker creates a new log broker
 func NewBroker() *LogBroker {
 	return &LogBroker{
-		subscribers: make(map[uuid.UUID]map[chan string]bool),
+		subscribers: make(map[uuid.UUID]map[chan string]*subscriber),
+		sendTimeout: defaultSendTimeout,
 	}
 }
 
@@ -24,12 +48,12 @@ func (b *LogBroker) Subscribe(jobID uuid.UUID) chan string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	ch := make(chan string, 100) // Buffered channel to prevent blocking
+	ch := make(chan string, subscriberBufferSize)
 
 	if b.subscribers[jobID] == nil {
-		b.subscribers[jobID] = make(map[chan string]bool)
+		b.subscribers[jobID] = make(map[chan string]*subscriber)
 	}
-	b.subscribers[jobID][ch] = true
+	b.subscribers[jobID][ch] = &subscriber{ch: ch}
 
 	return ch
 }
@@ -40,8 +64,10 @@ func (b *LogBroker) Unsubscribe(jobID uuid.UUID, ch chan string) {
 	defer b.mu.Unlock()
 
 	if subs, exists := b.subscribers[jobID]; exists {
-		delete(subs, ch)
-		close(ch)
+		if _, ok := subs[ch]; ok {
+			delete(subs, ch)
+			close(ch)
+		}
 
 		// Clean up if no more subscribers for this job
 		if len(subs) == 0 {
@@ -50,20 +76,65 @@ func (b *LogBroker) Unsubscribe(jobID uuid.UUID, ch chan string) {
 	}
 }
 
-// Publish sends a log line to all subscribers of a job
+// Publish sends a log line to all subscribers of a job.
+//
+// If a subscriber's buffer is full, Publish waits up to sendTimeout for it
+// to drain. If it still cannot deliver, the line is dropped for that
+// subscriber and counted; the next successful delivery to that subscriber
+// is preceded by a marker line reporting how many lines were lost, so the
+// gap is visible to the client instead of silent.
 func (b *LogBroker) Publish(jobID uuid.UUID, line string) {
+	// Holding the read lock for the bounded wait delays Unsubscribe/Close by
+	// at most sendTimeout per subscriber, which is acceptable.
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
-	if subs, exists := b.subscribers[jobID]; exists {
-		for ch := range subs {
-			// Non-blocking send - drop if channel is full
-			select {
-			case ch <- line:
-			default:
-				// Channel full, log is dropped
-			}
+	subs, exists := b.subscribers[jobID]
+	if !exists {
+		return
+	}
+
+	for _, sub := range subs {
+		b.publishTo(sub, line)
+	}
+}
+
+// publishTo delivers a line to one subscriber, emitting a drop marker first
+// if earlier lines were lost.
+func (b *LogBroker) publishTo(sub *subscriber, line string) {
+	sub.mu.Lock()
+	defer sub.mu.Unlock()
+
+	if sub.dropped > 0 {
+		marker := fmt.Sprintf("\n[nebi] %d log lines dropped because the client could not keep up; refresh to see the full log\n", sub.dropped)
+		if !b.send(sub.ch, marker) {
+			// Still no room; drop this line too and keep the counter growing.
+			sub.dropped++
+			return
 		}
+		sub.dropped = 0
+	}
+	if !b.send(sub.ch, line) {
+		sub.dropped++
+	}
+}
+
+// send attempts a non-blocking send, then waits up to sendTimeout. It
+// returns false if the line could not be delivered.
+func (b *LogBroker) send(ch chan string, line string) bool {
+	select {
+	case ch <- line:
+		return true
+	default:
+	}
+
+	timer := time.NewTimer(b.sendTimeout)
+	defer timer.Stop()
+	select {
+	case ch <- line:
+		return true
+	case <-timer.C:
+		return false
 	}
 }
 

--- a/internal/logstream/broker_test.go
+++ b/internal/logstream/broker_test.go
@@ -1,0 +1,213 @@
+package logstream
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestPublishDeliversBurstLargerThanOldBuffer(t *testing.T) {
+	b := NewBroker()
+	jobID := uuid.New()
+	ch := b.Subscribe(jobID)
+
+	const n = 1000
+	for i := 0; i < n; i++ {
+		b.Publish(jobID, fmt.Sprintf("line %d", i))
+	}
+	b.Close(jobID)
+
+	var got []string
+	for line := range ch {
+		got = append(got, line)
+	}
+	if len(got) != n {
+		t.Fatalf("got %d lines, want %d", len(got), n)
+	}
+}
+
+func TestPublishWaitsForSlowSubscriberWithinTimeout(t *testing.T) {
+	b := NewBroker()
+	b.sendTimeout = 500 * time.Millisecond
+	jobID := uuid.New()
+	ch := b.Subscribe(jobID)
+
+	// Fill the buffer completely.
+	for i := 0; i < subscriberBufferSize; i++ {
+		b.Publish(jobID, "fill")
+	}
+
+	// A consumer that starts draining shortly after the producer blocks.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		<-ch
+	}()
+
+	start := time.Now()
+	b.Publish(jobID, "late")
+	elapsed := time.Since(start)
+	if elapsed >= b.sendTimeout {
+		t.Fatalf("Publish took %v, should have unblocked once consumer read", elapsed)
+	}
+
+	b.Close(jobID)
+	var last string
+	for line := range ch {
+		last = line
+	}
+	if last != "late" {
+		t.Fatalf("last line = %q, want %q (no drop expected)", last, "late")
+	}
+}
+
+func TestPublishDropsAfterTimeoutAndEmitsMarker(t *testing.T) {
+	b := NewBroker()
+	b.sendTimeout = 10 * time.Millisecond
+	jobID := uuid.New()
+	ch := b.Subscribe(jobID)
+
+	for i := 0; i < subscriberBufferSize; i++ {
+		b.Publish(jobID, fmt.Sprintf("fill %d", i))
+	}
+
+	// Nobody is reading: these must be dropped after the bounded wait,
+	// and Publish must return promptly rather than blocking the producer.
+	const dropped = 3
+	start := time.Now()
+	for i := 0; i < dropped; i++ {
+		b.Publish(jobID, fmt.Sprintf("lost %d", i))
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("Publish blocked for %v with a full buffer", elapsed)
+	}
+
+	// Free two slots, then publish another line. The marker must be
+	// delivered before that line.
+	<-ch
+	<-ch
+	b.Publish(jobID, "after")
+	b.Close(jobID)
+
+	var got []string
+	for line := range ch {
+		got = append(got, line)
+	}
+	if len(got) < 2 {
+		t.Fatalf("got %d lines after drain, want at least marker + after: %q", len(got), got)
+	}
+	marker, after := got[len(got)-2], got[len(got)-1]
+	if !strings.Contains(marker, fmt.Sprintf("%d log lines dropped", dropped)) {
+		t.Fatalf("expected drop marker for %d lines, got %q", dropped, marker)
+	}
+	if after != "after" {
+		t.Fatalf("line following marker = %q, want %q", after, "after")
+	}
+	for _, l := range got {
+		if strings.HasPrefix(l, "lost") {
+			t.Fatalf("dropped line %q was unexpectedly delivered", l)
+		}
+	}
+}
+
+func TestDropMarkerNotRepeatedOnceDelivered(t *testing.T) {
+	b := NewBroker()
+	b.sendTimeout = 10 * time.Millisecond
+	jobID := uuid.New()
+	ch := b.Subscribe(jobID)
+
+	for i := 0; i < subscriberBufferSize; i++ {
+		b.Publish(jobID, "fill")
+	}
+	b.Publish(jobID, "lost")
+
+	// Drain everything so both the marker and subsequent lines fit.
+	for i := 0; i < subscriberBufferSize; i++ {
+		<-ch
+	}
+	b.Publish(jobID, "a")
+	b.Publish(jobID, "b")
+	b.Close(jobID)
+
+	var got []string
+	for line := range ch {
+		got = append(got, line)
+	}
+	markers := 0
+	for _, l := range got {
+		if strings.Contains(l, "dropped") {
+			markers++
+		}
+	}
+	if markers != 1 {
+		t.Fatalf("got %d drop markers, want exactly 1: %q", markers, got)
+	}
+	if len(got) != 3 || got[1] != "a" || got[2] != "b" {
+		t.Fatalf("unexpected sequence after drop: %q", got)
+	}
+}
+
+func TestPublishIsolatesSlowSubscriberFromFastOne(t *testing.T) {
+	b := NewBroker()
+	b.sendTimeout = 10 * time.Millisecond
+	jobID := uuid.New()
+	slow := b.Subscribe(jobID)
+	fast := b.Subscribe(jobID)
+
+	const n = subscriberBufferSize + 5
+	fastGot := make(chan int)
+	go func() {
+		count := 0
+		for range fast {
+			count++
+		}
+		fastGot <- count
+	}()
+
+	for i := 0; i < n; i++ {
+		b.Publish(jobID, "x")
+	}
+	b.Close(jobID)
+
+	if c := <-fastGot; c != n {
+		t.Fatalf("fast subscriber got %d lines, want %d", c, n)
+	}
+	slowCount := 0
+	for range slow {
+		slowCount++
+	}
+	if slowCount != subscriberBufferSize {
+		t.Fatalf("slow subscriber got %d lines, want %d buffered (rest dropped)", slowCount, subscriberBufferSize)
+	}
+}
+
+func TestConcurrentPublishDoesNotRace(t *testing.T) {
+	b := NewBroker()
+	b.sendTimeout = time.Millisecond
+	jobID := uuid.New()
+	ch := b.Subscribe(jobID)
+
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Enough total to overflow the buffer a few hundred times.
+			for i := 0; i < subscriberBufferSize/8+100; i++ {
+				b.Publish(jobID, "x")
+			}
+		}()
+	}
+	wg.Wait()
+	b.Close(jobID)
+	n := 0
+	for range ch {
+		n++
+	}
+	if n == 0 || n > subscriberBufferSize {
+		t.Fatalf("delivered %d lines, want 1..%d", n, subscriberBufferSize)
+	}
+}

--- a/internal/logstream/broker_test.go
+++ b/internal/logstream/broker_test.go
@@ -30,43 +30,8 @@ func TestPublishDeliversBurstLargerThanOldBuffer(t *testing.T) {
 	}
 }
 
-func TestPublishWaitsForSlowSubscriberWithinTimeout(t *testing.T) {
+func TestPublishDropsWhenFullAndEmitsMarker(t *testing.T) {
 	b := NewBroker()
-	b.sendTimeout = 500 * time.Millisecond
-	jobID := uuid.New()
-	ch := b.Subscribe(jobID)
-
-	// Fill the buffer completely.
-	for i := 0; i < subscriberBufferSize; i++ {
-		b.Publish(jobID, "fill")
-	}
-
-	// A consumer that starts draining shortly after the producer blocks.
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		<-ch
-	}()
-
-	start := time.Now()
-	b.Publish(jobID, "late")
-	elapsed := time.Since(start)
-	if elapsed >= b.sendTimeout {
-		t.Fatalf("Publish took %v, should have unblocked once consumer read", elapsed)
-	}
-
-	b.Close(jobID)
-	var last string
-	for line := range ch {
-		last = line
-	}
-	if last != "late" {
-		t.Fatalf("last line = %q, want %q (no drop expected)", last, "late")
-	}
-}
-
-func TestPublishDropsAfterTimeoutAndEmitsMarker(t *testing.T) {
-	b := NewBroker()
-	b.sendTimeout = 10 * time.Millisecond
 	jobID := uuid.New()
 	ch := b.Subscribe(jobID)
 
@@ -74,14 +39,14 @@ func TestPublishDropsAfterTimeoutAndEmitsMarker(t *testing.T) {
 		b.Publish(jobID, fmt.Sprintf("fill %d", i))
 	}
 
-	// Nobody is reading: these must be dropped after the bounded wait,
-	// and Publish must return promptly rather than blocking the producer.
+	// Nobody is reading: these must be dropped immediately, and Publish
+	// must return promptly rather than blocking the producer.
 	const dropped = 3
 	start := time.Now()
 	for i := 0; i < dropped; i++ {
 		b.Publish(jobID, fmt.Sprintf("lost %d", i))
 	}
-	if elapsed := time.Since(start); elapsed > time.Second {
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
 		t.Fatalf("Publish blocked for %v with a full buffer", elapsed)
 	}
 
@@ -115,7 +80,6 @@ func TestPublishDropsAfterTimeoutAndEmitsMarker(t *testing.T) {
 
 func TestDropMarkerNotRepeatedOnceDelivered(t *testing.T) {
 	b := NewBroker()
-	b.sendTimeout = 10 * time.Millisecond
 	jobID := uuid.New()
 	ch := b.Subscribe(jobID)
 
@@ -152,7 +116,6 @@ func TestDropMarkerNotRepeatedOnceDelivered(t *testing.T) {
 
 func TestPublishIsolatesSlowSubscriberFromFastOne(t *testing.T) {
 	b := NewBroker()
-	b.sendTimeout = 10 * time.Millisecond
 	jobID := uuid.New()
 	slow := b.Subscribe(jobID)
 	fast := b.Subscribe(jobID)
@@ -186,7 +149,6 @@ func TestPublishIsolatesSlowSubscriberFromFastOne(t *testing.T) {
 
 func TestConcurrentPublishDoesNotRace(t *testing.T) {
 	b := NewBroker()
-	b.sendTimeout = time.Millisecond
 	jobID := uuid.New()
 	ch := b.Subscribe(jobID)
 


### PR DESCRIPTION
## Problem

The in-memory `LogBroker` does a non-blocking send to each subscriber and silently drops lines when the 100-entry channel buffer is full. pixi emits output in bursts, so the live job log in the UI had gaps that disappeared after a refresh (the DB copy was complete; only the stream lost data).

This is the second half of https://github.com/nebari-dev/nebi/pull/419. That PR's SSE framing fix (one `data:` prefix per line for multiline chunks) already landed via https://github.com/nebari-dev/nebi/pull/466; its remaining change was the buffer bump, which this PR includes and extends.

## Changes

- Per-subscriber buffer raised from 100 to 4096 lines.
- `Publish` stays non-blocking: on a full buffer the line is dropped for that subscriber. `Publish` runs synchronously in the job's stdout writer, and a subscriber 4096 lines behind is not worth stalling the job for.
- Drops are counted per subscriber. As soon as room frees up, a marker line `[nebi] N log lines dropped because the client could not keep up; refresh to see the full log` is delivered ahead of the next line, so a gap is visible rather than silent.
- Slow subscribers no longer cause drops for fast subscribers on the same job.
- Per-subscriber mutex so concurrent `Publish` calls keep marker/line ordering and the drop counter consistent.

## Tests

`internal/logstream/broker_test.go`:
- 1000-line burst delivered intact (fails at buffer=100 with 900 lost)
- drop on full buffer without blocking, marker emitted with correct count, dropped lines not delivered
- marker emitted exactly once per gap
- slow subscriber isolated from fast subscriber
- concurrent Publish under `-race`

`internal/api/handlers/job_stream_test.go`:
- browser-style SSE parser; end-to-end through `streamLogsFromBroker` with a concurrent producer of multiline chunks (incl. `\r\n`), asserting every line is `data:`-prefixed and none dropped. Mutation-checked: fails against both the old `data: %s\n\n` format and the old buffer size.

`go test ./internal/... -race` and `golangci-lint` are clean.
