### PR TITLE
Resolve configured registries by name in nebi import

### DIFF
--- a/cmd/nebi/bundle_e2e_test.go
+++ b/cmd/nebi/bundle_e2e_test.go
@@ -114,6 +114,39 @@ func TestE2E_LocalBundlePublishImport(t *testing.T) {
 		t.Fatalf("import failed:\nstdout: %s\nstderr: %s", res.Stdout, res.Stderr)
 	}
 
+	// The same bundle must be reachable by registry name, which is the
+	// path that goes through parseWsRef -> StripScheme -> splitImportRef
+	// -> resolveImportRef rather than straight to the pull. The
+	// published ref is <host>/demo/<repo>:<tag>; strip the host and the
+	// registry's own namespace to get what a name-based reference
+	// carries.
+	bare := strings.TrimPrefix(strings.TrimPrefix(ref, "http://"), regHost+"/demo/")
+	if bare == ref {
+		t.Fatalf("could not derive a bare repository ref from %s", ref)
+	}
+	for _, tc := range []struct {
+		name string
+		ref  string
+	}{
+		{"alias prefix", "bundle-e2e:" + bare},
+		{"default registry", bare},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			nameOut := filepath.Join(t.TempDir(), "restored")
+			res := runCLI(t, outParent, "import", tc.ref, "-o", nameOut)
+			if res.ExitCode != 0 {
+				t.Fatalf("import %s failed:\nstdout: %s\nstderr: %s", tc.ref, res.Stdout, res.Stderr)
+			}
+			got, err := os.ReadFile(filepath.Join(nameOut, "README.md"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != readmeBody {
+				t.Errorf("import %s restored the wrong bundle", tc.ref)
+			}
+		})
+	}
+
 	// Asset layers must round-trip byte-identically.
 	wantAssets := map[string]string{
 		"README.md":       readmeBody,

--- a/cmd/nebi/client.go
+++ b/cmd/nebi/client.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/nebari-dev/nebi/internal/cliclient"
+	"github.com/nebari-dev/nebi/internal/oci"
 	"github.com/nebari-dev/nebi/internal/pixi"
 	"github.com/nebari-dev/nebi/internal/store"
 	"github.com/spf13/cobra"
@@ -231,6 +232,32 @@ func parseWsRef(ref string) (string, string) {
 		return ref[:idx], ref[idx+1:]
 	}
 	return ref, ""
+}
+
+// resolveLocalRegistry returns the local-store registry a command should
+// address: the one named, or the default when name is empty. Shared by
+// 'publish --local' and 'import' so both sides of a bundle's round trip
+// resolve the same name the same way.
+func resolveLocalRegistry(s *store.Store, name string) (*store.LocalRegistry, error) {
+	if name != "" {
+		reg, err := s.GetRegistryByName(name)
+		if err != nil {
+			return nil, fmt.Errorf("registry %q not found in local store; run 'nebi registry list --local' to see what is configured", name)
+		}
+		return reg, nil
+	}
+	return s.GetDefaultRegistry()
+}
+
+// registryTarget returns the host, namespace and transport a registry
+// record addresses. An explicit Namespace on the record wins over one
+// embedded in the URL.
+func registryTarget(reg *store.LocalRegistry) (host, namespace string, plainHTTP bool) {
+	host, namespace, plainHTTP = oci.ParseRegistryURLFull(reg.URL)
+	if reg.Namespace != "" {
+		namespace = reg.Namespace
+	}
+	return host, namespace, plainHTTP
 }
 
 // formatTimestamp parses an ISO 8601 timestamp and returns a human-friendly format.

