### PR TITLE
Fix SQLite startup crash dropping workspaces.package_manager on populated databases

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -100,16 +100,6 @@ func New(cfg config.DatabaseConfig) (*gorm.DB, error) {
 func Migrate(db *gorm.DB, seedRegistry bool) error {
 	slog.Info("Running database migrations...")
 
-	// The SQLite driver rebuilds tables through a workspaces__temp copy; a
-	// failed rebuild (e.g. the package_manager drop below, before it ran
-	// with foreign keys suspended) strands that table with rows already
-	// copied, and any later rebuild's CREATE TABLE would collide with it.
-	if db.Dialector.Name() == "sqlite" {
-		if err := db.Exec("DROP TABLE IF EXISTS `workspaces__temp`").Error; err != nil {
-			return fmt.Errorf("failed to drop stranded workspaces__temp table: %w", err)
-		}
-	}
-
 	// Auto-migrate all models
 	err := db.AutoMigrate(
 		&models.User{},

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -100,6 +100,16 @@ func New(cfg config.DatabaseConfig) (*gorm.DB, error) {
 func Migrate(db *gorm.DB, seedRegistry bool) error {
 	slog.Info("Running database migrations...")
 
+	// The SQLite driver rebuilds tables through a workspaces__temp copy; a
+	// failed rebuild (e.g. the package_manager drop below, before it ran
+	// with foreign keys suspended) strands that table with rows already
+	// copied, and any later rebuild's CREATE TABLE would collide with it.
+	if db.Dialector.Name() == "sqlite" {
+		if err := db.Exec("DROP TABLE IF EXISTS `workspaces__temp`").Error; err != nil {
+			return fmt.Errorf("failed to drop stranded workspaces__temp table: %w", err)
+		}
+	}
+
 	// Auto-migrate all models
 	err := db.AutoMigrate(
 		&models.User{},
@@ -132,7 +142,7 @@ func Migrate(db *gorm.DB, seedRegistry bool) error {
 	// manager, and the column was NOT NULL so leaving it would break inserts
 	// on databases created before its removal.
 	if db.Migrator().HasColumn(&models.Workspace{}, "package_manager") {
-		if err := db.Migrator().DropColumn(&models.Workspace{}, "package_manager"); err != nil {
+		if err := dropLegacyPackageManagerColumn(db); err != nil {
 			return fmt.Errorf("failed to drop workspaces.package_manager column: %w", err)
 		}
 	}
@@ -158,6 +168,31 @@ func Migrate(db *gorm.DB, seedRegistry bool) error {
 	}
 
 	return nil
+}
+
+// dropLegacyPackageManagerColumn removes the legacy workspaces.package_manager
+// column. On SQLite the driver emulates DropColumn by rebuilding the table
+// (create workspaces__temp, copy rows, drop workspaces, rename), and dropping
+// the old table violates the foreign keys that jobs/publications rows hold on
+// it, so enforcement is suspended for the duration. The foreign_keys pragma is
+// connection-scoped (the DSN pragma re-enables it on every new pooled
+// connection) and a no-op inside a transaction, so every statement is pinned
+// to a single connection and the pragma is flipped outside the rebuild's
+// transaction.
+func dropLegacyPackageManagerColumn(db *gorm.DB) error {
+	if db.Dialector.Name() != "sqlite" {
+		return db.Migrator().DropColumn(&models.Workspace{}, "package_manager")
+	}
+	return db.Connection(func(conn *gorm.DB) error {
+		if err := conn.Exec("PRAGMA foreign_keys = OFF").Error; err != nil {
+			return err
+		}
+		dropErr := conn.Migrator().DropColumn(&models.Workspace{}, "package_manager")
+		if err := conn.Exec("PRAGMA foreign_keys = ON").Error; err != nil && dropErr == nil {
+			dropErr = err
+		}
+		return dropErr
+	})
 }
 
 func seedResourceLocks(db *gorm.DB) error {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -205,22 +205,12 @@ func TestMigrateDropsLegacyPackageManagerColumnWithReferencingRows(t *testing.T)
 	).Error; err != nil {
 		t.Fatalf("insert referencing job: %v", err)
 	}
-	// A previously failed migration attempt strands the rebuild table.
-	if err := database.Exec(
-		"CREATE TABLE `workspaces__temp` (`id` text PRIMARY KEY)",
-	).Error; err != nil {
-		t.Fatalf("create stranded temp table: %v", err)
-	}
-
 	if err := Migrate(database, false); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 
 	if database.Migrator().HasColumn(&models.Workspace{}, "package_manager") {
 		t.Fatal("expected package_manager column to be dropped")
-	}
-	if database.Migrator().HasTable("workspaces__temp") {
-		t.Fatal("expected stranded workspaces__temp table to be removed")
 	}
 
 	var wsCount, jobCount int64

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -167,3 +167,73 @@ func TestMigrateDropsLegacyPackageManagerColumn(t *testing.T) {
 		t.Fatalf("create workspace after migration: %v", err)
 	}
 }
+
+func TestMigrateDropsLegacyPackageManagerColumnWithReferencingRows(t *testing.T) {
+	database := testDB(t)
+
+	// Simulate a real pre-removal database: the SQLite driver emulates
+	// DropColumn by rebuilding the table, and DROP TABLE on the old
+	// workspaces violates the foreign keys held by referencing jobs rows
+	// when enforcement is on (it is, via the DSN pragma).
+	if err := database.Exec(
+		"CREATE TABLE `users` (`id` text PRIMARY KEY, `username` text, `email` text, `password_hash` text NOT NULL)",
+	).Error; err != nil {
+		t.Fatalf("create legacy users table: %v", err)
+	}
+	if err := database.Exec(
+		"CREATE TABLE `workspaces` (`id` text PRIMARY KEY, `name` text NOT NULL, `package_manager` text NOT NULL, `owner_id` text, CONSTRAINT `fk_workspaces_owner` FOREIGN KEY (`owner_id`) REFERENCES `users`(`id`))",
+	).Error; err != nil {
+		t.Fatalf("create legacy workspaces table: %v", err)
+	}
+	if err := database.Exec(
+		"CREATE TABLE `jobs` (`id` text PRIMARY KEY, `workspace_id` text, `type` text NOT NULL, `status` text NOT NULL DEFAULT \"pending\", CONSTRAINT `fk_jobs_workspace` FOREIGN KEY (`workspace_id`) REFERENCES `workspaces`(`id`))",
+	).Error; err != nil {
+		t.Fatalf("create legacy jobs table: %v", err)
+	}
+	if err := database.Exec(
+		"INSERT INTO `users` (`id`, `username`, `email`, `password_hash`) VALUES ('user-1', 'owner', 'owner@example.com', 'x')",
+	).Error; err != nil {
+		t.Fatalf("insert legacy user: %v", err)
+	}
+	if err := database.Exec(
+		"INSERT INTO `workspaces` (`id`, `name`, `package_manager`, `owner_id`) VALUES ('ws-1', 'legacy', 'pixi', 'user-1')",
+	).Error; err != nil {
+		t.Fatalf("insert legacy workspace: %v", err)
+	}
+	if err := database.Exec(
+		"INSERT INTO `jobs` (`id`, `workspace_id`, `type`) VALUES ('job-1', 'ws-1', 'create')",
+	).Error; err != nil {
+		t.Fatalf("insert referencing job: %v", err)
+	}
+	// A previously failed migration attempt strands the rebuild table.
+	if err := database.Exec(
+		"CREATE TABLE `workspaces__temp` (`id` text PRIMARY KEY)",
+	).Error; err != nil {
+		t.Fatalf("create stranded temp table: %v", err)
+	}
+
+	if err := Migrate(database, false); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	if database.Migrator().HasColumn(&models.Workspace{}, "package_manager") {
+		t.Fatal("expected package_manager column to be dropped")
+	}
+	if database.Migrator().HasTable("workspaces__temp") {
+		t.Fatal("expected stranded workspaces__temp table to be removed")
+	}
+
+	var wsCount, jobCount int64
+	if err := database.Table("workspaces").Count(&wsCount).Error; err != nil {
+		t.Fatalf("count workspaces: %v", err)
+	}
+	if wsCount != 1 {
+		t.Fatalf("expected 1 workspace to survive the migration, got %d", wsCount)
+	}
+	if err := database.Table("jobs").Count(&jobCount).Error; err != nil {
+		t.Fatalf("count jobs: %v", err)
+	}
+	if jobCount != 1 {
+		t.Fatalf("expected 1 job to survive the migration, got %d", jobCount)
+	}
+}


### PR DESCRIPTION
Fixes #549

## Problem

Since #522, every SQLite-backed nebi (desktop app and `nebi serve`) crashes on startup when migrating a database created before the `package_manager` removal that contains workspaces referenced by child rows (`jobs`, `publications`, …):

```
Error: failed to run migrations: failed to drop workspaces.package_manager column: constraint failed: FOREIGN KEY constraint failed (787)
```

The glebarez/sqlite driver emulates `DropColumn` by rebuilding the table (create `workspaces__temp` → copy rows → `DROP TABLE workspaces` → rename), and — unlike its `DropTable`/`AlterColumn` paths — does not suspend `foreign_keys` first. With nebi's DSN-level `_pragma=foreign_keys(ON)`, the `DROP TABLE` on the parent violates the foreign keys held by referencing rows and aborts startup. The rebuild runs inside a single transaction, so the failure rolls back cleanly — the database is left intact but cannot boot, and the crash recurs on every startup.

Postgres is unaffected (`DropColumn` is a native `ALTER TABLE ... DROP COLUMN` there).

## Fix

- Run the `package_manager` drop pinned to a single connection (`db.Connection`) with `PRAGMA foreign_keys = OFF`/`ON` around it. Pinning is required because the DSN pragma re-enables enforcement on every new pooled connection, and the pragma must be flipped outside the rebuild's transaction, where SQLite ignores it.
- Keep the plain native drop on Postgres.

An earlier revision of this PR also dropped a "stranded" `workspaces__temp` table at startup, on the theory that failed attempts leave the rebuild's temp table behind. That premise was wrong — the rebuild is transactional and rolls the temp table back on failure (verified empirically and against a real post-crash database) — so that cleanup has been removed.

## Testing

- New `TestMigrateDropsLegacyPackageManagerColumnWithReferencingRows` reproduces the crash scenario: legacy schema with the `NOT NULL` column and a `jobs` row holding an FK to a workspace. It verifies the migration succeeds, the column is gone, and all rows survive.
- Verified end-to-end against a real pre-#522 `nebi.db` (legacy column + referencing job rows): `nebi serve` previously crashed, now boots cleanly with data intact.
- `go test ./internal/db/`, `go build ./internal/...`, `go vet`, `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
