### PR TITLE
Bump Go toolchain to 1.26.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN npm run build
 # Stage 2: Build Go binary
 # Pinned by exact version + digest; keep in sync with the toolchain directive
 # in go.mod (scripts/check-go-toolchain.sh gates supported lines in CI).
-FROM golang:1.26.6-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS backend-builder
+FROM golang:1.26.7-alpine@sha256:28d89ee9cc0ff9fec75c82ca201e6bf7fdf9a679d4b7b24dfa04f2bb766bb468 AS backend-builder
 WORKDIR /app
 
 # Copy go mod files and download dependencies (cached layer)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nebari-dev/nebi
 
 go 1.25.0
 
-toolchain go1.26.6
+toolchain go1.26.7
 
 require (
 	github.com/alicebob/miniredis/v2 v2.37.0


### PR DESCRIPTION
The release workflow's strict toolchain gate (`scripts/check-go-toolchain.sh --strict`) fails on main because go.mod pins go1.26.6 and go1.26.7 is out. This blocks cutting v0.15.

- `go.mod`: toolchain go1.26.6 -> go1.26.7
- `Dockerfile`: golang:1.26.7-alpine with pinned digest

govulncheck on `./cmd/... ./internal/...` is clean.