--- a/cmd/nebi/import.go
+++ b/cmd/nebi/import.go
@@ -28,11 +28,14 @@ var importCmd = &cobra.Command{
 The OCI reference should be in the format: registry/repository:tag
 (e.g., quay.io/nebari/my-env:v1)
 
-A reference whose first segment is not a registry host is resolved
-against the registries configured with 'nebi registry add --local':
-prefix it with '<registry-name>:' to pick one, or leave the prefix off
-to use the default registry. References that already name a host never
-consult the local store.
+A single-segment reference, or one prefixed with '<registry-name>:', is
+resolved against the registries configured with 'nebi registry add
+--local'. The prefix picks a registry; without one the default is used.
+
+Anything else is taken as naming its own host, including a reference
+whose first segment carries a port or is followed by a slash. Use the
+'<registry-name>:' prefix to reach a nested repository through a
+configured registry.
 
 Restores pixi.toml, pixi.lock, and any bundled asset files to the output
 directory. Works entirely locally — no server connection needed.
@@ -44,6 +47,7 @@ Examples:
   nebi import quay.io/nebari/my-env:v1
   nebi import ghcr.io/myorg/data-science:latest -o ./my-project
   nebi import myreg:my-env:v1
+  nebi import myreg:myorg/my-env:v1
   nebi import my-env:v1`,
 	Args: cobra.ExactArgs(1),
 	RunE: runImport,
@@ -144,34 +148,55 @@ func hasScheme(ref string) bool {
 
 // looksLikeHost reports whether a reference's first segment names a
 // registry host rather than a registry alias. A dot covers every public
-// registry and any FQDN, a colon covers host:port, and localhost is the
-// one hostless name in common use.
+// registry and any FQDN, and localhost is the one hostless name in
+// common use. Callers strip any ":port" before asking.
 func looksLikeHost(segment string) bool {
-	return strings.Contains(segment, ".") || strings.Contains(segment, ":") || segment == "localhost"
+	return strings.Contains(segment, ".") || segment == "localhost"
+}
+
+// isAllDigits reports whether s is a non-empty run of ASCII digits. This
+// is the only thing separating "<host>:<port>/<repo>" from
+// "<alias>:<repo>", which are otherwise the same shape. Empty must be
+// false so that "myreg:" stays an alias naming no repository.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // splitImportRef separates an optional registry alias from the repository
-// path of a tag-stripped import reference.
+// path of a tag-stripped import reference. A reference that names a host
+// is returned untouched with hasHost=true and never reaches the local
+// store.
 //
-// A reference whose first segment looks like a host is returned untouched
-// with hasHost=true, so every reference that resolves today keeps its
-// exact meaning and never reads the local store.
+// The grammar is genuinely ambiguous in two places, so the rule is
+// deliberately narrow:
+//
+//   - "<alias>:<repo>" and "<host>:<port>/<repo>" are the same shape.
+//     An all-digit run after the colon is a port, anything else an alias.
+//   - "<host>/<repo>" and a namespace-relative "<org>/<repo>" are also
+//     the same shape, and nothing can tell them apart. A slash therefore
+//     means the first segment is a host, which is what it means without
+//     this feature and what 'nebi publish' prints. To reach a nested
+//     repository through a configured registry, name the registry:
+//     "myreg:org/my-env:v1".
 func splitImportRef(ref string) (alias, repo string, hasHost bool) {
-	first := ref
-	if i := strings.Index(ref, "/"); i >= 0 {
-		first = ref[:i]
-	}
+	first, _, hasSlash := strings.Cut(ref, "/")
 
-	// "<alias>:<repository path>" is the only form that puts a colon in
-	// the first segment without naming a port.
-	if name, _, found := strings.Cut(first, ":"); found {
-		if looksLikeHost(name) {
+	if name, port, found := strings.Cut(first, ":"); found {
+		if looksLikeHost(name) || isAllDigits(port) {
 			return "", ref, true
 		}
 		return name, ref[len(name)+1:], false
 	}
 
-	if looksLikeHost(first) {
+	if hasSlash || looksLikeHost(first) {
 		return "", ref, true
 	}
 	return "", ref, false
@@ -183,6 +208,9 @@ func splitImportRef(ref string) (alias, repo string, hasHost bool) {
 // bundle by the same name.
 func resolveImportRef(alias, repo string) (string, bool, error) {
 	if repo == "" {
+		if alias == "" {
+			return "", false, fmt.Errorf("empty reference; use registry/repository:tag (e.g., quay.io/nebari/my-env:v1)")
+		}
 		return "", false, fmt.Errorf("registry %q named with no repository; use %s:<repository>:<tag>", alias, alias)
 	}
 
@@ -192,32 +220,25 @@ func resolveImportRef(alias, repo string) (string, bool, error) {
 	}
 	defer s.Close()
 
-	var reg *store.LocalRegistry
-	if alias != "" {
-		reg, err = s.GetRegistryByName(alias)
-		if err != nil {
-			return "", false, fmt.Errorf("registry %q not found in local store; run 'nebi registry list --local' to see what is configured", alias)
-		}
-	} else {
-		// A bare name that matches a configured registry is almost
-		// certainly an alias whose tag was swallowed by the reference
-		// parser, so say that rather than pulling a repository of the
-		// same name from the default registry.
-		if !strings.Contains(repo, "/") {
-			if _, nameErr := s.GetRegistryByName(repo); nameErr == nil {
-				return "", false, fmt.Errorf("%q names a configured registry, not a repository; use %s:<repository>:<tag>", repo, repo)
-			}
-		}
-		reg, err = s.GetDefaultRegistry()
-		if err != nil {
-			return "", false, fmt.Errorf("%q does not name a registry host and no default registry is configured; use a full reference such as quay.io/org/my-env:v1, or set a default with 'nebi registry add --local --default'", repo)
+	// A bare name that matches a configured registry is almost certainly
+	// an alias whose tag was swallowed by the reference parser, so say
+	// that rather than pulling a repository of the same name from the
+	// default registry.
+	if alias == "" {
+		if _, nameErr := s.GetRegistryByName(repo); nameErr == nil {
+			return "", false, fmt.Errorf("%q names a configured registry, not a repository; use %s:<repository>:<tag>", repo, repo)
 		}
 	}
 
-	host, ns, plainHTTP := oci.ParseRegistryURLFull(reg.URL)
-	if reg.Namespace != "" {
-		ns = reg.Namespace
+	reg, err := resolveLocalRegistry(s, alias)
+	if err != nil {
+		if alias == "" {
+			return "", false, fmt.Errorf("%q does not name a registry host and no default registry is configured; use a full reference such as quay.io/org/my-env:v1, or set a default with 'nebi registry add --local --default'", repo)
+		}
+		return "", false, err
 	}
+
+	host, ns, plainHTTP := registryTarget(reg)
 
 	parts := []string{host}
 	if ns != "" {

--- a/cmd/nebi/import.go
+++ b/cmd/nebi/import.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/nebari-dev/nebi/internal/oci"
+	"github.com/nebari-dev/nebi/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -26,6 +28,12 @@ var importCmd = &cobra.Command{
 The OCI reference should be in the format: registry/repository:tag
 (e.g., quay.io/nebari/my-env:v1)
 
+A reference whose first segment is not a registry host is resolved
+against the registries configured with 'nebi registry add --local':
+prefix it with '<registry-name>:' to pick one, or leave the prefix off
+to use the default registry. References that already name a host never
+consult the local store.
+
 Restores pixi.toml, pixi.lock, and any bundled asset files to the output
 directory. Works entirely locally — no server connection needed.
 
@@ -34,7 +42,9 @@ in the imported pixi.toml.
 
 Examples:
   nebi import quay.io/nebari/my-env:v1
-  nebi import ghcr.io/myorg/data-science:latest -o ./my-project`,
+  nebi import ghcr.io/myorg/data-science:latest -o ./my-project
+  nebi import myreg:my-env:v1
+  nebi import my-env:v1`,
 	Args: cobra.ExactArgs(1),
 	RunE: runImport,
 }
@@ -52,6 +62,19 @@ func runImport(cmd *cobra.Command, args []string) error {
 	}
 
 	repoRef, plainHTTP := oci.StripScheme(repoRef)
+
+	// A scheme-qualified reference always carries its own host, so it is
+	// never a candidate for alias resolution.
+	if !hasScheme(args[0]) {
+		alias, repo, hasHost := splitImportRef(repoRef)
+		if !hasHost {
+			resolved, regPlainHTTP, err := resolveImportRef(alias, repo)
+			if err != nil {
+				return err
+			}
+			repoRef, plainHTTP = resolved, regPlainHTTP
+		}
+	}
 
 	ctx := context.Background()
 
@@ -111,6 +134,97 @@ func runImport(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(os.Stderr, "Imported %s -> %s (%d asset file(s))\n", ref, absOutput, len(result.Assets))
 
 	return nil
+}
+
+// hasScheme reports whether a reference was written with an explicit
+// http:// or https:// prefix.
+func hasScheme(ref string) bool {
+	return strings.HasPrefix(ref, "http://") || strings.HasPrefix(ref, "https://")
+}
+
+// looksLikeHost reports whether a reference's first segment names a
+// registry host rather than a registry alias. A dot covers every public
+// registry and any FQDN, a colon covers host:port, and localhost is the
+// one hostless name in common use.
+func looksLikeHost(segment string) bool {
+	return strings.Contains(segment, ".") || strings.Contains(segment, ":") || segment == "localhost"
+}
+
+// splitImportRef separates an optional registry alias from the repository
+// path of a tag-stripped import reference.
+//
+// A reference whose first segment looks like a host is returned untouched
+// with hasHost=true, so every reference that resolves today keeps its
+// exact meaning and never reads the local store.
+func splitImportRef(ref string) (alias, repo string, hasHost bool) {
+	first := ref
+	if i := strings.Index(ref, "/"); i >= 0 {
+		first = ref[:i]
+	}
+
+	// "<alias>:<repository path>" is the only form that puts a colon in
+	// the first segment without naming a port.
+	if name, _, found := strings.Cut(first, ":"); found {
+		if looksLikeHost(name) {
+			return "", ref, true
+		}
+		return name, ref[len(name)+1:], false
+	}
+
+	if looksLikeHost(first) {
+		return "", ref, true
+	}
+	return "", ref, false
+}
+
+// resolveImportRef expands an alias-or-default reference into a fully
+// qualified host/namespace/repository, mirroring how 'nebi publish
+// --local' builds its push target so the two sides address the same
+// bundle by the same name.
+func resolveImportRef(alias, repo string) (string, bool, error) {
+	if repo == "" {
+		return "", false, fmt.Errorf("registry %q named with no repository; use %s:<repository>:<tag>", alias, alias)
+	}
+
+	s, err := store.New()
+	if err != nil {
+		return "", false, err
+	}
+	defer s.Close()
+
+	var reg *store.LocalRegistry
+	if alias != "" {
+		reg, err = s.GetRegistryByName(alias)
+		if err != nil {
+			return "", false, fmt.Errorf("registry %q not found in local store; run 'nebi registry list --local' to see what is configured", alias)
+		}
+	} else {
+		// A bare name that matches a configured registry is almost
+		// certainly an alias whose tag was swallowed by the reference
+		// parser, so say that rather than pulling a repository of the
+		// same name from the default registry.
+		if !strings.Contains(repo, "/") {
+			if _, nameErr := s.GetRegistryByName(repo); nameErr == nil {
+				return "", false, fmt.Errorf("%q names a configured registry, not a repository; use %s:<repository>:<tag>", repo, repo)
+			}
+		}
+		reg, err = s.GetDefaultRegistry()
+		if err != nil {
+			return "", false, fmt.Errorf("%q does not name a registry host and no default registry is configured; use a full reference such as quay.io/org/my-env:v1, or set a default with 'nebi registry add --local --default'", repo)
+		}
+	}
+
+	host, ns, plainHTTP := oci.ParseRegistryURLFull(reg.URL)
+	if reg.Namespace != "" {
+		ns = reg.Namespace
+	}
+
+	parts := []string{host}
+	if ns != "" {
+		parts = append(parts, ns)
+	}
+	parts = append(parts, repo)
+	return strings.Join(parts, "/"), plainHTTP, nil
 }
 
 // dirIsNonEmpty reports whether path exists and contains at least one

--- a/cmd/nebi/import_ref_test.go
+++ b/cmd/nebi/import_ref_test.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nebari-dev/nebi/internal/store"
+)
+
+func TestSplitImportRef(t *testing.T) {
+	tests := []struct {
+		ref         string
+		wantAlias   string
+		wantRepo    string
+		wantHasHost bool
+	}{
+		// Host-bearing references are passed through untouched.
+		{"quay.io/nebari/my-env", "", "quay.io/nebari/my-env", true},
+		{"ghcr.io/myorg/data-science", "", "ghcr.io/myorg/data-science", true},
+		{"localhost/my-env", "", "localhost/my-env", true},
+		{"localhost:5000/my-env", "", "localhost:5000/my-env", true},
+		{"registry.example.com:5000/org/my-env", "", "registry.example.com:5000/org/my-env", true},
+
+		// Explicit alias prefix.
+		{"myreg:my-env", "myreg", "my-env", false},
+		{"myreg:myorg/my-env", "myreg", "myorg/my-env", false},
+
+		// No alias, no host: resolved against the default registry.
+		{"my-env", "", "my-env", false},
+		{"myorg/my-env", "", "myorg/my-env", false},
+
+		// Alias named with nothing after it.
+		{"myreg:", "myreg", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			alias, repo, hasHost := splitImportRef(tt.ref)
+			if alias != tt.wantAlias || repo != tt.wantRepo || hasHost != tt.wantHasHost {
+				t.Errorf("splitImportRef(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tt.ref, alias, repo, hasHost, tt.wantAlias, tt.wantRepo, tt.wantHasHost)
+			}
+		})
+	}
+}
+
+// Every reference that names a host must report hasHost, because those are
+// the references that work today and whose meaning must not shift.
+func TestSplitImportRefNeverResolvesHostReferences(t *testing.T) {
+	hostRefs := []string{
+		"quay.io/nebari/my-env",
+		"ghcr.io/myorg/env",
+		"registry.example.com/env",
+		"localhost:5000/env",
+		"127.0.0.1:5000/env",
+	}
+	for _, ref := range hostRefs {
+		if _, _, hasHost := splitImportRef(ref); !hasHost {
+			t.Errorf("splitImportRef(%q) did not detect a host", ref)
+		}
+	}
+}
+
+func TestHasScheme(t *testing.T) {
+	tests := map[string]bool{
+		"http://localhost:5000/env:v1": true,
+		"https://quay.io/org/env:v1":   true,
+		"quay.io/org/env:v1":           false,
+		"myreg:env:v1":                 false,
+	}
+	for ref, want := range tests {
+		if got := hasScheme(ref); got != want {
+			t.Errorf("hasScheme(%q) = %v, want %v", ref, got, want)
+		}
+	}
+}
+
+// newRegistryStore points store.New at a temp data dir and returns an open
+// store, so registry resolution can be exercised without touching the
+// user's real nebi state.
+func newRegistryStore(t *testing.T) *store.Store {
+	t.Helper()
+	t.Setenv("NEBI_DATA_DIR", t.TempDir())
+	s, err := store.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+func TestResolveImportRefUsesDefaultRegistry(t *testing.T) {
+	s := newRegistryStore(t)
+	if err := s.CreateRegistry(&store.LocalRegistry{
+		Name:      "myreg",
+		URL:       "https://registry.example.com",
+		Namespace: "myorg",
+		IsDefault: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, plainHTTP, err := resolveImportRef("", "my-env")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "registry.example.com/myorg/my-env"; got != want {
+		t.Errorf("resolveImportRef = %q, want %q", got, want)
+	}
+	if plainHTTP {
+		t.Error("https registry URL should not select plain HTTP")
+	}
+}
+
+func TestResolveImportRefUsesNamedRegistry(t *testing.T) {
+	s := newRegistryStore(t)
+	if err := s.CreateRegistry(&store.LocalRegistry{
+		Name:      "default-reg",
+		URL:       "https://default.example.com",
+		IsDefault: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateRegistry(&store.LocalRegistry{
+		Name: "other",
+		URL:  "https://other.example.com/base",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _, err := resolveImportRef("other", "my-env")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "other.example.com/base/my-env"; got != want {
+		t.Errorf("resolveImportRef = %q, want %q", got, want)
+	}
+}
+
+func TestResolveImportRefCarriesPlainHTTP(t *testing.T) {
+	s := newRegistryStore(t)
+	if err := s.CreateRegistry(&store.LocalRegistry{
+		Name:      "local",
+		URL:       "http://localhost:5000",
+		IsDefault: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, plainHTTP, err := resolveImportRef("", "my-env")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "localhost:5000/my-env"; got != want {
+		t.Errorf("resolveImportRef = %q, want %q", got, want)
+	}
+	if !plainHTTP {
+		t.Error("http registry URL should select plain HTTP")
+	}
+}
+
+func TestResolveImportRefUnknownAlias(t *testing.T) {
+	newRegistryStore(t)
+
+	_, _, err := resolveImportRef("nope", "my-env")
+	if err == nil {
+		t.Fatal("expected an error for an unconfigured registry name")
+	}
+	if !strings.Contains(err.Error(), "not found in local store") {
+		t.Errorf("error should say the registry is unknown, got: %v", err)
+	}
+}
+
+func TestResolveImportRefNoDefaultRegistry(t *testing.T) {
+	newRegistryStore(t)
+
+	_, _, err := resolveImportRef("", "my-env")
+	if err == nil {
+		t.Fatal("expected an error when no default registry is configured")
+	}
+	if !strings.Contains(err.Error(), "no default registry") {
+		t.Errorf("error should mention the missing default, got: %v", err)
+	}
+}
+
+// "nebi import myreg:my-env" parses as repository "myreg", tag "my-env",
+// because the reference parser splits on the last colon. Resolving that
+// against the default registry would quietly pull the wrong thing, so it
+// has to be an error that names the full form.
+func TestResolveImportRefRejectsRegistryNameAsRepository(t *testing.T) {
+	s := newRegistryStore(t)
+	if err := s.CreateRegistry(&store.LocalRegistry{
+		Name:      "myreg",
+		URL:       "https://registry.example.com",
+		IsDefault: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := resolveImportRef("", "myreg")
+	if err == nil {
+		t.Fatal("expected an error when a registry name is used as a repository")
+	}
+	if !strings.Contains(err.Error(), "myreg:<repository>:<tag>") {
+		t.Errorf("error should show the full reference form, got: %v", err)
+	}
+}
+
+func TestResolveImportRefAliasWithoutRepository(t *testing.T) {
+	newRegistryStore(t)
+
+	_, _, err := resolveImportRef("myreg", "")
+	if err == nil {
+		t.Fatal("expected an error for an alias with no repository")
+	}
+}

--- a/cmd/nebi/import_ref_test.go
+++ b/cmd/nebi/import_ref_test.go
@@ -21,15 +21,34 @@ func TestSplitImportRef(t *testing.T) {
 		{"localhost:5000/my-env", "", "localhost:5000/my-env", true},
 		{"registry.example.com:5000/org/my-env", "", "registry.example.com:5000/org/my-env", true},
 
-		// Explicit alias prefix.
+		// A dotless host with a port is still a host: the digits after
+		// the colon are what separate it from an alias prefix. This is
+		// the in-cluster and docker-compose form.
+		{"registry:5000/env", "", "registry:5000/env", true},
+		{"registry:5000/org/env", "", "registry:5000/org/env", true},
+		{"192.168.1.10:5000/env", "", "192.168.1.10:5000/env", true},
+
+		// A slash with no alias prefix means the first segment is a
+		// host, because a namespace-relative path has the same shape
+		// and nothing can tell the two apart.
+		{"registry/my-env", "", "registry/my-env", true},
+		{"internal-reg/team/env", "", "internal-reg/team/env", true},
+		{"myorg/my-env", "", "myorg/my-env", true},
+
+		// Explicit alias prefix. The prefix is what reaches a nested
+		// repository through a configured registry.
 		{"myreg:my-env", "myreg", "my-env", false},
 		{"myreg:myorg/my-env", "myreg", "myorg/my-env", false},
 
-		// No alias, no host: resolved against the default registry.
+		// No alias, no host, no slash: the default registry.
 		{"my-env", "", "my-env", false},
-		{"myorg/my-env", "", "myorg/my-env", false},
 
-		// Alias named with nothing after it.
+		// An all-numeric repository is indistinguishable from a port,
+		// so it loses to the host reading. Degenerate, documented here
+		// so a change in the rule shows up as a test failure.
+		{"myreg:2024", "", "myreg:2024", true},
+
+		// Alias named with nothing after it, from "nebi import myreg::v1".
 		{"myreg:", "myreg", "", false},
 	}
 
@@ -53,6 +72,8 @@ func TestSplitImportRefNeverResolvesHostReferences(t *testing.T) {
 		"registry.example.com/env",
 		"localhost:5000/env",
 		"127.0.0.1:5000/env",
+		"registry:5000/env",
+		"registry/my-env",
 	}
 	for _, ref := range hostRefs {
 		if _, _, hasHost := splitImportRef(ref); !hasHost {
@@ -212,5 +233,35 @@ func TestResolveImportRefAliasWithoutRepository(t *testing.T) {
 	_, _, err := resolveImportRef("myreg", "")
 	if err == nil {
 		t.Fatal("expected an error for an alias with no repository")
+	}
+}
+
+func TestIsAllDigits(t *testing.T) {
+	tests := map[string]bool{
+		"5000": true,
+		"0":    true,
+		// Empty must be false, otherwise "myreg:" reads as a host and
+		// an alias naming no repository loses its error.
+		"":       false,
+		"my-env": false,
+		"50a0":   false,
+		"5000 ":  false,
+	}
+	for in, want := range tests {
+		if got := isAllDigits(in); got != want {
+			t.Errorf("isAllDigits(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestResolveImportRefEmptyReference(t *testing.T) {
+	newRegistryStore(t)
+
+	_, _, err := resolveImportRef("", "")
+	if err == nil {
+		t.Fatal("expected an error for an empty reference")
+	}
+	if strings.Contains(err.Error(), `""`) {
+		t.Errorf("error should not quote an empty alias, got: %v", err)
 	}
 }

--- a/cmd/nebi/publish.go
+++ b/cmd/nebi/publish.go
@@ -173,17 +173,9 @@ func runPublishLocal(args []string) error {
 	}
 
 	// Resolve registry
-	var reg *store.LocalRegistry
-	if publishRegistry != "" {
-		reg, err = s.GetRegistryByName(publishRegistry)
-		if err != nil {
-			return fmt.Errorf("registry %q not found in local store", publishRegistry)
-		}
-	} else {
-		reg, err = s.GetDefaultRegistry()
-		if err != nil {
-			return err
-		}
+	reg, err := resolveLocalRegistry(s, publishRegistry)
+	if err != nil {
+		return err
 	}
 
 	// Get credentials from keyring
@@ -213,10 +205,7 @@ func runPublishLocal(args []string) error {
 		repo = publishRepo
 	}
 
-	host, ns, plainHTTP := oci.ParseRegistryURLFull(reg.URL)
-	if reg.Namespace != "" {
-		ns = reg.Namespace
-	}
+	host, ns, plainHTTP := registryTarget(reg)
 	regEndpoint := oci.Registry{
 		Host:      host,
 		Namespace: ns,

--- a/docs/src/content/docs/cli-local.md
+++ b/docs/src/content/docs/cli-local.md
@@ -151,6 +151,31 @@ Imported quay.io/nebari/data-science:v1.0 -> /home/user/my-project (3 asset file
 
 Use `--concurrency N` to set how many files download at the same time (default 8).
 
+### Referring to a configured registry by name
+
+A reference that does not begin with a registry host is resolved against the
+registries you added with `nebi registry add --local`, the same way `nebi
+publish --local` resolves its target. Prefix the reference with a registry
+name to pick one, or leave the prefix off to use the default:
+
+```bash
+# Pull from the registry named "myreg"
+nebi import myreg:my-env:v1
+
+# Pull from the default registry
+nebi import my-env:v1
+```
+
+A reference that already names a host is never resolved, so
+`nebi import quay.io/nebari/data-science:v1.0` behaves exactly as before and
+works on a machine that has no registries configured.
+
+:::note The tag is still required
+`nebi import myreg:my-env` is read as repository `myreg`, tag `my-env`, because
+the reference parser splits on the last colon. Spell out all three parts:
+`myreg:my-env:v1`.
+:::
+
 :::note Imports do not overwrite existing files
 If the bundle includes asset files, `nebi import` refuses to write
 into a non-empty output directory. Use `-o ./some-new-dir` to land

--- a/docs/src/content/docs/cli-local.md
+++ b/docs/src/content/docs/cli-local.md
@@ -153,22 +153,36 @@ Use `--concurrency N` to set how many files download at the same time (default 8
 
 ### Referring to a configured registry by name
 
-A reference that does not begin with a registry host is resolved against the
-registries you added with `nebi registry add --local`, the same way `nebi
-publish --local` resolves its target. Prefix the reference with a registry
-name to pick one, or leave the prefix off to use the default:
+Prefix a reference with the name of a registry you added with
+`nebi registry add --local` to pull from it, or use a bare one-segment name to
+pull from the default registry. This is the same lookup `nebi publish --local`
+uses for its target:
 
 ```bash
 # Pull from the registry named "myreg"
 nebi import myreg:my-env:v1
 
+# Reach a nested repository through that registry
+nebi import myreg:myorg/my-env:v1
+
 # Pull from the default registry
 nebi import my-env:v1
 ```
 
-A reference that already names a host is never resolved, so
-`nebi import quay.io/nebari/data-science:v1.0` behaves exactly as before and
-works on a machine that has no registries configured.
+Everything else names its own host and is pulled directly, with no lookup, so
+`nebi import quay.io/nebari/data-science:v1.0` works on a machine that has no
+registries configured.
+
+:::caution A slash means a hostname
+`nebi import registry/my-env:v1` pulls from a host called `registry`, not from
+`my-env` inside the default registry. A namespace-relative path and a
+`host/repository` pair are written identically, so Nebi reads the first segment
+as a host whenever the reference contains a slash. Name the registry when you
+mean the other thing: `nebi import myreg:registry/my-env:v1`.
+
+The same applies to a port: `registry:5000/my-env:v1` is the host
+`registry:5000`, because the digits after the colon mark it as one.
+:::
 
 :::note The tag is still required
 `nebi import myreg:my-env` is read as repository `myreg`, tag `my-env`, because

--- a/docs/src/content/docs/cli-reference.md
+++ b/docs/src/content/docs/cli-reference.md
@@ -33,7 +33,7 @@ Two terms appear throughout these commands:
 | `nebi pull [<name>[:<tag>]]` | Pull workspace specs from a server |
 | `nebi diff [<ref-a>] [<ref-b>]` | Compare workspace specs |
 | `nebi publish [name]` | Publish a workspace bundle to an OCI registry (uses content hash tag by default) |
-| `nebi import <oci-reference>` | Import a workspace bundle from an OCI registry, restoring pixi files and asset layers (a reference with no host resolves against the local registries) |
+| `nebi import <oci-reference>` | Import a workspace bundle from an OCI registry, restoring pixi files and asset layers (a bare name or a `<registry-name>:` prefix resolves against the local registries) |
 
 ## Connection Commands
 

--- a/docs/src/content/docs/cli-reference.md
+++ b/docs/src/content/docs/cli-reference.md
@@ -33,7 +33,7 @@ Two terms appear throughout these commands:
 | `nebi pull [<name>[:<tag>]]` | Pull workspace specs from a server |
 | `nebi diff [<ref-a>] [<ref-b>]` | Compare workspace specs |
 | `nebi publish [name]` | Publish a workspace bundle to an OCI registry (uses content hash tag by default) |
-| `nebi import <oci-reference>` | Import a workspace bundle from an OCI registry, restoring pixi files and asset layers |
+| `nebi import <oci-reference>` | Import a workspace bundle from an OCI registry, restoring pixi files and asset layers (a reference with no host resolves against the local registries) |
 
 ## Connection Commands
 


### PR DESCRIPTION
Closes #551. The credentials half of that issue is split out into #553, so this closes what the title asks for and nothing else goes quiet with it.

`nebi import` treated the first path segment of its argument as a DNS hostname, so a registry added with `nebi registry add --local` could not be named on the import side, while `nebi publish --local` resolves those same names through the same store.

## What resolves now

```bash
nebi import myreg:my-env:v1         # the registry named myreg
nebi import myreg:myorg/my-env:v1   # a nested repository through it
nebi import my-env:v1               # the default registry
```

The target is assembled the way publish assembles its push target, host plus namespace plus repository, so a bundle published as `myreg` imports back by the same name.

## What stays a hostname

Only two shapes resolve: a bare one-segment name, and an explicit `<registry>:` prefix. Everything else names its own host and is pulled directly with no store lookup.

That line is where the first cut of this got it wrong, twice, and both cases are in the tests now:

- `registry:5000/env:v1`, the in-cluster and docker-compose form, was read as alias `registry` with the port demoted to a namespace segment. The digits after the colon are what separate a port from an alias prefix.
- `registry/my-env:v1` was resolved against the default registry. That is written identically to a namespace-relative path and nothing can tell the two apart, so choosing either breaks the other. Publishing to a single-label host prints `registry/team/env:v1`, and import could no longer consume publish's own output. A slash now means the first segment is a host.

Picking the host reading for both means nothing that works on `main` changes meaning. The cost is that `myorg/my-env:v1` does not reach the default registry; name the registry for that, `myreg:myorg/my-env:v1`.

## The two-segment form

`nebi import myreg:my-env` reads as repository `myreg`, tag `my-env`, because `parseWsRef` splits on the last colon. I did not pick a grammar for it. A bare name matching a configured registry is rejected with a message naming the full form:

```
Error: "myreg" names a configured registry, not a repository; use myreg:<repository>:<tag>
```

So the ambiguous form fails loudly with the shape that works, rather than guessing. If the shorthand turns out to be worth having, it drops into the same place.

## Tests

`cmd/nebi/import_ref_test.go` covers the split and the resolution against a temp store: named registry, default registry, namespace from the registry record, plain HTTP carried through, unknown name, no default configured, empty reference, and the bare-registry-name rejection. The two shapes above have rows asserting they stay hosts.

The unit tests all feed post-parse strings, so `cmd/nebi/bundle_e2e_test.go` now imports the published bundle a second and third time by name, once with the alias prefix and once through the default registry. That is the only test that runs the real `parseWsRef` to `StripScheme` to `splitImportRef` chain the command uses.

## Also here

The registry lookup and the host/namespace/transport split moved to `resolveLocalRegistry` and `registryTarget` in `cmd/nebi/client.go`, shared with `publish --local`. The two copies had already drifted: publish reads credentials from the keyring, import does not, which is #553.
